### PR TITLE
ci(msrv): pin cargo-msrv to ^0.18 for rustc 1.85 install path

### DIFF
--- a/.github/workflows/msrv-check.yml
+++ b/.github/workflows/msrv-check.yml
@@ -62,9 +62,11 @@ jobs:
 
       # Step 4: Install cargo-msrv only if not cached
       # --locked ensures Cargo.lock is respected (security)
+      # Version pinned to ^0.18 because cargo-msrv 0.19+ requires rustc 1.91+,
+      # which conflicts with our MSRV (1.85). Keep in sync with the cache key above.
       - name: Install cargo-msrv
         if: steps.cache-cargo-msrv.outputs.cache-hit != 'true'
-        run: cargo install cargo-msrv --locked
+        run: cargo install cargo-msrv --version "^0.18" --locked
 
       # Step 5: Cache project dependencies for faster verification
       # Separate cache key from other jobs to avoid conflicts


### PR DESCRIPTION
## Summary

- `cargo-msrv 0.19+` requires rustc 1.91+, but the MSRV check runs on rustc 1.85, so unpinned `cargo install cargo-msrv --locked` always fails on cache miss.
- Pin install to `--version "^0.18"` so cache miss installs `0.18.x` (last series supporting rustc 1.85). The cache key was already pinned to `v0.18` conceptually; this aligns the install command with that intent.
- Unblocks PR #96 (rust-dependencies group bump), which currently fails only on this workflow.

## Why this is `ci:` and not `fix:`

The MSRV check is a CI-only concern (no user-facing behavior changes), so it does not need to trigger a release per `release-plz.toml` (`release_commits = "^(feat|fix|perf|refactor|revert)"`).

## Test plan

- [ ] CI passes (MSRV Check job specifically — cache miss path will install 0.18.x).
- [ ] After merge, re-run PR #96 checks and verify MSRV Check turns green.