### PR TITLE
docs: refresh for v0.10.0 (version examples, test tooling, API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Add-Content $PROFILE 'Invoke-Expression (& scoop init powershell)'
 
 ```bash
 scoop --version
-# → scoop 0.8.0 🍨
+# → scoop 0.10.0 🍨
 ```
 
 #### What this enables

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -350,13 +350,25 @@ impl ScoopError {
     /// Returns error code string (e.g., "ENV_NOT_FOUND", "UV_COMMAND_FAILED")
     pub fn code(&self) -> &'static str
 
-    /// Returns user-friendly suggestion (if available)
+    /// Localized message in an explicit locale (bypasses the process-global
+    /// current locale). `Display` delegates to this with the current locale.
+    pub fn message_in(&self, locale: &str) -> String
+
+    /// Returns user-friendly suggestion in the current locale (if available)
     pub fn suggestion(&self) -> Option<String>
+
+    /// Locale-explicit sibling of `suggestion()` — useful for deterministic,
+    /// parallel tests that must not depend on the global locale.
+    pub fn suggestion_in(&self, locale: &str) -> Option<String>
 
     /// Returns migration-specific exit code
     pub fn migration_exit_code(&self) -> MigrationExitCode
 }
 ```
+
+> The `*_in(locale)` accessors pass `locale =` to rust-i18n's `t!`, which
+> bypasses the process-global current locale — this lets tests assert messages
+> deterministically without `#[serial]`.
 
 **Error Code String Prefixes:**
 - `ENV_*` - Environment errors (e.g., `ENV_NOT_FOUND`, `ENV_ALREADY_EXISTS`)

--- a/docs/src/development/testing.md
+++ b/docs/src/development/testing.md
@@ -96,9 +96,9 @@ cargo test test_name -- --nocapture --test-threads=1
 
 ## Test Categories
 
-### Unit Tests (520 tests)
+### Unit Tests
 
-Located within source files using `#[cfg(test)]`:
+The bulk of the suite (600+ tests) lives within source files using `#[cfg(test)]`:
 
 ```rust
 #[cfg(test)]
@@ -184,6 +184,46 @@ proptest! {
 ```
 
 Located in `src/validate.rs`.
+
+### Parameterized Tests
+
+Using `rstest` `#[case]` tables for input/output matrices (e.g. version parsing,
+env-name validation) so each case reports independently:
+
+```rust
+use rstest::rstest;
+
+#[rstest]
+#[case::simple("myenv", true)]
+#[case::digit_start("123", false)]
+#[case::reserved("activate", false)]
+fn is_valid_env_name_cases(#[case] input: &str, #[case] expected: bool) {
+    assert_eq!(is_valid_env_name(input), expected);
+}
+```
+
+### Mutation Testing
+
+`cargo-mutants` verifies the suite actually *catches* bugs (not just that lines
+run). Config in `.cargo/mutants.toml`; CI runs it on changed lines per PR
+(`--in-diff`) and a full pass weekly.
+
+```bash
+cargo install cargo-mutants
+cargo mutants                 # full (scoped via mutants.toml)
+git diff origin/main.. | cargo mutants --in-diff /dev/stdin   # changed lines
+```
+
+### Fuzz Testing
+
+`cargo-fuzz` (libFuzzer) fuzzes the untrusted-input parsers. It lives in an
+isolated `fuzz/` workspace pinned to nightly, so it never affects the
+MSRV-1.85 build; CI runs the targets on a weekly schedule.
+
+```bash
+cargo install cargo-fuzz
+cargo +nightly fuzz run fuzz_env_name -- -max_total_time=60
+```
 
 ## Writing Tests
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -35,7 +35,7 @@ scoop --version
 
 ```bash
 scoop --version
-# scoop 0.8.0
+# scoop 0.10.0
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Docs-only refresh after the v0.10.0 release. No version bump expected (the release-plz `release_commits` filter ignores `docs:` commits).

## Summary
- **Version examples** `0.8.0 → 0.10.0` in `README.md` and `docs/src/installation.md`.
- **`docs/src/development/testing.md`**: drop the stale "520 tests" count (use "600+"); add **rstest / cargo-mutants / cargo-fuzz** sections now that they're part of the suite and enforced in CI.
- **`docs/src/api.md`**: document the new `ScoopError::message_in` / `suggestion_in` locale-explicit accessors.

## Notes
- Verified `mdbook build docs` is clean.
- Internal/local docs (CLAUDE.md, `.serena/`, `.docs/` vault, AGENTS.md) are git-excluded and were refreshed separately (not part of this PR).

## Test plan
- [x] `mdbook build docs` builds without errors
- [ ] Docs site renders the new testing/API sections correctly