### PR TITLE
test: rstest/mutants/fuzz infra + i18n locale decoupling

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,25 @@
+# cargo-mutants configuration for scoop-uv
+# Docs: https://mutants.rs/
+#
+# Mutation testing verifies the test suite actually catches bugs (not just that
+# lines execute). We exclude code where a "missed" mutant is an acceptable gap
+# rather than a real test hole:
+#   - shell/**     : emits shell-script strings, validated at the integration level
+#   - cli/**       : thin handlers that shell out to `uv` (no uv on CI runners)
+#   - output/**    : terminal formatting and spinners (cosmetic)
+#   - i18n.rs      : locale glue
+#   - main.rs      : process entry / arg wiring
+#   - test_utils.rs: test-only helpers
+exclude_globs = [
+    "src/shell/**",
+    "src/cli/**",
+    "src/output/**",
+    "src/i18n.rs",
+    "src/main.rs",
+    "src/test_utils.rs",
+]
+
+# `cargo test` runs in well under a second; give each mutant generous headroom
+# so a slow machine doesn't report false timeouts.
+timeout_multiplier = 8.0
+minimum_test_timeout = 30

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,58 @@
+# Fuzz Testing (cargo-fuzz / libFuzzer)
+# Nightly-only, time-bounded. Runs weekly and on demand — NOT on every PR and
+# NOT part of the MSRV matrix. The fuzz/ crate is an isolated workspace.
+
+name: Fuzz
+
+on:
+  schedule:
+    - cron: "0 2 * * 1" # Monday 02:00 UTC
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_env_name
+          - fuzz_uv_version_parse
+          - fuzz_python_version
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+
+      - name: Restore corpus
+        uses: actions/cache@v4
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-${{ matrix.target }}-
+
+      - name: Run fuzzer (time-bounded)
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=120
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,103 @@
+# Mutation Testing (cargo-mutants)
+# Verifies the test suite catches injected bugs.
+#  - On PRs: only mutate changed lines (--in-diff) so it stays fast.
+#  - Weekly / manual: full run over the configured scope.
+
+name: Mutants
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * 1" # Monday 03:00 UTC
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  SCOOP_LANG: en
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Fast PR gate: mutate only the lines this PR changed.
+  incremental:
+    name: Mutants (diff)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "stable-ci"
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Build diff against base
+        run: git diff "origin/${{ github.base_ref }}"... > git.diff
+
+      - name: Run mutation tests on changed lines
+        run: cargo mutants --no-shuffle -vV --in-diff git.diff
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-incremental.out
+          path: mutants.out
+
+  # Weekly / on-demand: full run over the configured scope.
+  full:
+    name: Mutants (full)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "stable-ci"
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Run full mutation suite
+        run: cargo mutants --no-shuffle -vV
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-full.out
+          path: mutants.out

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,15 @@ htmlcov/
 # Benchmarks output
 criterion/
 
+# Mutation testing (cargo-mutants) output
+mutants.out/
+mutants.out.old/
+
+# Fuzzing (cargo-fuzz) build artifacts
+fuzz/target/
+fuzz/corpus/
+fuzz/artifacts/
+
 # ==============================================================================
 # Project Specific
 # ==============================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "rust-i18n",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sys-locale",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,10 +478,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -490,6 +507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -934,6 +952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,10 +1103,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "roff"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rust-i18n"
@@ -1134,6 +1196,15 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1210,6 +1281,7 @@ dependencies = [
  "predicates",
  "proptest",
  "regex",
+ "rstest",
  "rust-i18n",
  "serde",
  "serde_json",
@@ -1475,8 +1547,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1489,6 +1561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,9 +1578,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1861,6 +1963,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ serial_test = "3.2"
 proptest = "1.11"
 insta = { version = "1.47", features = ["yaml"] }
 rstest = "0.26"
+serde_yaml = "0.9"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tempfile = "3.27"
 serial_test = "3.2"
 proptest = "1.11"
 insta = { version = "1.47", features = ["yaml"] }
+rstest = "0.26"
 
 [profile.release]
 lto = true

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target/
+corpus/
+artifacts/
+coverage/
+Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "scoop-uv-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.scoop-uv]
+path = ".."
+
+# Independent workspace: keeps the nightly-only fuzz crate out of the main
+# (MSRV 1.85) workspace so it never affects the project's build or CI matrix.
+[workspace]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_env_name"
+path = "fuzz_targets/fuzz_env_name.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_uv_version_parse"
+path = "fuzz_targets/fuzz_uv_version_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_python_version"
+path = "fuzz_targets/fuzz_python_version.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_env_name.rs
+++ b/fuzz/fuzz_targets/fuzz_env_name.rs
@@ -1,0 +1,27 @@
+#![no_main]
+//! Fuzz environment-name validation — the security-critical gate, since names
+//! become filesystem paths.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(name) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let is_valid = scoop_uv::validate::is_valid_env_name(name);
+
+    // Invariant 1: the bool and Result validators must always agree.
+    assert_eq!(is_valid, scoop_uv::validate::validate_env_name(name).is_ok());
+
+    // Invariant 2: an accepted name must satisfy the security contract — no path
+    // separators, parent refs, NUL, and it must look like a plain identifier.
+    if is_valid {
+        assert!(!name.contains('/'));
+        assert!(!name.contains('\\'));
+        assert!(!name.contains('\0'));
+        assert!(!name.contains(".."));
+        assert!(name.chars().next().is_some_and(|c| c.is_ascii_alphabetic()));
+        assert!(name.len() <= 64);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_python_version.rs
+++ b/fuzz/fuzz_targets/fuzz_python_version.rs
@@ -1,0 +1,15 @@
+#![no_main]
+//! Fuzz Python-version validation/parsing. The contract is "never panic on
+//! arbitrary input"; both entry points are exercised.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(version) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let _ = scoop_uv::validate::is_valid_python_version(version);
+    let _ = scoop_uv::validate::validate_python_version(version);
+    let _ = scoop_uv::validate::PythonVersion::parse(version);
+});

--- a/fuzz/fuzz_targets/fuzz_uv_version_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_uv_version_parse.rs
@@ -1,0 +1,20 @@
+#![no_main]
+//! Fuzz `uv --version` parsing. Must never panic, and a parsed triple must
+//! round-trip through formatting.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(raw) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    if let Some((major, minor, patch)) = scoop_uv::uv::version::parse(raw) {
+        // Round-trip: a canonical "uv X.Y.Z" string must parse back identically.
+        let formatted = format!("uv {major}.{minor}.{patch}");
+        assert_eq!(
+            scoop_uv::uv::version::parse(&formatted),
+            Some((major, minor, patch))
+        );
+    }
+});

--- a/fuzz/rust-toolchain.toml
+++ b/fuzz/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# cargo-fuzz (libFuzzer) requires a nightly toolchain for -Z sanitizer flags.
+# This directory-scoped override applies to all `cargo fuzz` invocations here
+# and does NOT affect the project root, which stays pinned at MSRV 1.85.
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -735,6 +735,7 @@ error.use_missing_name:
   en: "Environment name required (use --unset to remove setting)"
   ko: "환경 이름 필요 (설정 제거는 --unset 사용)"
   pt-BR: "Nome do ambiente necessário (use --unset para remover configuração)"
+  ja: "環境名が必要です (設定を削除するには --unset を使用)"
 
 error.shell_missing_name:
   en: "Environment name required (use --unset to clear)"

--- a/src/core/migrate/migrator.rs
+++ b/src/core/migrate/migrator.rs
@@ -10,6 +10,7 @@ use crate::error::{MigrationExitCode, Result, ScoopError};
 use crate::paths;
 use crate::uv::PythonInfo;
 use crate::uv::UvClient;
+use crate::validate::PythonVersion;
 
 use super::extractor::{ExtractionResult, PackageExtractor};
 use super::source::{EnvironmentStatus, SourceEnvironment};
@@ -164,12 +165,16 @@ impl Migrator {
             });
         }
 
-        // 3. Check if it can be installed (uv knows a matching version)
+        // 3. Check if it can be installed: uv knows a version matching the
+        //    requested major.minor. Reuse PythonVersion::matches (as steps 1-2
+        //    do via find_python) instead of ad-hoc string matching.
         let available = self.uv.list_pythons()?;
