### PR TITLE
fix(doctor): treat .scoop-version: system as valid sentinel

### DIFF
--- a/src/core/doctor.rs
+++ b/src/core/doctor.rs
@@ -1166,6 +1166,34 @@ mod tests {
         );
     }
 
+    /// Mirror of the local-version test for the global path. Without
+    /// this, deleting the `!` in the `if !env_name.is_empty()` guard
+    /// on the global branch (doctor.rs:867) silently dropped every
+    /// version:global result and went unkilled by mutation testing.
+    #[test]
+    #[serial]
+    fn version_check_treats_global_system_sentinel_as_ok() {
+        with_temp_scoop_home(|temp| {
+            // Global version file lives at <SCOOP_HOME>/version (see
+            // paths::global_version_file). Materialise it with the
+            // sentinel value.
+            std::fs::write(temp.path().join("version"), "system").unwrap();
+            // virtualenvs dir presence shouldn't matter for the
+            // sentinel, but create it so other checks behave normally.
+            std::fs::create_dir_all(temp.path().join("virtualenvs")).unwrap();
+
+            let results = VersionCheck.run();
+            let global = results
+                .iter()
+                .find(|r| r.id == "version:global")
+                .expect("version:global must run when ~/.scoop/version exists");
+            assert!(
+                global.is_ok(),
+                "version:global must be Ok for system sentinel, got {global:#?}"
+            );
+        });
+    }
+
     #[test]
     #[serial]
     fn version_check_treats_local_system_sentinel_as_ok() {

--- a/src/core/doctor.rs
+++ b/src/core/doctor.rs
@@ -812,6 +812,36 @@ impl Check for ShellCheck {
     }
 }
 
+/// Classify a non-empty version-file entry into a [`CheckResult`].
+///
+/// The `system` sentinel (case-insensitive) is the documented value
+/// for "use the system Python, no virtualenv active" — it's what
+/// `scoop use system` writes — and must NOT be treated as a regular
+/// env name to look up. Pre-0.14.1 the doctor's version checks
+/// flagged `.scoop-version: system` as a non-existent-env error
+/// because the post-self-update doctor pass took it as a regular
+/// reference. `use_env::mod.rs:41` uses the same case-insensitive
+/// match on the writer side, so we mirror that contract here.
+fn classify_version_entry(
+    id: &'static str,
+    name: &'static str,
+    entry: &str,
+    venvs_dir: Option<&std::path::Path>,
+) -> CheckResult {
+    if entry.eq_ignore_ascii_case("system") {
+        return CheckResult::ok(id, name).with_details("system Python (no virtualenv)");
+    }
+    let env_exists = venvs_dir
+        .map(|dir| dir.join(entry).exists())
+        .unwrap_or(false);
+    if env_exists {
+        CheckResult::ok(id, name).with_details(format!("set to '{}'", entry))
+    } else {
+        CheckResult::error(id, name, format!("references non-existent env '{}'", entry))
+            .with_suggestion(format!("Run: scoop create {} <python-version>", entry))
+    }
+}
+
 /// Check for version file validity.
 struct VersionCheck;
 
