### PR TITLE
fix(shell): use double quotes in activate script for $PATH expansion

### DIFF
--- a/src/cli/commands/activate.rs
+++ b/src/cli/commands/activate.rs
@@ -14,9 +14,10 @@ pub fn execute(name: &str) -> Result<()> {
     let bin_path = paths::virtualenv_bin(name)?;
 
     // Output activation script for eval
-    println!("export VIRTUAL_ENV='{}'", venv_path.display());
-    println!("export PATH='{}:$PATH'", bin_path.display());
-    println!("export SCOOP_ACTIVE='{name}'");
+    // Use double quotes so $PATH expands in shell
+    println!("export VIRTUAL_ENV=\"{}\"", venv_path.display());
+    println!("export PATH=\"{}:$PATH\"", bin_path.display());
+    println!("export SCOOP_ACTIVE=\"{}\"", name);
     println!("unset PYTHONHOME");
 
     Ok(())


### PR DESCRIPTION
## Summary
Fix critical bug where `$PATH` was not expanded in activate script due to single quotes.

## Problem
```bash
# Before (broken)
export PATH='/path/to/bin:$PATH'  # $PATH is literal string, not expanded
```

After `scoop use`, all commands failed:
- `ls` → `command not found: lsd`
- `cd ..` → `command not found: autojump --add /path`

## Fix
```bash
# After (fixed)
export PATH="/path/to/bin:$PATH"  # $PATH expands correctly
```

## Test plan
- [x] `scoop use testenv` → commands work normally
- [x] `cd ..` → no errors
- [x] `cargo test` passed