-        let prefix = format!("{major_minor}.");
-        let can_install = available
-            .iter()
-            .any(|info| info.version == major_minor || info.version.starts_with(&prefix));
+        let can_install = PythonVersion::parse(&major_minor).is_some_and(|req| {
+            available
+                .iter()
+                .filter_map(|info| PythonVersion::parse(&info.version))
+                .any(|have| req.matches(&have))
+        });
 
         if can_install {
             Ok(PythonAvailability::CanInstall {

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -335,6 +335,34 @@ mod tests {
         });
     }
 
+    /// Pins the exact depth boundary: with limit=1, traversal must still reach
+    /// the *immediate* parent. Distinguishes `depth > max` from `depth >= max`
+    /// (the latter would stop one directory too early).
+    #[test]
+    #[serial]
+    fn test_resolve_max_depth_reaches_immediate_parent() {
+        with_temp_scoop_home(|_temp_dir| {
+            let temp = TempDir::new().unwrap();
+            let parent = temp.path().join("a").join("b");
+            let deep = parent.join("c");
+            std::fs::create_dir_all(&deep).unwrap();
+
+            VersionService::set_local(&parent, "parentenv").unwrap();
+            VersionService::set_global("globalenv").unwrap();
+
+            // SAFETY: serial test, no concurrent env access.
+            unsafe {
+                std::env::set_var("SCOOP_RESOLVE_MAX_DEPTH", "1");
+                assert_eq!(
+                    VersionService::resolve(&deep),
+                    Some("parentenv".to_string()),
+                    "limit=1 must still reach the immediate parent"
+                );
+                std::env::remove_var("SCOOP_RESOLVE_MAX_DEPTH");
+            }
+        });
+    }
+
     #[test]
     #[serial]
     fn test_resolve_fallback_to_global() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,146 +116,149 @@ pub enum ScoopError {
 // Display Implementation (i18n-aware)
 // ============================================================================
 
-impl fmt::Display for ScoopError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl ScoopError {
+    /// Render the localized message in an explicit `locale`, bypassing the
+    /// process-global current locale.
+    ///
+    /// rust-i18n stores the active locale as process-global state, so tests
+    /// that assert on [`Display`] output must serialize against any test that
+    /// flips the locale. Asserting via `message_in("en")` / `message_in("ko")`
+    /// instead is race-free and needs no `#[serial]`.
+    ///
+    /// [`Display`]: std::fmt::Display
+    pub fn message_in(&self, locale: &str) -> String {
         match self {
             Self::VirtualenvNotFound { name } => {
-                write!(f, "{}", t!("error.virtualenv_not_found", name = name))
+                t!("error.virtualenv_not_found", locale = locale, name = name).to_string()
             }
             Self::VirtualenvExists { name } => {
-                write!(f, "{}", t!("error.virtualenv_exists", name = name))
+                t!("error.virtualenv_exists", locale = locale, name = name).to_string()
             }
-            Self::InvalidEnvName { name, reason } => {
-                write!(
-                    f,
-                    "{}",
-                    t!("error.invalid_env_name", name = name, reason = reason)
-                )
-            }
-            Self::InvalidPythonVersion { version } => {
-                write!(
-                    f,
-                    "{}",
-                    t!("error.invalid_python_version", version = version)
-                )
-            }
-            Self::UvNotFound => write!(f, "{}", t!("error.uv_not_found")),
-            Self::UvCommandFailed { command, message } => {
-                write!(
-                    f,
-                    "{}",
-                    t!(
-                        "error.uv_command_failed",
-                        command = command,
-                        message = message
-                    )
-                )
-            }
+            Self::InvalidEnvName { name, reason } => t!(
+                "error.invalid_env_name",
+                locale = locale,
+                name = name,
+                reason = reason
+            )
+            .to_string(),
+            Self::InvalidPythonVersion { version } => t!(
+                "error.invalid_python_version",
+                locale = locale,
+                version = version
+            )
+            .to_string(),
+            Self::UvNotFound => t!("error.uv_not_found", locale = locale).to_string(),
+            Self::UvCommandFailed { command, message } => t!(
+                "error.uv_command_failed",
+                locale = locale,
+                command = command,
+                message = message
+            )
+            .to_string(),
             Self::PathError(msg) => {
-                write!(f, "{}", t!("error.path_error", message = msg))
+                t!("error.path_error", locale = locale, message = msg).to_string()
             }
-            Self::HomeNotFound => write!(f, "{}", t!("error.home_not_found")),
-            Self::Io(err) => {
-                write!(f, "{}", t!("error.io", message = err.to_string()))
-            }
+            Self::HomeNotFound => t!("error.home_not_found", locale = locale).to_string(),
+            Self::Io(err) => t!("error.io", locale = locale, message = err.to_string()).to_string(),
             Self::Json(err) => {
-                write!(f, "{}", t!("error.json", message = err.to_string()))
+                t!("error.json", locale = locale, message = err.to_string()).to_string()
             }
-            Self::VersionFileNotFound { path } => {
-                write!(
-                    f,
-                    "{}",
-                    t!("error.version_file_not_found", path = path.display())
-                )
-            }
+            Self::VersionFileNotFound { path } => t!(
+                "error.version_file_not_found",
+                locale = locale,
+                path = path.display()
+            )
+            .to_string(),
             Self::UnsupportedShell { shell } => {
-                write!(f, "{}", t!("error.unsupported_shell", shell = shell))
+                t!("error.unsupported_shell", locale = locale, shell = shell).to_string()
             }
-            Self::PythonNotInstalled { version } => {
-                write!(f, "{}", t!("error.python_not_installed", version = version))
-            }
-            Self::PythonInstallFailed { version, message } => {
-                write!(
-                    f,
-                    "{}",
-                    t!(
-                        "error.python_install_failed",
-                        version = version,
-                        message = message
-                    )
-                )
-            }
-            Self::PythonUninstallFailed { version, message } => {
-                write!(
-                    f,
-                    "{}",
-                    t!(
-                        "error.python_uninstall_failed",
-                        version = version,
-                        message = message
-                    )
-                )
-            }
-            Self::NoPythonVersions { pattern } => {
-                write!(f, "{}", t!("error.no_python_versions", pattern = pattern))
-            }
+            Self::PythonNotInstalled { version } => t!(
+                "error.python_not_installed",
+                locale = locale,
+                version = version
+            )
+            .to_string(),
+            Self::PythonInstallFailed { version, message } => t!(
+                "error.python_install_failed",
+                locale = locale,
+                version = version,
+                message = message
+            )
+            .to_string(),
+            Self::PythonUninstallFailed { version, message } => t!(
+                "error.python_uninstall_failed",
+                locale = locale,
+                version = version,
+                message = message
+            )
+            .to_string(),
+            Self::NoPythonVersions { pattern } => t!(
+                "error.no_python_versions",
+                locale = locale,
+                pattern = pattern
+            )
+            .to_string(),
             Self::InvalidArgument { message } => {
-                write!(f, "{}", t!("error.invalid_argument", message = message))
+                t!("error.invalid_argument", locale = locale, message = message).to_string()
             }
-            Self::PyenvNotFound => write!(f, "{}", t!("error.pyenv_not_found")),
+            Self::PyenvNotFound => t!("error.pyenv_not_found", locale = locale).to_string(),
             Self::PyenvEnvNotFound { name } => {
-                write!(f, "{}", t!("error.pyenv_env_not_found", name = name))
+                t!("error.pyenv_env_not_found", locale = locale, name = name).to_string()
             }
-            Self::VenvWrapperEnvNotFound { name } => {
-                write!(f, "{}", t!("error.venvwrapper_env_not_found", name = name))
-            }
+            Self::VenvWrapperEnvNotFound { name } => t!(
+                "error.venvwrapper_env_not_found",
+                locale = locale,
+                name = name
+            )
+            .to_string(),
             Self::CondaEnvNotFound { name } => {
-                write!(f, "{}", t!("error.conda_env_not_found", name = name))
+                t!("error.conda_env_not_found", locale = locale, name = name).to_string()
             }
-            Self::CorruptedEnvironment { name, reason } => {
-                write!(
-                    f,
-                    "{}",
-                    t!("error.corrupted_environment", name = name, reason = reason)
-                )
-            }
-            Self::PackageExtractionFailed { reason } => {
-                write!(
-                    f,
-                    "{}",
-                    t!("error.package_extraction_failed", reason = reason)
-                )
-            }
+            Self::CorruptedEnvironment { name, reason } => t!(
+                "error.corrupted_environment",
+                locale = locale,
+                name = name,
+                reason = reason
+            )
+            .to_string(),
+            Self::PackageExtractionFailed { reason } => t!(
+                "error.package_extraction_failed",
+                locale = locale,
+                reason = reason
+            )
+            .to_string(),
             Self::MigrationFailed { reason } => {
-                write!(f, "{}", t!("error.migration_failed", reason = reason))
+                t!("error.migration_failed", locale = locale, reason = reason).to_string()
             }
-            Self::MigrationNameConflict { name, existing } => {
-                write!(
-                    f,
-                    "{}",
-                    t!(
-                        "error.migration_name_conflict",
-                        name = name,
-                        path = existing.display()
-                    )
-                )
-            }
-            Self::InvalidPythonPath { path, reason } => {
-                write!(
-                    f,
-                    "{}",
-                    t!(
-                        "error.invalid_python_path",
-                        path = path.display(),
-                        reason = reason
-                    )
-                )
-            }
-            Self::CascadeAborted => write!(f, "{}", t!("error.cascade_aborted")),
-            Self::SelfUpdateFailed { message } => {
-                write!(f, "{}", t!("error.self_update_failed", message = message))
-            }
+            Self::MigrationNameConflict { name, existing } => t!(
+                "error.migration_name_conflict",
+                locale = locale,
+                name = name,
+                path = existing.display()
+            )
+            .to_string(),
+            Self::InvalidPythonPath { path, reason } => t!(
+                "error.invalid_python_path",
+                locale = locale,
+                path = path.display(),
+                reason = reason
+            )
+            .to_string(),
+            Self::CascadeAborted => t!("error.cascade_aborted", locale = locale).to_string(),
+            Self::SelfUpdateFailed { message } => t!(
+                "error.self_update_failed",
+                locale = locale,
+                message = message
+            )
+            .to_string(),
         }
+    }
+}
+
+impl fmt::Display for ScoopError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let locale = rust_i18n::locale();
+        write!(f, "{}", self.message_in(&locale))
     }
 }
 
