### PR TITLE
fix(ci): add ghcr.io auth to trivy-scan job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -100,6 +100,8 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      packages: read
       security-events: write
 
     strategy:
@@ -108,6 +110,19 @@ jobs:
         tag: [latest, slim]
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image for scanning
+        run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.tag }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -115,8 +130,11 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # Scan local image (already pulled)
+          scan-type: 'image'
 
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
+        if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary

Docker Build 워크플로우의 Trivy 보안 스캔이 ghcr.io 인증 실패로 실패하던 문제 수정.

### 원인

`trivy-scan` job에서 ghcr.io에 push된 이미지를 pull하려 할 때 인증 정보가 없어서 `UNAUTHORIZED` 에러 발생.

### 수정 내용

- `docker/login-action` 추가: ghcr.io 인증
- `docker pull` step 추가: 로컬에 이미지 확보 후 스캔
- `checkout` step 추가: 일부 action 요구사항
- `packages: read` 권한 추가: 이미지 pull 권한 명시
- `if: always()` 추가: 취약점 발견 시에도 결과 업로드

## Test plan

- [x] YAML 문법 검증 통과
- [ ] Docker Build 워크플로우 성공 확인 (머지 후)