### PR TITLE
fix: resolve 4 bugs found in codebase audit (pt-BR, pyvenv version_info, latest Python, migrate traversal)

### DIFF
--- a/src/core/migrate/conda.rs
+++ b/src/core/migrate/conda.rs
@@ -92,12 +92,12 @@ impl CondaDiscovery {
         let cfg_path = env_path.join("pyvenv.cfg");
         if cfg_path.exists() {
             if let Ok(content) = fs::read_to_string(&cfg_path) {
-                for line in content.lines() {
-                    let line = line.trim();
-                    if let Some(version) = line.strip_prefix("version") {
-                        let version = version.trim_start_matches([' ', '=']);
-                        return Some(version.trim().to_string());
-                    }
+                // Reads both `version` (stdlib venv) and `version_info` (uv) keys.
+                if let Some(version) = content
+                    .lines()
+                    .find_map(crate::core::pyvenv_version_from_line)
+                {
+                    return Some(version);
                 }
             }
         }

--- a/src/core/migrate/discovery.rs
+++ b/src/core/migrate/discovery.rs
@@ -47,13 +47,12 @@ impl PyenvDiscovery {
         let cfg_path = path.join("pyvenv.cfg");
         let content = fs::read_to_string(&cfg_path).ok()?;
 
-        for line in content.lines() {
-            let line = line.trim();
-            if let Some(version) = line.strip_prefix("version") {
-                // Handle both "version = 3.11.0" and "version=3.11.0"
-                let version = version.trim_start_matches([' ', '=']);
-                return Some(version.trim().to_string());
-            }
+        // Reads both `version` (stdlib venv) and `version_info` (uv) keys.
+        if let Some(version) = content
+            .lines()
+            .find_map(crate::core::pyvenv_version_from_line)
+        {
+            return Some(version);
         }
 
         // Fallback: try to extract from home path

--- a/src/core/migrate/migrator.rs
+++ b/src/core/migrate/migrator.rs
@@ -222,6 +222,12 @@ impl Migrator {
 
     /// Creates the target scoop environment.
     fn create_target_env(&self, name: &str, python_version: &str, force: bool) -> Result<PathBuf> {
+        // Validate at the trust boundary: for `--rename` / `--auto-rename` the
+        // target name comes straight from CLI args and would otherwise reach
+        // the filesystem unchecked, allowing path traversal (e.g. `../../x`).
+        // Every other entry point already validates; this covers the migrate path.
+        crate::validate::validate_env_name(name)?;
+
         let target_path = paths::virtualenv_path(name)?;
 
         if target_path.exists() {
@@ -452,6 +458,23 @@ mod tests {
             source_type: SourceType::Pyenv,
             size_bytes: Some(1024),
             status,
+        }
+    }
+
+    #[test]
+    fn create_target_env_rejects_path_traversal_name() {
+        let migrator = Migrator {
+            uv: UvClient::with_path(PathBuf::from("/mock/uv")),
+            extractor: PackageExtractor::new(),
+        };
+        // Names that escape the virtualenvs dir must be rejected before any
+        // filesystem access (validation runs before uv is invoked).
+        for evil in ["../../etc/evil", "..", "foo/bar", "/abs", ".hidden"] {
+            let result = migrator.create_target_env(evil, "3.12", false);
+            assert!(
+                matches!(result, Err(ScoopError::InvalidEnvName { .. })),
+                "name {evil:?} should be rejected as invalid"
+            );
         }
     }
 

--- a/src/core/migrate/venvwrapper.rs
+++ b/src/core/migrate/venvwrapper.rs
@@ -42,12 +42,12 @@ impl VenvWrapperDiscovery {
         let cfg_path = path.join("pyvenv.cfg");
         let content = fs::read_to_string(&cfg_path).ok()?;
 
-        for line in content.lines() {
-            let line = line.trim();
-            if let Some(version) = line.strip_prefix("version") {
-                let version = version.trim_start_matches([' ', '=']);
-                return Some(version.trim().to_string());
-            }
+        // Reads both `version` (stdlib venv) and `version_info` (uv) keys.
+        if let Some(version) = content
+            .lines()
+            .find_map(crate::core::pyvenv_version_from_line)
+        {
+            return Some(version);
         }
 
         // Fallback: try to extract from home path

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,9 +15,10 @@ pub const SCOOP_ACTIVE_ENV: &str = "SCOOP_ACTIVE";
 
 /// Parse `pyvenv.cfg` to extract the resolved Python version.
 ///
-/// Reads the `version` key from a venv's `pyvenv.cfg` file.
-/// This is used to resolve the actual Python version after environment creation,
-/// regardless of the specifier used (e.g., `cpython@3.12` resolves to `3.12.0`).
+/// Reads the `version` key (written by the stdlib `venv`) or `version_info`
+/// (written by `uv`) and normalizes the value to `MAJOR.MINOR.PATCH`. This
+/// resolves the actual Python version after environment creation, regardless
+/// of the specifier used (e.g. `cpython@3.12` -> `3.12.0`).
 ///
 /// # Examples
 ///
@@ -29,16 +30,41 @@ pub const SCOOP_ACTIVE_ENV: &str = "SCOOP_ACTIVE";
 pub fn parse_pyvenv_version(venv_path: &std::path::Path) -> Option<String> {
     let cfg_path = venv_path.join("pyvenv.cfg");
     let content = std::fs::read_to_string(&cfg_path).ok()?;
+    content.lines().find_map(pyvenv_version_from_line)
+}
 
-    for line in content.lines() {
-        let line = line.trim();
-        if let Some(value) = line.strip_prefix("version") {
-            let value = value.trim_start_matches([' ', '=']);
-            return Some(value.trim().to_string());
-        }
+/// Extract a normalized Python version from a single `pyvenv.cfg` line.
+///
+/// Returns `Some` only when the line's key is exactly `version` (written by
+/// the stdlib `venv`) or `version_info` (written by `uv`). Matching the key
+/// precisely avoids the prefix bug where `strip_prefix("version")` turned
+/// `version_info = 3.14.3.final.0` into the literal `_info = 3.14.3.final.0`.
+/// The value is normalized to `MAJOR.MINOR.PATCH`.
+///
+/// Shared by the migrate discovery parsers so every `pyvenv.cfg` reader in the
+/// codebase handles both keys identically.
+pub(crate) fn pyvenv_version_from_line(line: &str) -> Option<String> {
+    let (key, value) = line.split_once('=')?;
+    matches!(key.trim(), "version" | "version_info").then(|| normalize_python_version(value.trim()))
+}
+
+/// Keep only the leading `MAJOR.MINOR.PATCH` numeric dotted components.
+///
+/// uv's `version_info` can be `3.14.3.final.0`; this normalizes it to
+/// `3.14.3`. A clean `MAJOR.MINOR.PATCH` (or shorter) passes through
+/// unchanged. Falls back to the original string if there is no leading
+/// numeric segment.
+fn normalize_python_version(raw: &str) -> String {
+    let numeric: Vec<&str> = raw
+        .split('.')
+        .take_while(|seg| !seg.is_empty() && seg.bytes().all(|b| b.is_ascii_digit()))
+        .take(3)
+        .collect();
+    if numeric.is_empty() {
+        raw.to_string()
+    } else {
+        numeric.join(".")
     }
-
-    None
 }
 
 /// Get the currently active environment name from $SCOOP_ACTIVE
@@ -54,4 +80,55 @@ pub fn parse_pyvenv_version(venv_path: &std::path::Path) -> Option<String> {
 /// ```
 pub fn get_active_env() -> Option<String> {
     std::env::var(SCOOP_ACTIVE_ENV).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn venv_with_cfg(contents: &str) -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut f = std::fs::File::create(dir.path().join("pyvenv.cfg")).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_pyvenv_version_reads_stdlib_version_key() {
+        let dir = venv_with_cfg("home = /usr/bin\nversion = 3.12.12\n");
+        assert_eq!(
+            parse_pyvenv_version(dir.path()),
+            Some("3.12.12".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_pyvenv_version_reads_uv_version_info_key() {
+        // Regression: uv writes `version_info`. The old prefix match produced
+        // "_info = 3.14.3.final.0"; we must read the value and normalize it.
+        let dir =
+            venv_with_cfg("home = /x\nimplementation = CPython\nversion_info = 3.14.3.final.0\n");
+        assert_eq!(parse_pyvenv_version(dir.path()), Some("3.14.3".to_string()));
+    }
+
+    #[test]
+    fn parse_pyvenv_version_missing_returns_none() {
+        let dir = venv_with_cfg("home = /x\nimplementation = CPython\n");
+        assert_eq!(parse_pyvenv_version(dir.path()), None);
+    }
+
+    #[test]
+    fn normalize_python_version_truncates_suffix() {
+        assert_eq!(normalize_python_version("3.14.3.final.0"), "3.14.3");
+        assert_eq!(normalize_python_version("3.12.12"), "3.12.12");
+        assert_eq!(normalize_python_version("3.12"), "3.12");
+        assert_eq!(normalize_python_version("3"), "3");
+    }
+
+    #[test]
+    fn normalize_python_version_non_numeric_falls_back() {
+        assert_eq!(normalize_python_version("garbage"), "garbage");
+        assert_eq!(normalize_python_version(""), "");
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -45,7 +45,7 @@ pub fn parse_pyvenv_version(venv_path: &std::path::Path) -> Option<String> {
 /// codebase handles both keys identically.
 pub(crate) fn pyvenv_version_from_line(line: &str) -> Option<String> {
     let (key, value) = line.split_once('=')?;
-    matches!(key.trim(), "version" | "version_info").then(|| normalize_python_version(value.trim()))
+    matches!(key.trim(), "version" | "version_info").then(|| normalize_pyvenv_version(value.trim()))
 }
 
 /// Keep only the leading `MAJOR.MINOR.PATCH` numeric dotted components.
@@ -54,7 +54,7 @@ pub(crate) fn pyvenv_version_from_line(line: &str) -> Option<String> {
 /// `3.14.3`. A clean `MAJOR.MINOR.PATCH` (or shorter) passes through
 /// unchanged. Falls back to the original string if there is no leading
 /// numeric segment.
-fn normalize_python_version(raw: &str) -> String {
+fn normalize_pyvenv_version(raw: &str) -> String {
     let numeric: Vec<&str> = raw
         .split('.')
         .take_while(|seg| !seg.is_empty() && seg.bytes().all(|b| b.is_ascii_digit()))
@@ -119,16 +119,20 @@ mod tests {
     }
 
     #[test]
-    fn normalize_python_version_truncates_suffix() {
-        assert_eq!(normalize_python_version("3.14.3.final.0"), "3.14.3");
-        assert_eq!(normalize_python_version("3.12.12"), "3.12.12");
-        assert_eq!(normalize_python_version("3.12"), "3.12");
-        assert_eq!(normalize_python_version("3"), "3");
+    fn normalize_pyvenv_version_truncates_suffix() {
+        assert_eq!(normalize_pyvenv_version("3.14.3.final.0"), "3.14.3");
+        assert_eq!(normalize_pyvenv_version("3.12.12"), "3.12.12");
+        assert_eq!(normalize_pyvenv_version("3.12"), "3.12");
+        assert_eq!(normalize_pyvenv_version("3"), "3");
     }
 
     #[test]
-    fn normalize_python_version_non_numeric_falls_back() {
-        assert_eq!(normalize_python_version("garbage"), "garbage");
-        assert_eq!(normalize_python_version(""), "");
+    fn normalize_pyvenv_version_non_numeric_falls_back() {
+        assert_eq!(normalize_pyvenv_version("garbage"), "garbage");
+        assert_eq!(normalize_pyvenv_version(""), "");
+        // Stops at the first empty/non-numeric segment; a leading `v` has no
+        // numeric prefix at all, so the original string is returned.
+        assert_eq!(normalize_pyvenv_version("3..4"), "3");
+        assert_eq!(normalize_pyvenv_version("v3.12"), "v3.12");
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -30,33 +30,24 @@ pub fn init() {
 pub fn detect_locale() -> String {
     // 1. SCOOP_LANG environment variable (override for scripts/CI)
     if let Ok(lang) = std::env::var("SCOOP_LANG") {
-        let normalized = normalize(&lang);
-        if is_supported(&normalized) {
-            return normalized;
-        }
-        // If SCOOP_LANG is set but unsupported, extract language code
-        let lang_code = normalized.split('-').next().unwrap_or("en");
-        if is_supported(lang_code) {
-            return lang_code.to_string();
+        if let Some(code) = resolve_supported(&lang) {
+            return code.to_string();
         }
     }
 
     // 2. Config file (scoop lang command)
     if let Ok(config) = Config::load() {
         if let Some(lang) = config.lang {
-            if is_supported(&lang) {
-                return lang;
+            if let Some(code) = resolve_supported(&lang) {
+                return code.to_string();
             }
         }
     }
 
     // 3. System locale
     if let Some(locale) = sys_locale::get_locale() {
-        let normalized = normalize(&locale);
-        // Extract language code (e.g., "ko-kr" -> "ko")
-        let lang_code = normalized.split('-').next().unwrap_or("en");
-        if is_supported(lang_code) {
-            return lang_code.to_string();
+        if let Some(code) = resolve_supported(&locale) {
+            return code.to_string();
         }
     }
 
@@ -64,14 +55,37 @@ pub fn detect_locale() -> String {
     "en".to_string()
 }
 
+/// Resolve any locale string to a supported canonical code.
+///
+/// Tries a full case-insensitive match first — so `pt-BR`, `pt-br`,
+/// `pt_BR`, and `pt-BR.UTF-8` all map to the canonical `"pt-BR"` — then
+/// falls back to the language-only prefix (e.g. `ko-KR` → `ko`). Returns
+/// `None` for unsupported locales.
+fn resolve_supported(raw: &str) -> Option<&'static str> {
+    let normalized = normalize(raw);
+    canonical_supported(&normalized)
+        .or_else(|| canonical_supported(normalized.split('-').next().unwrap_or("")))
+}
+
+/// Find the canonical supported code matching `candidate` case-insensitively.
+///
+/// Returns the code exactly as declared in [`SUPPORTED_LANGS`] (e.g. `"pt-BR"`),
+/// which is the form `rust_i18n::set_locale` and `locales/app.yml` expect.
+fn canonical_supported(candidate: &str) -> Option<&'static str> {
+    SUPPORTED_LANGS
+        .iter()
+        .map(|(code, _)| *code)
+        .find(|code| code.eq_ignore_ascii_case(candidate))
+}
+
 /// Get current locale.
 pub fn current() -> String {
     rust_i18n::locale().to_string()
 }
 
-/// Check if a language code is supported.
+/// Check if a language code is supported (case-insensitive).
 pub fn is_supported(lang: &str) -> bool {
-    SUPPORTED_LANGS.iter().any(|(code, _)| *code == lang)
+    canonical_supported(lang).is_some()
 }
 
 /// Get language display name for a code.
@@ -173,5 +187,54 @@ mod tests {
                 None => std::env::remove_var("SCOOP_LANG"),
             }
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_detect_pt_br_from_env_variants() {
+        let original = std::env::var("SCOOP_LANG").ok();
+
+        // SAFETY: serialized via #[serial]; env restored after test.
+        unsafe {
+            // All of these spellings must resolve to the canonical "pt-BR".
+            for input in ["pt-BR", "pt-br", "PT-BR", "pt_BR", "pt-BR.UTF-8"] {
+                std::env::set_var("SCOOP_LANG", input);
+                assert_eq!(
+                    detect_locale(),
+                    "pt-BR",
+                    "SCOOP_LANG={input} should resolve to canonical pt-BR"
+                );
+            }
+
+            match original {
+                Some(val) => std::env::set_var("SCOOP_LANG", val),
+                None => std::env::remove_var("SCOOP_LANG"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_supported_is_case_insensitive() {
+        assert!(is_supported("pt-BR"));
+        assert!(is_supported("pt-br"));
+        assert!(is_supported("PT-BR"));
+        assert!(is_supported("EN"));
+        assert!(is_supported("Ja"));
+        assert!(!is_supported("fr"));
+        assert!(!is_supported("zh-CN")); // Not yet supported
+    }
+
+    #[test]
+    fn test_resolve_supported_full_then_prefix() {
+        // Full case-insensitive match (region preserved as canonical).
+        assert_eq!(resolve_supported("pt-BR.UTF-8"), Some("pt-BR"));
+        assert_eq!(resolve_supported("PT_br"), Some("pt-BR"));
+        // Language-only prefix fallback.
+        assert_eq!(resolve_supported("ko_KR"), Some("ko"));
+        assert_eq!(resolve_supported("en_US.UTF-8"), Some("en"));
+        assert_eq!(resolve_supported("ja"), Some("ja"));
+        // Unsupported.
+        assert_eq!(resolve_supported("fr"), None);
+        assert_eq!(resolve_supported("zh-CN"), None);
     }
 }

--- a/src/uv/client.rs
+++ b/src/uv/client.rs
@@ -263,28 +263,25 @@ impl UvClient {
         Ok(())
     }
 
-    /// Get the latest installed Python version
+    /// Get the latest installed Python version.
     pub fn latest_installed_python(&self) -> Result<Option<PythonInfo>> {
-        let mut installed = self.list_installed_pythons()?;
-
-        // Sort by version descending
-        installed.sort_by(|a, b| {
-            let va = PythonVersion::parse(&a.version);
-            let vb = PythonVersion::parse(&b.version);
-            match (va, vb) {
-                (Some(a), Some(b)) => match b.major.cmp(&a.major) {
-                    std::cmp::Ordering::Equal => match (b.minor, a.minor) {
-                        (Some(bm), Some(am)) => bm.cmp(&am),
-                        _ => std::cmp::Ordering::Equal,
-                    },
-                    other => other,
-                },
-                _ => std::cmp::Ordering::Equal,
-            }
-        });
-
-        Ok(installed.into_iter().next())
+        Ok(pick_latest_python(self.list_installed_pythons()?))
     }
+}
+
+/// Pick the highest-versioned entry using [`PythonVersion`]'s full `Ord`
+/// (major.minor.patch.suffix).
+///
+/// The previous hand-rolled comparator only compared major then minor, so
+/// ties on minor (e.g. `3.12.1` vs `3.12.9`) were left in input order and
+/// could return an older patch as "latest". Entries whose version string
+/// doesn't parse are skipped; returns `None` if nothing parses.
+fn pick_latest_python(pythons: Vec<PythonInfo>) -> Option<PythonInfo> {
+    pythons
+        .into_iter()
+        .filter_map(|info| PythonVersion::parse(&info.version).map(|v| (v, info)))
+        .max_by(|(a, _), (b, _)| a.cmp(b))
+        .map(|(_, info)| info)
 }
 
 /// Parse uv python list output into structured info
@@ -563,5 +560,50 @@ graalpy-3.11.0    /path/graalpy
 
         assert!(info.path.is_none());
         assert!(!info.installed);
+    }
+
+    // =========================================================================
+    // pick_latest_python Tests
+    // =========================================================================
+
+    fn py_info(version: &str) -> PythonInfo {
+        PythonInfo {
+            version: version.to_string(),
+            path: None,
+            installed: true,
+            implementation: "cpython".to_string(),
+        }
+    }
+
+    /// Regression: ties on minor must compare patch (was returning input order).
+    #[test]
+    fn pick_latest_python_picks_highest_patch() {
+        let got = pick_latest_python(vec![
+            py_info("3.12.1"),
+            py_info("3.12.9"),
+            py_info("3.12.3"),
+        ]);
+        assert_eq!(got.unwrap().version, "3.12.9");
+    }
+
+    #[test]
+    fn pick_latest_python_compares_major_then_minor() {
+        let got = pick_latest_python(vec![
+            py_info("3.9.18"),
+            py_info("3.13.0"),
+            py_info("3.12.12"),
+        ]);
+        assert_eq!(got.unwrap().version, "3.13.0");
+    }
+
+    #[test]
+    fn pick_latest_python_skips_unparseable() {
+        let got = pick_latest_python(vec![py_info("garbage"), py_info("3.10.1")]);
+        assert_eq!(got.unwrap().version, "3.10.1");
+    }
+
+    #[test]
+    fn pick_latest_python_empty_is_none() {
+        assert!(pick_latest_python(vec![]).is_none());
     }
 }


### PR DESCRIPTION
## Summary

A security + logic audit (two specialist reviewers) surfaced four real bugs; this PR fixes each as its own commit, plus one review-driven rename. All fixes include unit tests and root-cause solutions.

| Severity | Bug | Fix |
|----------|-----|-----|
| 🔴 CRITICAL | `scoop list`/`info` showed `_info = 3.14.3.final.0` instead of the version | `fix(core)` |
| 🟠 HIGH | `latest_installed_python` could pick an older patch | `fix(uv)` |
| 🟡 MEDIUM (security) | `migrate --rename` allowed path traversal | `fix(migrate)` |
| 🟡 | `SCOOP_LANG=pt-BR` was ignored | `fix(i18n)` |

## Commits

1. **`fix(i18n)`** — `SCOOP_LANG=pt-BR` fell through to the system locale because `normalize()` lowercased to `pt-br` while matching was case-sensitive against canonical `pt-BR`. New `resolve_supported` (full case-insensitive match → language-prefix fallback) used by all three detection sources; `is_supported` is case-insensitive.

2. **`fix(core)`** — uv writes `version_info = 3.14.3.final.0` in `pyvenv.cfg`, but `strip_prefix("version")` also matched `version_info`, yielding the literal `_info = …` that poisoned `.scoop-metadata.json` at create time. New shared `pyvenv_version_from_line` (exact key match via `split_once('=')` + `normalize_pyvenv_version` truncating to MAJOR.MINOR.PATCH). **All four pyvenv.cfg readers (core + migrate discovery/venvwrapper/conda) now share it** — no duplicated parsing remains.

3. **`fix(uv)`** — `latest_installed_python`'s hand-rolled comparator compared only major/minor and ignored patch, so `3.12.1` vs `3.12.9` kept input order. Replaced with `pick_latest_python` using `PythonVersion`'s full `Ord`.

4. **`fix(migrate)`** — `migrate --rename`/`--auto-rename` passed the CLI name straight to the filesystem; `../../../tmp/x` under `--force` ran `remove_dir_all` + `uv venv` outside the venv dir. Added `validate_env_name` at the `create_target_env` trust boundary (the single choke point both single and batch migrate pass through).

5. **`refactor(core)`** — rename the core helper to `normalize_pyvenv_version` to avoid a name collision with the existing `validate::normalize_python_version` (different behavior). Review-flagged maintenance trap.

## Verification

- `cargo test --all-features --workspace`: **567 unit + 43 integration + 19 doctest pass** (+10 new tests)
- `cargo clippy --all-targets --all-features -- -D warnings`: 0 warnings
- Manual smoke: `scoop create demoenv 3.12` → `scoop list`/`info` now show `3.12.12` (was `_info = 3.12.12`); `SCOOP_LANG=pt-BR` now prints Portuguese; ko/en/ja unchanged.

## Audit outcome

Comprehensive review of the diff: **APPROVE** — 0 critical / 0 high / 1 medium / 3 low in the *fixes themselves*; the medium (name collision) is addressed by commit 5, the lows are benign or covered by added edge-case tests. No security bypass: `cargo audit` clean, all subprocess calls use arg arrays, migrate validation covers every path to `create_target_env`.

## Release impact

`fix:` commits → release-plz will open a v0.9.0 → **v0.9.1** patch release PR.