@@ -835,30 +865,12 @@ impl Check for VersionCheck {
                     Ok(content) => {
                         let env_name = content.trim();
                         if !env_name.is_empty() {
-                            // Check if referenced environment exists
-                            let env_exists = venvs_dir
-                                .as_ref()
-                                .map(|dir| dir.join(env_name).exists())
-                                .unwrap_or(false);
-
-                            if env_exists {
-                                results.push(
-                                    CheckResult::ok("version:global", "global version")
-                                        .with_details(format!("set to '{}'", env_name)),
-                                );
-                            } else {
-                                results.push(
-                                    CheckResult::error(
-                                        "version:global",
-                                        "global version",
-                                        format!("references non-existent env '{}'", env_name),
-                                    )
-                                    .with_suggestion(format!(
-                                        "Run: scoop create {} <python-version>",
-                                        env_name
-                                    )),
-                                );
-                            }
+                            results.push(classify_version_entry(
+                                "version:global",
+                                "global version",
+                                env_name,
+                                venvs_dir.as_deref(),
+                            ));
                         }
                     }
                     Err(_) => {
@@ -886,30 +898,12 @@ impl Check for VersionCheck {
                 Ok(content) => {
                     let env_name = content.trim();
                     if !env_name.is_empty() {
-                        // Check if referenced environment exists
-                        let env_exists = venvs_dir
-                            .as_ref()
-                            .map(|dir| dir.join(env_name).exists())
-                            .unwrap_or(false);
-
-                        if env_exists {
-                            results.push(
-                                CheckResult::ok("version:local", "local version")
-                                    .with_details(format!("set to '{}'", env_name)),
-                            );
-                        } else {
-                            results.push(
-                                CheckResult::error(
-                                    "version:local",
-                                    "local version",
-                                    format!("references non-existent env '{}'", env_name),
-                                )
-                                .with_suggestion(format!(
-                                    "Run: scoop create {} <python-version>",
-                                    env_name
-                                )),
-                            );
-                        }
+                        results.push(classify_version_entry(
+                            "version:local",
+                            "local version",
+                            env_name,
+                            venvs_dir.as_deref(),
+                        ));
                     }
                 }
                 Err(_) => {
@@ -1094,6 +1088,140 @@ mod tests {
                 "expected at least one error result, got {results:#?}"
             );
         });
+    }
+
+    // ==========================================================================
+    // VersionCheck: `system` sentinel handling
+    //
+    // The `system` value in .scoop-version (or the global version file) is
+    // a documented sentinel meaning "use the system Python, no virtualenv
+    // active" — written by `scoop use system`. Pre-0.14.1 the post-self-update
+    // doctor pass flagged it as a non-existent env, which the user
+    // reported as a false-positive after `scoop self update` to 0.14.0.
+    // ==========================================================================
+
+    #[test]
+    fn classify_treats_system_as_valid_sentinel() {
+        let result = classify_version_entry("version:test", "test version", "system", None);
+        assert!(
+            result.is_ok(),
+            "system must classify as Ok, got {result:#?}"
+        );
+        assert!(
+            result
+                .details
+                .as_deref()
+                .is_some_and(|d| d.contains("system Python")),
+            "details should explain the sentinel, got {:?}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn classify_is_case_insensitive_for_system_sentinel() {
+        // The writer side (use_env::mod.rs:41) uses eq_ignore_ascii_case;
+        // doctor's reader must mirror that contract so `SYSTEM` or `System`
+        // round-trip cleanly even though `scoop use system` always writes
+        // the lowercase form.
+        for variant in ["SYSTEM", "System", "sYsTeM"] {
+            let result = classify_version_entry("version:test", "test version", variant, None);
+            assert!(
+                result.is_ok(),
+                "case-variant '{variant}' must classify as Ok"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_existing_env_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("myenv")).unwrap();
+        let result =
+            classify_version_entry("version:test", "test version", "myenv", Some(tmp.path()));
+        assert!(result.is_ok());
+        assert!(
+            result
+                .details
+                .as_deref()
+                .is_some_and(|d| d.contains("myenv"))
+        );
+    }
+
+    #[test]
+    fn classify_missing_env_is_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        // venvs dir exists but env doesn't — should error with suggestion.
+        let result = classify_version_entry(
+            "version:test",
+            "test version",
+            "missingenv",
+            Some(tmp.path()),
+        );
+        assert!(result.is_error());
+        assert!(
+            result
+                .suggestion
+                .as_deref()
+                .is_some_and(|s| s.contains("scoop create"))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn version_check_treats_local_system_sentinel_as_ok() {
+        with_temp_scoop_home(|temp| {
+            // Materialise a `.scoop-version: system` file in the CWD.
+            let cwd_guard = TempDirCwdGuard::new();
+            std::fs::write(cwd_guard.path().join(".scoop-version"), "system").unwrap();
+
+            // Ensure virtualenvs dir exists so its absence doesn't muddle the
+            // assertion (we only want the system-sentinel branch to fire).
+            std::fs::create_dir_all(temp.path().join("virtualenvs")).unwrap();
+
+            let results = VersionCheck.run();
+            let local = results
+                .iter()
+                .find(|r| r.id == "version:local")
+                .expect("version:local check should run when .scoop-version exists");
+            assert!(
+                local.is_ok(),
+                "version:local must be Ok for system sentinel, got {local:#?}"
+            );
+        });
+    }
+
+    /// RAII guard: chdir into a fresh tempdir for the duration of the
+    /// test, then restore the original cwd on drop. The VersionCheck's
+    /// local-version branch reads `.scoop-version` from the current
+    /// directory, so we have to actually move there — env vars can't
+    /// substitute.
+    struct TempDirCwdGuard {
+        _tmp: tempfile::TempDir,
+        new_cwd: std::path::PathBuf,
+        original: std::path::PathBuf,
+    }
+
+    impl TempDirCwdGuard {
+        fn new() -> Self {
+            let original = std::env::current_dir().expect("cwd readable");
+            let tmp = tempfile::tempdir().unwrap();
+            let new_cwd = tmp.path().to_path_buf();
+            std::env::set_current_dir(&new_cwd).expect("chdir into tempdir");
+            Self {
+                _tmp: tmp,
+                new_cwd,
+                original,
+            }
+        }
+        fn path(&self) -> &std::path::Path {
+            &self.new_cwd
+        }
+    }
+
+    impl Drop for TempDirCwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

User-reported regression in v0.14.0: `scoop self update` runs `scoop doctor` as a post-update check, and the doctor's version-file branch flags `.scoop-version: system` as a missing env:

\`\`\`
✗ local version: references non-existent env 'system'
  → Run: scoop create system <python-version>
\`\`\`

\`system\` is the documented sentinel for "use the system Python, no virtualenv active" — written by \`scoop use system\` (see \`src/cli/commands/use_env/system.rs\`, \`use_env::mod.rs:41\`). It is also a *reserved* name per CLAUDE.md naming conventions, so the suggested fix (\`scoop create system\`) would itself fail.

## Fix

Extract \`classify_version_entry\` and route both global and local version-file checks through it. Sentinel handling matches the writer's case-insensitive contract (\`use_env::mod.rs:41\`), so \`SYSTEM\`/\`System\`/\`sYsTeM\` all round-trip cleanly.

## Behaviour after fix

\`\`\`
$ cat .scoop-version
system
$ scoop doctor
…
✓ shell configuration
✓ local version: system Python (no virtualenv)
\`\`\`

## Test plan

- [x] \`cargo test --lib\` → 843 pass (+5 new tests)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI matrix (will run on push)

5 new tests:
- \`classify_treats_system_as_valid_sentinel\`
- \`classify_is_case_insensitive_for_system_sentinel\` (SYSTEM/System/sYsTeM)
- \`classify_existing_env_is_ok\`
- \`classify_missing_env_is_error\`
- \`version_check_treats_local_system_sentinel_as_ok\` (end-to-end via \`VersionCheck.run()\` with a real \`.scoop-version: system\` file in CWD; \`TempDirCwdGuard\` RAII restores cwd on drop)