### PR TITLE
test(cli): auto-guard man/completions for every non-hidden subcommand

### DIFF
--- a/src/cli/commands/completions.rs
+++ b/src/cli/commands/completions.rs
@@ -21,3 +21,77 @@ pub fn execute(shell: ShellType) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Generate completions for `shell` into an in-memory buffer.
+    /// Helper so the per-shell tests stay one-liners.
+    fn generate_for(shell: Shell) -> String {
+        let mut cmd = Cli::command();
+        let mut buf: Vec<u8> = Vec::new();
+        generate(shell, &mut cmd, "scoop", &mut buf);
+        String::from_utf8(buf).expect("completion output must be valid UTF-8")
+    }
+
+    /// Regression guard: every non-hidden subcommand in the clap tree
+    /// must appear in the generated completion output for every shell.
+    /// Without this, a future CLI command added to `Commands` would
+    /// silently miss completion coverage if a regression somewhere
+    /// stripped it from the tree clap-complete consumes.
+    ///
+    /// Naive substring check works because every shell that clap-
+    /// complete supports embeds subcommand names verbatim somewhere
+    /// in the body (bash function names, zsh case branches, fish
+    /// `complete` lines, PowerShell `[CompletionResult]` entries).
+    fn assert_every_subcommand_present(shell: Shell, body: &str) {
+        let cmd = Cli::command();
+        for sub in cmd.get_subcommands() {
+            if sub.is_hide_set() {
+                continue;
+            }
+            let name = sub.get_name();
+            assert!(
+                body.contains(name),
+                "expected subcommand '{name}' in {shell:?} completion output \
+                 (body length {} chars)",
+                body.len()
+            );
+        }
+    }
+
+    #[test]
+    fn bash_completion_includes_every_non_hidden_subcommand() {
+        let body = generate_for(Shell::Bash);
+        assert_every_subcommand_present(Shell::Bash, &body);
+    }
+
+    #[test]
+    fn zsh_completion_includes_every_non_hidden_subcommand() {
+        let body = generate_for(Shell::Zsh);
+        assert_every_subcommand_present(Shell::Zsh, &body);
+    }
+
+    #[test]
+    fn fish_completion_includes_every_non_hidden_subcommand() {
+        let body = generate_for(Shell::Fish);
+        assert_every_subcommand_present(Shell::Fish, &body);
+    }
+
+    #[test]
+    fn powershell_completion_includes_every_non_hidden_subcommand() {
+        let body = generate_for(Shell::PowerShell);
+        assert_every_subcommand_present(Shell::PowerShell, &body);
+    }
+
+    // Note: a "hidden subcommands don't appear in completions" probe
+    // was considered and rejected. clap-complete embeds every
+    // subcommand name (including hidden ones) in helper-function
+    // identifiers like `_scoop__subcmd__activate` — they participate
+    // in the dispatch table but aren't offered as interactive
+    // suggestions. Asserting their *absence* in the body needs a
+    // shell-specific parser, which is out of proportion to the
+    // value: man.rs::render_to_dir_skips_hidden_subcommands already
+    // pins the user-facing contract for hidden commands.
+}

--- a/src/cli/commands/man.rs
+++ b/src/cli/commands/man.rs
@@ -148,6 +148,32 @@ mod tests {
         }
     }
 
+    /// Future-proof regression guard: every non-hidden subcommand in
+    /// the clap tree must get its own man page. This is what catches
+    /// "we added a new command but the man emission missed it"
+    /// before reviewers do. The previous static list
+    /// (list/create/doctor) caught the renderer crashing wholesale
+    /// but not a per-command miss; this one does.
+    #[test]
+    fn render_to_dir_emits_page_for_every_non_hidden_subcommand() {
+        let tmp = TempDir::new().unwrap();
+        let output = Output::new(0, true, true, false);
+        execute(&output, Some(tmp.path())).unwrap();
+
+        let cmd = Cli::command();
+        for sub in cmd.get_subcommands() {
+            if sub.is_hide_set() {
+                continue;
+            }
+            let filename = format!("scoop-{}.1", sub.get_name());
+            assert!(
+                tmp.path().join(&filename).exists(),
+                "expected man page {filename} for subcommand '{}'",
+                sub.get_name()
+            );
+        }
+    }
+
     #[test]
     fn render_to_dir_skips_hidden_subcommands() {
         let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

A small follow-up to PR #127. `scoop diff` (added in v0.14.0) already lands in both `scoop man` and `scoop completions` output automatically — the existing clap-derive + clap_mangen / clap_complete pipeline reads straight from the `Commands` enum. Verified manually:

```bash
./target/release/scoop completions bash | grep diff   # → 8 matches
./target/release/scoop man /tmp/man-test/             # → scoop-diff.1 created
```

But the existing test coverage doesn't future-proof that contract — `man.rs::render_to_dir_emits_top_level_and_subcommand_pages` only checks a hardcoded triple (`list/create/doctor`), and `completions.rs` had no test module at all. A regression that drops a new command from the tree would slip past both.

This PR adds two auto-iterating regression guards that walk `Cli::command().get_subcommands()` at test time and assert every non-hidden subcommand surfaces in the output.

## Changes

- **`src/cli/commands/man.rs`**
  - New test `render_to_dir_emits_page_for_every_non_hidden_subcommand` — iterates every non-hidden subcommand and asserts the corresponding `scoop-<name>.1` exists in the temp dir.

- **`src/cli/commands/completions.rs`**
  - New `#[cfg(test)] mod tests` — runs the same iteration against the buffer that `generate(Shell::Bash | Zsh | Fish | PowerShell, ...)` produces. Substring match works for every shell because they all embed subcommand names verbatim somewhere in the generated body.

Both guards use `is_hide_set()` to skip `activate`/`deactivate`/`resolve` (shell-wrapper implementation details), matching the existing `render_to_dir_skips_hidden_subcommands` contract.

## Considered and rejected

A "hidden subcommands don't appear in completions" probe — clap-complete embeds hidden command names in *dispatch-helper* identifiers (e.g. `_scoop__subcmd__activate`) even though they're not surfaced as interactive suggestions. Asserting their *absence* in the body would need a shell-specific parser, which is out of proportion to the value: `man.rs::render_to_dir_skips_hidden_subcommands` already pins the user-facing contract for hidden commands.

## Test plan

- [x] `cargo test --lib` → 838 lib tests pass (5 new, 833 baseline)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: `scoop completions bash | grep diff` returns matches
- [x] Manual: `scoop man /tmp/dir` produces `scoop-diff.1` with full option set
- [ ] CI matrix (will run on push)