@@ -298,30 +301,51 @@ impl ScoopError {
         }
     }
 
-    /// Returns a suggested fix for the error (if available)
-    pub fn suggestion(&self) -> Option<String> {
+    /// Returns a suggested fix for the error in an explicit `locale`.
+    ///
+    /// Locale-explicit sibling of [`suggestion`](Self::suggestion); use it in
+    /// tests to assert hint text without depending on the process-global locale.
+    pub fn suggestion_in(&self, locale: &str) -> Option<String> {
         match self {
-            Self::VirtualenvNotFound { name } => {
-                Some(t!("suggestion.virtualenv_not_found", name = name).to_string())
+            Self::VirtualenvNotFound { name } => Some(
+                t!(
+                    "suggestion.virtualenv_not_found",
+                    locale = locale,
+                    name = name
+                )
+                .to_string(),
+            ),
+            Self::VirtualenvExists { .. } => {
+                Some(t!("suggestion.virtualenv_exists", locale = locale).to_string())
             }
-            Self::VirtualenvExists { .. } => Some(t!("suggestion.virtualenv_exists").to_string()),
-            Self::InvalidEnvName { .. } => Some(t!("suggestion.invalid_env_name").to_string()),
-            Self::UvNotFound => Some(t!("suggestion.uv_not_found").to_string()),
-            Self::PythonNotInstalled { version } => {
-                Some(t!("suggestion.python_not_installed", version = version).to_string())
+            Self::InvalidEnvName { .. } => {
+                Some(t!("suggestion.invalid_env_name", locale = locale).to_string())
             }
-            Self::NoPythonVersions { .. } => Some(t!("suggestion.no_python_versions").to_string()),
-            Self::PyenvNotFound => Some(t!("suggestion.pyenv_not_found").to_string()),
+            Self::UvNotFound => Some(t!("suggestion.uv_not_found", locale = locale).to_string()),
+            Self::PythonNotInstalled { version } => Some(
+                t!(
+                    "suggestion.python_not_installed",
+                    locale = locale,
+                    version = version
+                )
+                .to_string(),
+            ),
+            Self::NoPythonVersions { .. } => {
+                Some(t!("suggestion.no_python_versions", locale = locale).to_string())
+            }
+            Self::PyenvNotFound => {
+                Some(t!("suggestion.pyenv_not_found", locale = locale).to_string())
+            }
             Self::PyenvEnvNotFound { .. }
             | Self::VenvWrapperEnvNotFound { .. }
             | Self::CondaEnvNotFound { .. } => {
-                Some(t!("suggestion.source_env_not_found").to_string())
+                Some(t!("suggestion.source_env_not_found", locale = locale).to_string())
             }
             Self::MigrationNameConflict { .. } => {
-                Some(t!("suggestion.migration_name_conflict").to_string())
+                Some(t!("suggestion.migration_name_conflict", locale = locale).to_string())
             }
             Self::InvalidPythonPath { .. } => {
-                Some(t!("suggestion.invalid_python_path").to_string())
+                Some(t!("suggestion.invalid_python_path", locale = locale).to_string())
             }
             // uv-backed operations failing mid-command often trace back to an
             // unhealthy uv (missing, too old, broken PATH). Point users at the
@@ -329,9 +353,17 @@ impl ScoopError {
             // don't run the version/health checks that doctor and self update do.
             Self::UvCommandFailed { .. }
             | Self::PythonInstallFailed { .. }
-            | Self::PythonUninstallFailed { .. } => Some(t!("suggestion.run_doctor").to_string()),
+            | Self::PythonUninstallFailed { .. } => {
+                Some(t!("suggestion.run_doctor", locale = locale).to_string())
+            }
             _ => None,
         }
+    }
+
+    /// Returns a suggested fix for the error (if available), in the current locale.
+    pub fn suggestion(&self) -> Option<String> {
+        let locale = rust_i18n::locale();
+        self.suggestion_in(&locale)
     }
 
     /// Returns the migration exit code for this error.
@@ -355,92 +387,124 @@ impl ScoopError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
+    use rstest::rstest;
     use std::io;
 
     #[test]
-    #[serial]
     fn test_virtualenv_not_found_message() {
         let err = ScoopError::VirtualenvNotFound {
             name: "myenv".to_string(),
         };
-        assert_eq!(err.to_string(), "Can't find 'myenv' environment");
+        assert_eq!(err.message_in("en"), "Can't find 'myenv' environment");
+    }
+
+    // ==========================================================================
+    // Localized rendering (per-call locale, no global mutation → no #[serial])
+    // ==========================================================================
+
+    #[test]
+    fn message_renders_in_korean() {
+        let err = ScoopError::VirtualenvNotFound {
+            name: "myenv".to_string(),
+        };
+        let ko = err.message_in("ko");
+        // Structural assertion: keeps the interpolated name, and is not English.
+        assert!(ko.contains("myenv"));
+        assert_ne!(ko, err.message_in("en"));
+    }
+
+    /// Every supported locale renders a non-empty message that preserves the
+    /// interpolated environment name. Runs in parallel — no global locale touched.
+    #[rstest]
+    #[case::en("en")]
+    #[case::ko("ko")]
+    #[case::ja("ja")]
+    #[case::pt_br("pt-BR")]
+    fn message_in_all_locales_keeps_name(#[case] locale: &str) {
+        let err = ScoopError::VirtualenvNotFound {
+            name: "proj-env".to_string(),
+        };
+        let msg = err.message_in(locale);
+        assert!(!msg.is_empty(), "[{locale}] message must not be empty");
+        assert!(msg.contains("proj-env"), "[{locale}] must keep the name");
     }
 
     #[test]
-    #[serial]
+    fn suggestion_renders_in_korean() {
+        let err = ScoopError::VirtualenvNotFound {
+            name: "myenv".to_string(),
+        };
+        let ko = err.suggestion_in("ko").expect("has suggestion");
+        assert!(ko.starts_with("→"));
+        assert!(ko.contains("myenv"));
+        assert_ne!(ko, err.suggestion_in("en").unwrap());
+    }
+
+    #[test]
     fn test_virtualenv_exists_message() {
         let err = ScoopError::VirtualenvExists {
             name: "existing".to_string(),
         };
-        assert_eq!(err.to_string(), "'existing' already exists");
+        assert_eq!(err.message_in("en"), "'existing' already exists");
     }
 
     #[test]
-    #[serial]
     fn test_invalid_env_name_message() {
         let err = ScoopError::InvalidEnvName {
             name: "123bad".to_string(),
             reason: "must start with a letter".to_string(),
         };
-        assert!(err.to_string().contains("123bad"));
-        assert!(err.to_string().contains("must start with a letter"));
+        assert!(err.message_in("en").contains("123bad"));
+        assert!(err.message_in("en").contains("must start with a letter"));
     }
 
     #[test]
-    #[serial]
     fn test_invalid_python_version_message() {
         let err = ScoopError::InvalidPythonVersion {
             version: "abc".to_string(),
         };
-        assert_eq!(err.to_string(), "Invalid Python version: abc");
+        assert_eq!(err.message_in("en"), "Invalid Python version: abc");
     }
 
     #[test]
-    #[serial]
     fn test_uv_not_found_message() {
         let err = ScoopError::UvNotFound;
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(msg.contains("uv not found"));
         assert!(msg.contains("core engine"));
     }
 
     #[test]
-    #[serial]
     fn test_uv_command_failed_message() {
         let err = ScoopError::UvCommandFailed {
             command: "venv".to_string(),
             message: "Python not found".to_string(),
         };
-        assert!(err.to_string().contains("uv venv failed"));
-        assert!(err.to_string().contains("Python not found"));
+        assert!(err.message_in("en").contains("uv venv failed"));
+        assert!(err.message_in("en").contains("Python not found"));
     }
 
     #[test]
-    #[serial]
     fn test_path_error_message() {
         let err = ScoopError::PathError("invalid UTF-8".to_string());
-        assert_eq!(err.to_string(), "Path error: invalid UTF-8");
+        assert_eq!(err.message_in("en"), "Path error: invalid UTF-8");
     }
 
     #[test]
-    #[serial]
     fn test_home_not_found_message() {
         let err = ScoopError::HomeNotFound;
-        assert!(err.to_string().contains("Can't find home directory"));
+        assert!(err.message_in("en").contains("Can't find home directory"));
     }
 
     #[test]
-    #[serial]
     fn test_io_error_conversion() {
         let io_err = io::Error::new(io::ErrorKind::NotFound, "file missing");
         let err: ScoopError = io_err.into();
         assert!(matches!(err, ScoopError::Io(_)));
-        assert!(err.to_string().contains("file missing"));
+        assert!(err.message_in("en").contains("file missing"));
     }
 
     #[test]
-    #[serial]
     fn test_json_error_conversion() {
         let json_str = "{ invalid json }";
         let json_err: serde_json::Error =
@@ -450,75 +514,71 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_version_file_not_found_message() {
         let err = ScoopError::VersionFileNotFound {
             path: PathBuf::from("/some/path"),
         };
-        assert!(err.to_string().contains("/some/path"));
-        assert!(err.to_string().contains("parent directories"));
+        assert!(err.message_in("en").contains("/some/path"));
+        assert!(err.message_in("en").contains("parent directories"));
     }
 
     #[test]
-    #[serial]
     fn test_unsupported_shell_message() {
         let err = ScoopError::UnsupportedShell {
             shell: "fish".to_string(),
         };
-        assert_eq!(err.to_string(), "Shell 'fish' not supported");
+        assert_eq!(err.message_in("en"), "Shell 'fish' not supported");
     }
 
     #[test]
-    #[serial]
     fn test_python_not_installed_message() {
         let err = ScoopError::PythonNotInstalled {
             version: "3.13".to_string(),
         };
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(msg.contains("3.13"));
         assert!(msg.contains("not installed"));
     }
 
     #[test]
-    #[serial]
     fn test_python_install_failed_message() {
         let err = ScoopError::PythonInstallFailed {
             version: "3.12".to_string(),
             message: "network error".to_string(),
         };
-        assert!(err.to_string().contains("Couldn't install"));
-        assert!(err.to_string().contains("3.12"));
-        assert!(err.to_string().contains("network error"));
+        assert!(err.message_in("en").contains("Couldn't install"));
+        assert!(err.message_in("en").contains("3.12"));
+        assert!(err.message_in("en").contains("network error"));
     }
 
     #[test]
-    #[serial]
     fn test_python_uninstall_failed_message() {
         let err = ScoopError::PythonUninstallFailed {
             version: "3.11".to_string(),
             message: "in use".to_string(),
         };
-        assert!(err.to_string().contains("Couldn't uninstall"));
-        assert!(err.to_string().contains("3.11"));
-        assert!(err.to_string().contains("in use"));
+        assert!(err.message_in("en").contains("Couldn't uninstall"));
+        assert!(err.message_in("en").contains("3.11"));
+        assert!(err.message_in("en").contains("in use"));
     }
 
     #[test]
-    #[serial]
     fn test_no_python_versions_message() {
         let err = ScoopError::NoPythonVersions {
             pattern: "2.7".to_string(),
         };
-        assert!(err.to_string().contains("2.7"));
+        assert!(err.message_in("en").contains("2.7"));
     }
 
     #[test]
-    #[serial]
     fn test_invalid_argument_message() {
         let err = ScoopError::InvalidArgument {
             message: "Cannot use --stable and --latest together".to_string(),
         };
-        assert_eq!(err.to_string(), "Cannot use --stable and --latest together");
+        assert_eq!(
+            err.message_in("en"),
+            "Cannot use --stable and --latest together"
+        );
     }
 
     // ==========================================================================
@@ -526,25 +586,22 @@ mod tests {
     // ==========================================================================
 
     #[test]
-    #[serial]
     fn test_io_error_not_found() {
         let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
         let err: ScoopError = io_err.into();
         assert!(matches!(err, ScoopError::Io(_)));
-        assert!(err.to_string().contains("file not found"));
+        assert!(err.message_in("en").contains("file not found"));
     }
 
     #[test]
-    #[serial]
     fn test_io_error_permission_denied() {
         let io_err = io::Error::new(io::ErrorKind::PermissionDenied, "access denied");
         let err: ScoopError = io_err.into();
         assert!(matches!(err, ScoopError::Io(_)));
-        assert!(err.to_string().contains("access denied"));
+        assert!(err.message_in("en").contains("access denied"));
     }
 
     #[test]
-    #[serial]
     fn test_io_error_already_exists() {
         let io_err = io::Error::new(io::ErrorKind::AlreadyExists, "file exists");
         let err: ScoopError = io_err.into();
@@ -552,7 +609,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_io_error_preserves_kind() {
         let original = io::Error::new(io::ErrorKind::TimedOut, "operation timed out");
         let err: ScoopError = original.into();
@@ -565,7 +621,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_json_error_details() {
         // Invalid JSON syntax
         let json_err: serde_json::Error =
@@ -574,12 +629,11 @@ mod tests {
         assert!(matches!(err, ScoopError::Json(_)));
 
         // The error message should contain useful info
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(msg.contains("JSON"));
     }
 
     #[test]
-    #[serial]
     fn test_result_type_alias() {
         // Verify that Result<T> is an alias for std::result::Result<T, ScoopError>
         fn returns_result() -> Result<i32> {
@@ -595,7 +649,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_source_chain() {
         use std::error::Error;
 
@@ -620,7 +673,6 @@ mod tests {
     // ==========================================================================
 
     #[test]
-    #[serial]
     fn test_error_messages_are_user_friendly() {
         // All error messages should be complete sentences or clear phrases
         let errors = vec![
@@ -635,7 +687,7 @@ mod tests {
         ];
 
         for err in errors {
-            let msg = err.to_string();
+            let msg = err.message_in("en");
             // Messages should not be empty
             assert!(!msg.is_empty(), "Error message should not be empty");
             // Messages should start with uppercase, quote, or 'u' (for 'uv')
@@ -649,14 +701,13 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_messages_include_context() {
         // Errors with context should include that context in the message
         let err = ScoopError::VirtualenvNotFound {
             name: "myenv".to_string(),
         };
         assert!(
-            err.to_string().contains("myenv"),
+            err.message_in("en").contains("myenv"),
             "Error should include the env name"
         );
 
@@ -664,7 +715,7 @@ mod tests {
             version: "abc".to_string(),
         };
         assert!(
-            err.to_string().contains("abc"),
+            err.message_in("en").contains("abc"),
             "Error should include the invalid version"
         );
 
@@ -672,17 +723,16 @@ mod tests {
             shell: "fish".to_string(),
         };
         assert!(
-            err.to_string().contains("fish"),
+            err.message_in("en").contains("fish"),
             "Error should include the shell name"
         );
     }
 
     #[test]
-    #[serial]
     fn test_error_suggestions_provide_hints() {
         // UvNotFound suggestion should include installation instructions
         let err = ScoopError::UvNotFound;
-        let suggestion = err.suggestion().expect("should have suggestion");
+        let suggestion = err.suggestion_in("en").expect("should have suggestion");
         assert!(
             suggestion.contains("curl") && suggestion.contains("astral.sh"),
             "UvNotFound suggestion should include install command"
@@ -692,7 +742,7 @@ mod tests {
         let err = ScoopError::PythonNotInstalled {
             version: "3.13".to_string(),
         };
-        let suggestion = err.suggestion().expect("should have suggestion");
+        let suggestion = err.suggestion_in("en").expect("should have suggestion");
         assert!(
             suggestion.contains("scoop install") && suggestion.contains("3.13"),
             "PythonNotInstalled suggestion should include scoop install"
@@ -700,11 +750,10 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_messages_no_sensitive_info() {
         // Ensure error messages don't leak sensitive paths or info
         let err = ScoopError::PathError("test path error".to_string());
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         // Should not contain home directory patterns
         assert!(
             !msg.contains("/Users/") && !msg.contains("/home/"),
@@ -713,13 +762,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_invalid_env_name_provides_reason() {
         let err = ScoopError::InvalidEnvName {
             name: "123".to_string(),
             reason: "must start with a letter".to_string(),
         };
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(msg.contains("123"), "Should include the invalid name");
         assert!(
             msg.contains("must start with a letter"),
@@ -728,13 +776,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_uv_command_failed_includes_details() {
         let err = ScoopError::UvCommandFailed {
             command: "venv".to_string(),
             message: "Python 3.15 not found".to_string(),
         };
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(
             msg.contains("uv venv failed"),
             "Should indicate uv command failure"
@@ -746,12 +793,11 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_version_file_not_found_shows_path() {
         let err = ScoopError::VersionFileNotFound {
             path: PathBuf::from("/project/dir"),
         };
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(msg.contains("/project/dir"), "Should include the path");
         assert!(
             msg.contains("parent directories"),
@@ -764,21 +810,18 @@ mod tests {
     // ==========================================================================
 
     #[test]
-    #[serial]
     fn test_error_code_env_not_found() {
         let err = ScoopError::VirtualenvNotFound { name: "x".into() };
         assert_eq!(err.code(), "ENV_NOT_FOUND");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_env_already_exists() {
         let err = ScoopError::VirtualenvExists { name: "x".into() };
         assert_eq!(err.code(), "ENV_ALREADY_EXISTS");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_env_invalid_name() {
         let err = ScoopError::InvalidEnvName {
             name: "x".into(),
@@ -788,7 +831,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_python_invalid_version() {
         let err = ScoopError::InvalidPythonVersion {
             version: "x".into(),
@@ -797,14 +839,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_uv_not_installed() {
         let err = ScoopError::UvNotFound;
         assert_eq!(err.code(), "UV_NOT_INSTALLED");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_uv_command_failed() {
         let err = ScoopError::UvCommandFailed {
             command: "x".into(),
@@ -814,28 +854,24 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_io_path_error() {
         let err = ScoopError::PathError("x".into());
         assert_eq!(err.code(), "IO_PATH_ERROR");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_io_home_not_found() {
         let err = ScoopError::HomeNotFound;
         assert_eq!(err.code(), "IO_HOME_NOT_FOUND");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_io_error() {
         let err = ScoopError::Io(io::Error::other("test"));
         assert_eq!(err.code(), "IO_ERROR");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_internal_json_error() {
         let json_err: serde_json::Error =
             serde_json::from_str::<serde_json::Value>("invalid").expect_err("should fail");
@@ -844,7 +880,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_config_version_file_not_found() {
         let err = ScoopError::VersionFileNotFound {
             path: PathBuf::new(),
@@ -853,14 +888,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_shell_not_supported() {
         let err = ScoopError::UnsupportedShell { shell: "x".into() };
         assert_eq!(err.code(), "SHELL_NOT_SUPPORTED");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_python_not_installed() {
         let err = ScoopError::PythonNotInstalled {
             version: "x".into(),
@@ -869,7 +902,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_python_install_failed() {
         let err = ScoopError::PythonInstallFailed {
             version: "x".into(),
@@ -879,7 +911,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_python_uninstall_failed() {
         let err = ScoopError::PythonUninstallFailed {
             version: "x".into(),
@@ -889,7 +920,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_python_no_matching_version() {
         let err = ScoopError::NoPythonVersions {
             pattern: "x".into(),
@@ -898,7 +928,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_arg_invalid() {
         let err = ScoopError::InvalidArgument {
             message: "x".into(),
@@ -907,35 +936,30 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_source_pyenv_not_found() {
         let err = ScoopError::PyenvNotFound;
         assert_eq!(err.code(), "SOURCE_PYENV_NOT_FOUND");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_source_pyenv_env_not_found() {
         let err = ScoopError::PyenvEnvNotFound { name: "x".into() };
         assert_eq!(err.code(), "SOURCE_PYENV_ENV_NOT_FOUND");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_source_venvwrapper_env_not_found() {
         let err = ScoopError::VenvWrapperEnvNotFound { name: "x".into() };
         assert_eq!(err.code(), "SOURCE_VENVWRAPPER_ENV_NOT_FOUND");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_source_conda_env_not_found() {
         let err = ScoopError::CondaEnvNotFound { name: "x".into() };
         assert_eq!(err.code(), "SOURCE_CONDA_ENV_NOT_FOUND");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_migrate_corrupted() {
         let err = ScoopError::CorruptedEnvironment {
             name: "x".into(),
@@ -945,21 +969,18 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_migrate_extraction_failed() {
         let err = ScoopError::PackageExtractionFailed { reason: "x".into() };
         assert_eq!(err.code(), "MIGRATE_EXTRACTION_FAILED");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_migrate_failed() {
         let err = ScoopError::MigrationFailed { reason: "x".into() };
         assert_eq!(err.code(), "MIGRATE_FAILED");
     }
 
     #[test]
-    #[serial]
     fn test_error_code_migrate_name_conflict() {
         let err = ScoopError::MigrationNameConflict {
             name: "x".into(),
@@ -969,7 +990,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_code_invalid_python_path() {
         let err = ScoopError::InvalidPythonPath {
             path: PathBuf::from("/bad/python"),
@@ -979,31 +999,28 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_invalid_python_path_message() {
         let err = ScoopError::InvalidPythonPath {
             path: PathBuf::from("/usr/bin/fake-python"),
             reason: "file not found".into(),
         };
-        let msg = err.to_string();
+        let msg = err.message_in("en");
         assert!(msg.contains("/usr/bin/fake-python"));
         assert!(msg.contains("file not found"));
     }
 
     #[test]
-    #[serial]
     fn test_invalid_python_path_suggestion() {
         let err = ScoopError::InvalidPythonPath {
             path: PathBuf::from("/bad/path"),
             reason: "not executable".into(),
         };
-        let suggestion = err.suggestion().expect("should have suggestion");
+        let suggestion = err.suggestion_in("en").expect("should have suggestion");
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("Python executable"));
     }
 
     #[test]
-    #[serial]
     fn test_all_error_codes_are_unique() {
         use std::collections::HashSet;
 
@@ -1077,7 +1094,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_error_codes_follow_naming_convention() {
         // All codes should be SCREAMING_SNAKE_CASE
         let codes = vec![
@@ -1123,170 +1139,151 @@ mod tests {
     // ==========================================================================
 
     #[test]
-    #[serial]
     fn test_suggestion_virtualenv_not_found_includes_name() {
         let err = ScoopError::VirtualenvNotFound {
             name: "myenv".into(),
         };
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("myenv"));
         assert!(suggestion.contains("scoop create"));
     }
 
     #[test]
-    #[serial]
     fn test_suggestion_virtualenv_exists() {
         let err = ScoopError::VirtualenvExists {
             name: "existing".into(),
         };
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("--force"));
     }
 
     #[test]
-    #[serial]
     fn test_suggestion_invalid_env_name() {
         let err = ScoopError::InvalidEnvName {
             name: "123".into(),
             reason: "must start with letter".into(),
         };
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("letter"));
     }
 
     #[test]
-    #[serial]
     fn test_suggestion_uv_not_found() {
         let err = ScoopError::UvNotFound;
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("curl"));
         assert!(suggestion.contains("astral.sh"));
     }
 
     #[test]
-    #[serial]
     fn test_suggestion_python_not_installed_includes_version() {
         let err = ScoopError::PythonNotInstalled {
             version: "3.13".into(),
         };
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("3.13"));
         assert!(suggestion.contains("scoop install"));
     }
 
     #[test]
-    #[serial]
     fn test_suggestion_no_python_versions() {
         let err = ScoopError::NoPythonVersions {
             pattern: "2.7".into(),
         };
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("scoop list --pythons"));
     }
 
     #[test]
-    #[serial]
     fn test_no_suggestion_for_io_error() {
         let err = ScoopError::Io(io::Error::other("test"));
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
     fn test_no_suggestion_for_json_error() {
         let json_err: serde_json::Error =
             serde_json::from_str::<serde_json::Value>("invalid").expect_err("should fail");
         let err: ScoopError = json_err.into();
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
     fn test_suggestion_uv_command_failed_points_to_doctor() {
         let err = ScoopError::UvCommandFailed {
             command: "venv".into(),
             message: "failed".into(),
         };
-        let suggestion = err.suggestion().unwrap();
+        let suggestion = err.suggestion_in("en").unwrap();
         assert!(suggestion.starts_with("→"));
         assert!(suggestion.contains("scoop doctor"));
     }
 
     #[test]
-    #[serial]
-    fn test_suggestion_python_install_failed_points_to_doctor() {
-        let err = ScoopError::PythonInstallFailed {
-            version: "3.13".into(),
-            message: "failed".into(),
-        };
-        let suggestion = err.suggestion().unwrap();
-        assert!(suggestion.contains("scoop doctor"));
-    }
-
-    #[test]
-    #[serial]
-    fn test_suggestion_python_uninstall_failed_points_to_doctor() {
-        let err = ScoopError::PythonUninstallFailed {
-            version: "3.13".into(),
-            message: "failed".into(),
-        };
-        let suggestion = err.suggestion().unwrap();
-        assert!(suggestion.contains("scoop doctor"));
-    }
-
-    #[test]
-    #[serial]
     fn test_no_suggestion_for_path_error() {
         let err = ScoopError::PathError("invalid path".into());
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
     fn test_no_suggestion_for_home_not_found() {
         let err = ScoopError::HomeNotFound;
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
     fn test_no_suggestion_for_version_file_not_found() {
         let err = ScoopError::VersionFileNotFound {
             path: PathBuf::from("/project"),
         };
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
     fn test_no_suggestion_for_unsupported_shell() {
         let err = ScoopError::UnsupportedShell {
             shell: "fish".into(),
         };
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
+    fn test_suggestion_python_install_failed_points_to_doctor() {
+        let err = ScoopError::PythonInstallFailed {
+            version: "3.12".into(),
+            message: "network error".into(),
+        };
+        assert!(err.suggestion_in("en").unwrap().contains("scoop doctor"));
+    }
+
+    #[test]
+    fn test_suggestion_python_uninstall_failed_points_to_doctor() {
+        let err = ScoopError::PythonUninstallFailed {
+            version: "3.11".into(),
+            message: "in use".into(),
+        };
+        assert!(err.suggestion_in("en").unwrap().contains("scoop doctor"));
+    }
+
+    #[test]
     fn test_no_suggestion_for_invalid_python_version() {
         let err = ScoopError::InvalidPythonVersion {
             version: "abc".into(),
         };
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 
     #[test]
-    #[serial]
     fn test_no_suggestion_for_invalid_argument() {
         let err = ScoopError::InvalidArgument {
             message: "conflicting flags".into(),
         };
-        assert!(err.suggestion().is_none());
+        assert!(err.suggestion_in("en").is_none());
     }
 }

--- a/src/uv/client.rs
+++ b/src/uv/client.rs
@@ -336,37 +336,12 @@ mod tests {
         }
     }
 
-    /// `UvClient::default()` panics by contract when uv is absent from PATH.
-    /// This is the one production `.expect()` worth a `#[should_panic]` test —
-    /// everything else returns `Result`/`Option` and is asserted via `is_err()`.
-    #[test]
-    #[serial_test::serial]
-    #[should_panic(expected = "uv not found in PATH")]
-    fn default_panics_when_uv_absent() {
-        // RAII guard restores PATH during the should_panic unwind, so emptying
-        // it can't leak into other tests on this thread.
-        struct PathGuard(Option<std::ffi::OsString>);
-        impl Drop for PathGuard {
-            fn drop(&mut self) {
-                // SAFETY: serialized by ENV_LOCK + #[serial].
-                unsafe {
-                    match self.0.take() {
-                        Some(v) => std::env::set_var("PATH", v),
-                        None => std::env::remove_var("PATH"),
-                    }
-                }
-            }
-        }
-
-        let _lock = crate::test_utils::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let _guard = PathGuard(std::env::var_os("PATH"));
-        // SAFETY: serialized; restored by PathGuard even on the panic unwind.
-        unsafe { std::env::set_var("PATH", "") };
-
-        let _ = UvClient::default();
-    }
+    // Note: `UvClient::default()`'s `.expect("uv not found in PATH")` is the
+    // only production panic, but it can only be triggered by emptying the
+    // process-global `PATH`, which races with any concurrent test that resolves
+    // uv. A `#[should_panic]` test for it was intentionally dropped — a flaky
+    // test is worse than none, and the contract is obvious from the one-line
+    // impl. See `.docs/dev/testing-strategy.md` (should_panic policy).
 
     #[test]
     fn test_parse_python_list_with_paths() {

--- a/src/uv/client.rs
+++ b/src/uv/client.rs
@@ -65,66 +65,39 @@ impl UvClient {
 
     /// Get the uv version
     pub fn version(&self) -> Result<String> {
-        let output = Command::new(&self.path)
-            .arg("--version")
-            .output()
-            .map_err(|e| ScoopError::UvCommandFailed {
-                command: "uv --version".to_string(),
-                message: e.to_string(),
-            })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::UvCommandFailed {
-                command: "uv --version".to_string(),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        let mut cmd = Command::new(&self.path);
+        cmd.arg("--version");
+        let stdout = run_uv(cmd, |message| ScoopError::UvCommandFailed {
+            command: "uv --version".to_string(),
+            message,
+        })?;
+        Ok(String::from_utf8_lossy(&stdout).trim().to_string())
     }
 
     /// Create a virtual environment
     pub fn create_venv(&self, path: &Path, python_version: &str) -> Result<()> {
-        let output = Command::new(&self.path)
-            .arg("venv")
+        let mut cmd = Command::new(&self.path);
+        cmd.arg("venv")
             .arg(path)
             .arg("--python")
-            .arg(python_version)
-            .output()
-            .map_err(|e| ScoopError::UvCommandFailed {
-                command: format!("uv venv {} --python {}", path.display(), python_version),
-                message: e.to_string(),
-            })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::UvCommandFailed {
-                command: format!("uv venv {} --python {}", path.display(), python_version),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
+            .arg(python_version);
+        let display = format!("uv venv {} --python {}", path.display(), python_version);
+        run_uv(cmd, |message| ScoopError::UvCommandFailed {
+            command: display.clone(),
+            message,
+        })?;
         Ok(())
     }
 
     /// Install a Python version
     pub fn install_python(&self, version: &str) -> Result<()> {
-        let output = Command::new(&self.path)
-            .arg("python")
-            .arg("install")
-            .arg(version)
-            .output()
-            .map_err(|e| ScoopError::UvCommandFailed {
-                command: format!("uv python install {version}"),
-                message: e.to_string(),
-            })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::UvCommandFailed {
-                command: format!("uv python install {version}"),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
+        let mut cmd = Command::new(&self.path);
+        cmd.arg("python").arg("install").arg(version);
+        let display = format!("uv python install {version}");
+        run_uv(cmd, |message| ScoopError::UvCommandFailed {
+            command: display.clone(),
+            message,
+        })?;
         Ok(())
     }
 
@@ -158,41 +131,21 @@ impl UvClient {
             "uv python list --output-format=json"
         };
 
-        let output = cmd.output().map_err(|e| ScoopError::UvCommandFailed {
+        let stdout = run_uv(cmd, |message| ScoopError::UvCommandFailed {
             command: display.to_string(),
-            message: e.to_string(),
+            message,
         })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::UvCommandFailed {
-                command: display.to_string(),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        parse_python_list_json(&stdout)
+        parse_python_list_json(&String::from_utf8_lossy(&stdout))
     }
 
     /// Uninstall a Python version
     pub fn uninstall_python(&self, version: &str) -> Result<()> {
-        let output = Command::new(&self.path)
-            .arg("python")
-            .arg("uninstall")
-            .arg(version)
-            .output()
-            .map_err(|e| ScoopError::PythonUninstallFailed {
-                version: version.to_string(),
-                message: e.to_string(),
-            })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::PythonUninstallFailed {
-                version: version.to_string(),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
+        let mut cmd = Command::new(&self.path);
+        cmd.arg("python").arg("uninstall").arg(version);
+        run_uv(cmd, |message| ScoopError::PythonUninstallFailed {
+            version: version.to_string(),
+            message,
+        })?;
         Ok(())
     }
 
@@ -238,18 +191,11 @@ impl UvClient {
             cmd.arg(package);
         }
 
-        let output = cmd.output().map_err(|e| ScoopError::UvCommandFailed {
-            command: format!("uv pip install (into {})", venv_path.display()),
-            message: e.to_string(),
+        let display = format!("uv pip install (into {})", venv_path.display());
+        run_uv(cmd, |message| ScoopError::UvCommandFailed {
+            command: display.clone(),
+            message,
         })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::UvCommandFailed {
-                command: format!("uv pip install (into {})", venv_path.display()),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
         Ok(())
     }
 
@@ -263,26 +209,18 @@ impl UvClient {
         venv_path: &Path,
         requirements_path: &Path,
     ) -> Result<()> {
-        let output = Command::new(&self.path)
-            .arg("pip")
+        let mut cmd = Command::new(&self.path);
+        cmd.arg("pip")
             .arg("install")
             .arg("--python")
             .arg(venv_path.join("bin").join("python"))
             .arg("-r")
-            .arg(requirements_path)
-            .output()
-            .map_err(|e| ScoopError::UvCommandFailed {
-                command: format!("uv pip install -r {}", requirements_path.display()),
-                message: e.to_string(),
-            })?;
-
-        if !output.status.success() {
-            return Err(ScoopError::UvCommandFailed {
-                command: format!("uv pip install -r {}", requirements_path.display()),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
+            .arg(requirements_path);
+        let display = format!("uv pip install -r {}", requirements_path.display());
+        run_uv(cmd, |message| ScoopError::UvCommandFailed {
+            command: display.clone(),
+            message,
+        })?;
         Ok(())
     }
 
@@ -290,6 +228,22 @@ impl UvClient {
     pub fn latest_installed_python(&self) -> Result<Option<PythonInfo>> {
         Ok(pick_latest_python(self.list_installed_pythons()?))
     }
+}
+
+/// Run a built uv `Command`, returning captured stdout on success.
+///
+/// Centralizes the spawn + non-zero-exit handling every uv call repeats.
+/// `make_err` builds the error from the failure message, letting each caller
+/// pick its own variant (most use [`ScoopError::UvCommandFailed`]; uninstall
+/// uses [`ScoopError::PythonUninstallFailed`]). It is invoked at most once.
+fn run_uv(mut cmd: Command, make_err: impl Fn(String) -> ScoopError) -> Result<Vec<u8>> {
+    let output = cmd.output().map_err(|e| make_err(e.to_string()))?;
+    if !output.status.success() {
+        return Err(make_err(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+    Ok(output.stdout)
 }
 
 /// Pick the highest-versioned entry using [`PythonVersion`]'s full `Ord`

--- a/src/uv/client.rs
+++ b/src/uv/client.rs
@@ -336,6 +336,38 @@ mod tests {
         }
     }
 
+    /// `UvClient::default()` panics by contract when uv is absent from PATH.
+    /// This is the one production `.expect()` worth a `#[should_panic]` test —
+    /// everything else returns `Result`/`Option` and is asserted via `is_err()`.
+    #[test]
+    #[serial_test::serial]
+    #[should_panic(expected = "uv not found in PATH")]
+    fn default_panics_when_uv_absent() {
+        // RAII guard restores PATH during the should_panic unwind, so emptying
+        // it can't leak into other tests on this thread.
+        struct PathGuard(Option<std::ffi::OsString>);
+        impl Drop for PathGuard {
+            fn drop(&mut self) {
+                // SAFETY: serialized by ENV_LOCK + #[serial].
+                unsafe {
+                    match self.0.take() {
+                        Some(v) => std::env::set_var("PATH", v),
+                        None => std::env::remove_var("PATH"),
+                    }
+                }
+            }
+        }
+
+        let _lock = crate::test_utils::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _guard = PathGuard(std::env::var_os("PATH"));
+        // SAFETY: serialized; restored by PathGuard even on the panic unwind.
+        unsafe { std::env::set_var("PATH", "") };
+
+        let _ = UvClient::default();
+    }
+
     #[test]
     fn test_parse_python_list_with_paths() {
         let json = r#"[

--- a/src/uv/version.rs
+++ b/src/uv/version.rs
@@ -46,34 +46,21 @@ pub fn format_version(version: (u32, u32, u32)) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn parse_plain() {
-        assert_eq!(parse("uv 0.5.14"), Some((0, 5, 14)));
-        assert_eq!(parse("uv 0.11.16"), Some((0, 11, 16)));
-    }
-
-    #[test]
-    fn parse_homebrew_suffix() {
-        assert_eq!(
-            parse("uv 0.11.16 (Homebrew 2026-05-21 aarch64-apple-darwin)"),
-            Some((0, 11, 16))
-        );
-    }
-
-    #[test]
-    fn parse_build_suffix() {
-        assert_eq!(parse("uv 0.5.14 (build 1234)"), Some((0, 5, 14)));
-    }
-
-    #[test]
-    fn parse_rejects_garbage() {
-        assert_eq!(parse(""), None);
-        assert_eq!(parse("uv"), None);
-        assert_eq!(parse("uv abc"), None);
-        assert_eq!(parse("uv 0.5"), None);
-        assert_eq!(parse("uv 0.5.abc"), None);
-        assert_eq!(parse("uv 0.5.14.1"), Some((0, 5, 14))); // extra segments ignored
+    #[rstest]
+    #[case::plain("uv 0.5.14", Some((0, 5, 14)))]
+    #[case::plain_higher("uv 0.11.16", Some((0, 11, 16)))]
+    #[case::homebrew_suffix("uv 0.11.16 (Homebrew 2026-05-21 aarch64-apple-darwin)", Some((0, 11, 16)))]
+    #[case::build_suffix("uv 0.5.14 (build 1234)", Some((0, 5, 14)))]
+    #[case::extra_segments_ignored("uv 0.5.14.1", Some((0, 5, 14)))]
+    #[case::empty("", None)]
+    #[case::name_only("uv", None)]
+    #[case::non_numeric("uv abc", None)]
+    #[case::missing_patch("uv 0.5", None)]
+    #[case::non_numeric_patch("uv 0.5.abc", None)]
+    fn parse_cases(#[case] input: &str, #[case] expected: Option<(u32, u32, u32)>) {
+        assert_eq!(parse(input), expected);
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -481,50 +481,41 @@ pub fn detect_python_version(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn test_valid_env_names() {
-        assert!(is_valid_env_name("myenv"));
-        assert!(is_valid_env_name("MyEnv"));
-        assert!(is_valid_env_name("my-env"));
-        assert!(is_valid_env_name("my_env"));
-        assert!(is_valid_env_name("env123"));
-        assert!(is_valid_env_name("a"));
+    #[rstest]
+    #[case::simple("myenv", true)]
+    #[case::mixed_case("MyEnv", true)]
+    #[case::hyphen("my-env", true)]
+    #[case::underscore("my_env", true)]
+    #[case::trailing_digits("env123", true)]
+    #[case::single_char("a", true)]
+    #[case::empty("", false)]
+    #[case::digit_start("123", false)]
+    #[case::version_like("3.12", false)]
+    #[case::hyphen_start("-env", false)]
+    #[case::underscore_start("_env", false)]
+    #[case::space("my env", false)]
+    #[case::dot("my.env", false)]
+    #[case::reserved_activate("activate", false)]
+    #[case::reserved_activate_upper("ACTIVATE", false)]
+    #[case::reserved_list("list", false)]
+    #[case::reserved_version("version", false)]
+    fn is_valid_env_name_cases(#[case] input: &str, #[case] expected: bool) {
+        assert_eq!(is_valid_env_name(input), expected);
     }
 
-    #[test]
-    fn test_invalid_env_names() {
-        assert!(!is_valid_env_name(""));
-        assert!(!is_valid_env_name("123"));
-        assert!(!is_valid_env_name("3.12"));
-        assert!(!is_valid_env_name("-env"));
-        assert!(!is_valid_env_name("_env"));
-        assert!(!is_valid_env_name("my env"));
-        assert!(!is_valid_env_name("my.env"));
-    }
-
-    #[test]
-    fn test_reserved_names() {
-        assert!(!is_valid_env_name("activate"));
-        assert!(!is_valid_env_name("ACTIVATE"));
-        assert!(!is_valid_env_name("list"));
-        assert!(!is_valid_env_name("version"));
-    }
-
-    #[test]
-    fn test_valid_python_versions() {
-        assert!(is_valid_python_version("3"));
-        assert!(is_valid_python_version("3.12"));
-        assert!(is_valid_python_version("3.12.0"));
-        assert!(is_valid_python_version("3.12.0a1"));
-    }
-
-    #[test]
-    fn test_invalid_python_versions() {
-        assert!(!is_valid_python_version(""));
-        assert!(!is_valid_python_version("abc"));
-        assert!(!is_valid_python_version("v3.12")); // "v" prefix is invalid
-        assert!(!is_valid_python_version("3.12-beta")); // Hyphen is invalid
+    #[rstest]
+    #[case::major_only("3", true)]
+    #[case::major_minor("3.12", true)]
+    #[case::major_minor_patch("3.12.0", true)]
+    #[case::alpha_suffix("3.12.0a1", true)]
+    #[case::empty("", false)]
+    #[case::non_numeric("abc", false)]
+    #[case::v_prefix("v3.12", false)]
+    #[case::hyphen_beta("3.12-beta", false)]
+    fn is_valid_python_version_cases(#[case] input: &str, #[case] expected: bool) {
+        assert_eq!(is_valid_python_version(input), expected);
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -832,6 +832,105 @@ mod tests {
         let err = result.unwrap_err();
         assert!(err.to_string().contains("must start with a letter"));
     }
+
+    // ==========================================================================
+    // Boundary / branch coverage (kills mutation-testing gaps)
+    // ==========================================================================
+
+    /// `validate_env_name` length check: exactly MAX is allowed, MAX+1 rejected.
+    #[test]
+    fn validate_env_name_length_boundary() {
+        assert!(validate_env_name(&"a".repeat(MAX_ENV_NAME_LENGTH)).is_ok());
+        let too_long = validate_env_name(&"a".repeat(MAX_ENV_NAME_LENGTH + 1));
+        assert!(too_long.is_err());
+        assert!(too_long.unwrap_err().to_string().contains("maximum length"));
+    }
+
+    #[test]
+    fn normalize_python_version_trims_whitespace() {
+        assert_eq!(normalize_python_version("  3.12  "), "3.12");
+        assert_eq!(normalize_python_version("3.12.0"), "3.12.0");
+        assert_eq!(normalize_python_version("\t3.13\n"), "3.13");
+    }
+
+    /// The digit/dot fallback accepts version-shaped strings the regex rejects
+    /// (e.g. a trailing dot). Pins the `||` fallback branch.
+    #[test]
+    fn is_valid_python_version_digit_dot_fallback() {
+        assert!(!VERSION_REGEX.is_match("3."), "precondition: regex rejects");
+        assert!(is_valid_python_version("3."));
+        assert!(is_valid_python_version("3.12.4.5"));
+    }
+
+    #[test]
+    fn validate_python_path_rejects_nonexistent() {
+        let err = validate_python_path(Path::new("/no/such/python")).unwrap_err();
+        assert!(err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn validate_python_path_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = validate_python_path(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("not a file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_python_path_rejects_non_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("python");
+        std::fs::write(&file, "").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let err = validate_python_path(&file).unwrap_err();
+        assert!(err.to_string().contains("not executable"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_python_path_accepts_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("python");
+        std::fs::write(&file, "").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(validate_python_path(&file).is_ok());
+    }
+
+    /// Create an executable shell script for `detect_python_version` tests.
+    #[cfg(unix)]
+    fn write_exec_script(dir: &Path, name: &str, body: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_python_version_parses_stdout() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_exec_script(dir.path(), "py", "#!/bin/sh\necho \"Python 3.12.7\"\n");
+        assert_eq!(detect_python_version(&script), Some("3.12.7".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_python_version_none_on_failure_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_exec_script(dir.path(), "py", "#!/bin/sh\nexit 1\n");
+        assert_eq!(detect_python_version(&script), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_python_version_none_on_non_python_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_exec_script(dir.path(), "py", "#!/bin/sh\necho \"bash 5.2\"\n");
+        assert_eq!(detect_python_version(&script), None);
+    }
 }
 
 // =============================================================================

--- a/tests/i18n_completeness.rs
+++ b/tests/i18n_completeness.rs
@@ -94,6 +94,10 @@ fn strip_line_comments(content: &str) -> String {
 
 /// Extract literal keys from `t!("key" ...)`, tolerating whitespace/newlines
 /// between `t!(` and the opening quote (multi-line invocations).
+///
+/// Only string-literal keys are detected — `t!(SOME_CONST)` or concatenated
+/// keys are not covered. Every `t!` in this codebase uses a literal key, so
+/// this is complete today; revisit if a non-literal key is ever introduced.
 fn extract_t_keys(code: &str) -> BTreeSet<String> {
     let bytes = code.as_bytes();
     let needle = b"t!(";

--- a/tests/i18n_completeness.rs
+++ b/tests/i18n_completeness.rs
@@ -1,0 +1,150 @@
+//! Locale completeness checks.
+//!
+//! 1. Every translation key in `locales/app.yml` must exist in every supported
+//!    locale (en/ko/ja/pt-BR).
+//! 2. Every `t!("...")` key used in `src/` must have a translation.
+//!
+//! Both are pure file reads — no process-global locale is touched, so they run
+//! in parallel and need no `#[serial]`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+const LOCALES: &[&str] = &["en", "ko", "ja", "pt-BR"];
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Parse `app.yml` into `key -> set of locales that define it`.
+fn translation_keys() -> BTreeMap<String, BTreeSet<String>> {
+    let path = manifest_dir().join("locales/app.yml");
+    let raw = std::fs::read_to_string(&path).expect("read locales/app.yml");
+    let doc: BTreeMap<String, serde_yaml::Value> =
+        serde_yaml::from_str(&raw).expect("parse locales/app.yml");
+
+    let mut keys = BTreeMap::new();
+    for (key, value) in doc {
+        if key.starts_with('_') {
+            continue; // _version and other metadata
+        }
+        let Some(mapping) = value.as_mapping() else {
+            continue;
+        };
+        let locales: BTreeSet<String> = mapping
+            .keys()
+            .filter_map(|k| k.as_str().map(str::to_string))
+            .collect();
+        keys.insert(key, locales);
+    }
+    keys
+}
+
+#[test]
+fn every_key_exists_in_all_locales() {
+    let keys = translation_keys();
+    assert!(!keys.is_empty(), "no translation keys parsed");
+
+    let mut missing = Vec::new();
+    for (key, locales) in &keys {
+        for loc in LOCALES {
+            if !locales.contains(*loc) {
+                missing.push(format!("  {key} -> [{loc}]"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "Translation keys missing in some locales:\n{}",
+        missing.join("\n")
+    );
+}
+
+#[test]
+fn every_t_key_in_code_has_a_translation() {
+    let known = translation_keys();
+    let mut missing = Vec::new();
+
+    for file in rs_files(&manifest_dir().join("src")) {
+        let content = std::fs::read_to_string(&file).expect("read source file");
+        let code = strip_line_comments(&content);
+        for key in extract_t_keys(&code) {
+            if !known.contains_key(&key) {
+                missing.push(format!("  {key}  ({})", file.display()));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "`t!` keys used in code but absent from locales/app.yml:\n{}",
+        missing.join("\n")
+    );
+}
+
+/// Drop `//`-prefixed lines so doc/example keys don't count as real usage.
+fn strip_line_comments(content: &str) -> String {
+    content
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extract literal keys from `t!("key" ...)`, tolerating whitespace/newlines
+/// between `t!(` and the opening quote (multi-line invocations).
+fn extract_t_keys(code: &str) -> BTreeSet<String> {
+    let bytes = code.as_bytes();
+    let needle = b"t!(";
+    let mut keys = BTreeSet::new();
+    let mut i = 0;
+
+    while let Some(pos) = window_find(&bytes[i..], needle) {
+        let idx = i + pos; // absolute index of the `t`
+
+        // Require a standalone `t!` token; otherwise `t!(` also matches the
+        // tails of `format!(`, `assert!(`, `print!(`, etc.
+        let token_start = idx == 0 || {
+            let prev = bytes[idx - 1];
+            !(prev.is_ascii_alphanumeric() || prev == b'_')
+        };
+
+        if token_start {
+            let mut j = idx + needle.len();
+            while j < bytes.len() && (bytes[j] as char).is_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'"' {
+                let start = j + 1;
+                if let Some(end) = bytes[start..].iter().position(|&b| b == b'"') {
+                    keys.insert(code[start..start + end].to_string());
+                    i = start + end + 1;
+                    continue;
+                }
+            }
+        }
+        i = idx + needle.len();
+    }
+    keys
+}
+
+fn window_find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn rs_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d).expect("read_dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}


### PR DESCRIPTION
Stacked on #106 (base = `feat/uv-json-list-and-doctor-hint`). **Merge #106 first**; this PR's diff then shows only the test-quality + refactor changes. (GitHub will retarget this to `main` after #106 merges.)

## Summary
**Test quality**
- **rstest** `#[case]` table tests for `uv::version::parse` and `validate` (env-name / python-version).
- **i18n**: fixed a real bug — `error.use_missing_name` was missing its `ja` translation (Japanese users hit the English fallback). Added `ScoopError::message_in(locale)` / `suggestion_in(locale)` that pass `locale =` to `t!`, bypassing rust-i18n's process-global locale; `Display`/`suggestion()` delegate with the current locale. This dropped ~75 `#[serial]` from `error.rs` and enabled deterministic Korean tests — **behavior-preserving** for real CLI output. New `tests/i18n_completeness.rs` enforces locale parity + that every `t!` key in code has a translation.
- **cargo-mutants**: `.cargo/mutants.toml` + `Mutants` workflow (PR `--in-diff`, weekly full). Gap-filling tests → **81 caught / 0 missed / 3 unviable** on validate / uv::version / core::version.
- **cargo-fuzz**: isolated nightly `fuzz/` workspace (root MSRV 1.85 untouched) + 3 targets (env-name, uv-version round-trip, python-version) + weekly `Fuzz` workflow.

**Reuse/refactor**
- Extracted `run_uv(cmd, make_err)` — deduped the "spawn + status-check + error-map" boilerplate across 7 `UvClient` methods.
- Migrator availability check reuses `PythonVersion::matches` (consistent with steps 1–2) instead of ad-hoc string matching.

**Review follow-ups applied**: removed a flaky `should_panic` test that mutated global `PATH` (raced concurrent uv-resolving tests; reproduced ~1/8). Independent code + security review (incl. `cargo audit`) found no exploitable issues.

## Test plan
- [x] `cargo test`: 672 passed, 0 failed; clippy `-D warnings` + `fmt --check` clean
- [x] lib suite 10× consecutive runs — no flakiness
- [x] fuzz targets build (nightly+ASAN); `fuzz_env_name` smoke 200k runs, 0 crashes