### PR TITLE
docs(i18n): complete Korean documentation translation (ko.po)

### DIFF
--- a/docs/po/ko.po
+++ b/docs/po/ko.po
@@ -1,7 +1,8 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: scoop Documentation\n"
-"POT-Creation-Date: 2026-06-04T17:38:52+09:00\n"
+"POT-Creation-Date: 2026-06-16T15:21:09+09:00\n"
 "PO-Revision-Date: 2026-06-04T17:32:29+09:00\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -13,7 +14,7 @@ msgstr ""
 
 #: src/SUMMARY.md:1 src/python-management.md:307
 msgid "Summary"
-msgstr ""
+msgstr "목차"
 
 #: src/SUMMARY.md:3 src/index.md:1
 msgid "Introduction"
@@ -21,212 +22,215 @@ msgstr "소개"
 
 #: src/SUMMARY.md:7
 msgid "User Guide"
-msgstr ""
+msgstr "사용자 가이드"
 
 #: src/SUMMARY.md:9 src/installation.md:1
 msgid "Installation"
-msgstr ""
+msgstr "설치"
 
 #: src/SUMMARY.md:10 src/quick-start.md:1
 msgid "Quick Start"
-msgstr ""
+msgstr "빠른 시작"
 
 #: src/SUMMARY.md:11 src/shell-integration.md:1
-#: src/development/contributing.md:131 src/api.md:441 src/llms.md:167
+#: src/development/contributing.md:135 src/api.md:441 src/llms.md:169
 msgid "Shell Integration"
-msgstr ""
+msgstr "셸 통합"
 
 #: src/SUMMARY.md:12 src/python-management.md:1
 msgid "Python Management"
-msgstr ""
+msgstr "Python 관리"
 
 #: src/SUMMARY.md:13
 msgid "FAQ"
-msgstr ""
+msgstr "FAQ"
 
 #: src/SUMMARY.md:17 src/development/code-quality.md:35 src/llms.md:17
 msgid "Commands"
-msgstr ""
+msgstr "명령어"
 
 #: src/SUMMARY.md:19 src/llms.md:11
 msgid "Overview"
-msgstr ""
+msgstr "개요"
 
 #: src/SUMMARY.md:20 src/commands/list.md:1
 msgid "list"
-msgstr ""
+msgstr "list"
 
 #: src/SUMMARY.md:21 src/commands/create.md:1
-#: src/development/translation.md:189
+#: src/development/translation.md:190
 msgid "create"
-msgstr ""
+msgstr "create"
 
 #: src/SUMMARY.md:22 src/commands/use.md:1
 msgid "use"
-msgstr ""
+msgstr "use"
 
 #: src/SUMMARY.md:23 src/commands/remove.md:1
 msgid "remove"
-msgstr ""
+msgstr "remove"
 
 #: src/SUMMARY.md:24 src/commands/install.md:1
-#: src/development/translation.md:191
+#: src/development/translation.md:192
 msgid "install"
-msgstr ""
+msgstr "install"
 
 #: src/SUMMARY.md:25 src/commands/uninstall.md:1
-#: src/development/translation.md:192
+#: src/development/translation.md:193
 msgid "uninstall"
-msgstr ""
+msgstr "uninstall"
 
 #: src/SUMMARY.md:26 src/commands/doctor.md:1
 msgid "doctor"
-msgstr ""
+msgstr "doctor"
 
 #: src/SUMMARY.md:27 src/commands/info.md:1
 msgid "info"
-msgstr ""
+msgstr "info"
 
 #: src/SUMMARY.md:28 src/commands/status.md:1
 msgid "status"
-msgstr ""
+msgstr "status"
 
 #: src/SUMMARY.md:29 src/commands/which.md:1
-#: src/development/architecture.md:326
+#: src/development/architecture.md:330
 msgid "which"
-msgstr ""
+msgstr "which"
 
 #: src/SUMMARY.md:30 src/commands/run.md:1 src/development/testing.md:378
 #: src/development/testing.md:381 src/development/code-quality.md:235
 #: src/development/code-quality.md:238 src/development/code-quality.md:241
 msgid "run"
-msgstr ""
+msgstr "run"
 
 #: src/SUMMARY.md:31 src/commands/sync.md:1
 msgid "sync"
-msgstr ""
+msgstr "sync"
 
 #: src/SUMMARY.md:32 src/commands/export.md:1
 msgid "export"
-msgstr ""
+msgstr "export"
 
 #: src/SUMMARY.md:33 src/commands/import.md:1
 msgid "import"
-msgstr ""
+msgstr "import"
 
 #: src/SUMMARY.md:34 src/commands/clone.md:1
 msgid "clone"
-msgstr ""
+msgstr "clone"
 
 #: src/SUMMARY.md:35 src/commands/migrate.md:1
-#: src/development/translation.md:195
+#: src/development/translation.md:196
 msgid "migrate"
-msgstr ""
+msgstr "migrate"
 
 #: src/SUMMARY.md:36 src/commands/gc.md:1
 msgid "gc"
-msgstr ""
+msgstr "gc"
 
 #: src/SUMMARY.md:37 src/commands/prune.md:1
 msgid "prune"
-msgstr ""
+msgstr "prune"
 
 #: src/SUMMARY.md:38 src/commands/verify.md:1
 msgid "verify"
-msgstr ""
+msgstr "verify"
 
 #: src/SUMMARY.md:39 src/commands/diff.md:1
 msgid "diff"
-msgstr ""
+msgstr "diff"
 
 #: src/SUMMARY.md:40 src/commands/lang.md:1 src/development/translation.md:32
 msgid "lang"
-msgstr ""
+msgstr "lang"
 
-#: src/SUMMARY.md:41 src/commands/init.md:1
+#: src/SUMMARY.md:41
+msgid "self"
+msgstr "self"
+
+#: src/SUMMARY.md:42 src/commands/init.md:1
 msgid "init"
-msgstr ""
+msgstr "init"
 
-#: src/SUMMARY.md:42 src/commands/shell.md:1
+#: src/SUMMARY.md:43 src/commands/shell.md:1
 msgid "shell"
-msgstr ""
+msgstr "shell"
 
-#: src/SUMMARY.md:43 src/commands/completions.md:1
+#: src/SUMMARY.md:44 src/commands/completions.md:1
 msgid "completions"
-msgstr ""
+msgstr "completions"
 
-#: src/SUMMARY.md:44 src/commands/man.md:1
+#: src/SUMMARY.md:45 src/commands/man.md:1
 msgid "man"
-msgstr ""
+msgstr "man"
 
-#: src/SUMMARY.md:48
+#: src/SUMMARY.md:49
 msgid "Development"
-msgstr ""
+msgstr "개발"
 
-#: src/SUMMARY.md:50 src/development/contributing.md:1
+#: src/SUMMARY.md:51 src/development/contributing.md:1
 msgid "Contributing"
-msgstr ""
-
-#: src/SUMMARY.md:51
-msgid "Translation"
-msgstr ""
+msgstr "기여하기"
 
 #: src/SUMMARY.md:52
-msgid "Docs Translation"
-msgstr ""
+msgid "Translation"
+msgstr "번역"
 
-#: src/SUMMARY.md:53 src/development/contributing.md:107
+#: src/SUMMARY.md:53
+msgid "Docs Translation"
+msgstr "문서 번역"
+
+#: src/SUMMARY.md:54 src/development/contributing.md:111
 #: src/development/architecture.md:1
 msgid "Architecture"
-msgstr ""
+msgstr "아키텍처"
 
-#: src/SUMMARY.md:54 src/api.md:1
+#: src/SUMMARY.md:55 src/api.md:1
 msgid "API Reference"
-msgstr ""
+msgstr "API 레퍼런스"
 
-#: src/SUMMARY.md:55 src/development/contributing.md:174
+#: src/SUMMARY.md:56 src/development/contributing.md:178
 #: src/development/testing.md:1
 msgid "Testing"
-msgstr ""
+msgstr "테스트"
 
-#: src/SUMMARY.md:56 src/development/code-quality.md:1
+#: src/SUMMARY.md:57 src/development/code-quality.md:1
 msgid "Code Quality"
-msgstr ""
+msgstr "코드 품질"
 
-#: src/SUMMARY.md:60
+#: src/SUMMARY.md:61
 msgid "AI/LLM Integration"
-msgstr ""
+msgstr "AI/LLM 통합"
 
-#: src/SUMMARY.md:62 src/llms.md:1
+#: src/SUMMARY.md:63 src/llms.md:1
 msgid "LLM Reference"
-msgstr ""
+msgstr "LLM 레퍼런스"
 
-#: src/SUMMARY.md:66 src/SUMMARY.md:68 src/commands/list.md:45
-#: src/commands/create.md:26 src/commands/use.md:57 src/commands/remove.md:25
-#: src/commands/install.md:31 src/commands/uninstall.md:24
+#: src/SUMMARY.md:67 src/SUMMARY.md:69 src/commands/list.md:45
+#: src/commands/create.md:27 src/commands/use.md:58 src/commands/remove.md:26
+#: src/commands/install.md:32 src/commands/uninstall.md:25
 #: src/commands/doctor.md:29 src/commands/info.md:75 src/commands/status.md:82
 #: src/commands/which.md:36 src/commands/run.md:42 src/commands/sync.md:65
 #: src/commands/import.md:39 src/commands/clone.md:39
 #: src/commands/migrate.md:117 src/commands/gc.md:84 src/commands/prune.md:25
 #: src/commands/verify.md:50 src/commands/diff.md:60 src/commands/lang.md:51
-#: src/commands/init.md:45 src/commands/shell.md:53
+#: src/commands/self.md:28 src/commands/init.md:45 src/commands/shell.md:53
 #: src/commands/completions.md:17 src/examples.md:1
 msgid "Examples"
-msgstr ""
+msgstr "예시"
 
 #: src/index.md:3
 msgid ""
-"**scoop** is a centralized Python virtual environment manager powered by [uv]"
-"(https://github.com/astral-sh/uv)."
+"**scoop** is a centralized Python virtual environment manager powered by "
+"[uv](https://github.com/astral-sh/uv)."
 msgstr ""
-"**scoop**은 [uv](https://github.com/astral-sh/uv) 기반의 중앙 집중식 Python "
-"가상환경 관리자예요."
+"**scoop**은 [uv](https://github.com/astral-sh/uv) 기반의 중앙 집중식 Python 가상환경 "
+"관리자예요."
 
 #: src/index.md:5
-msgid "One scoop, endless envs — pyenv-style workflow with uv's blazing speed."
-msgstr ""
-"한 스쿱이면 수많은 환경을 손쉽게 — pyenv 스타일 워크플로와 uv의 압도적인 속"
-"도를 함께."
+msgid ""
+"One scoop, endless envs — pyenv-style workflow with uv's blazing speed."
+msgstr "한 스쿱이면 수많은 환경을 손쉽게 — pyenv 스타일 워크플로와 uv의 압도적인 속도를 함께."
 
 #: src/index.md:7
 msgid "What is scoop?"
@@ -333,9 +337,7 @@ msgstr "**셸 통합** — bash, zsh, fish, PowerShell 모두 지원해요"
 msgid ""
 "**IDE friendly** — `scoop use --link` creates `.venv` symlink for IDE "
 "discovery"
-msgstr ""
-"**IDE 친화적** — `scoop use --link`로 `.venv` 심볼릭 링크를 만들어 IDE가 인식"
-"하게 해요"
+msgstr "**IDE 친화적** — `scoop use --link`로 `.venv` 심볼릭 링크를 만들어 IDE가 인식하게 해요"
 
 #: src/index.md:46
 msgid "**Health checks** — `scoop doctor` diagnoses your setup"
@@ -349,8 +351,7 @@ msgstr "시작하기"
 msgid ""
 "Ready to scoop? Head to the [Installation](installation.md) guide to get "
 "started."
-msgstr ""
-"scoop을 떠 볼 준비됐나요? [설치 가이드](installation.md)부터 시작해 보세요."
+msgstr "scoop을 떠 볼 준비됐나요? [설치 가이드](installation.md)부터 시작해 보세요."
 
 #: src/index.md:52
 msgid "Links"
@@ -370,11 +371,11 @@ msgstr "[Crates.io](https://crates.io/crates/scoop-uv)"
 
 #: src/index.md:57
 msgid ""
-"[llms.txt](https://github.com/ai-screams/scoop-uv/blob/main/llms.txt) — AI/"
-"LLM-friendly project reference"
+"[llms.txt](https://github.com/ai-screams/scoop-uv/blob/main/llms.txt) — "
+"AI/LLM-friendly project reference"
 msgstr ""
-"[llms.txt](https://github.com/ai-screams/scoop-uv/blob/main/llms.txt) — AI/"
-"LLM 친화적인 프로젝트 참고 자료"
+"[llms.txt](https://github.com/ai-screams/scoop-uv/blob/main/llms.txt) — "
+"AI/LLM 친화적인 프로젝트 참고 자료"
 
 #: src/index.md:58
 msgid ""
@@ -387,497 +388,502 @@ msgstr ""
 #: src/installation.md:3 src/development/contributing.md:5
 #: src/development/docs-translation.md:24
 msgid "Prerequisites"
-msgstr ""
+msgstr "사전 요구사항"
 
 #: src/installation.md:5
 msgid "Dependency"
-msgstr ""
+msgstr "의존성"
 
 #: src/installation.md:5
 msgid "Version"
-msgstr ""
+msgstr "버전"
 
 #: src/installation.md:5
 msgid "Install Command"
-msgstr ""
+msgstr "설치 명령"
 
 #: src/installation.md:7
 msgid "**uv**"
-msgstr ""
+msgstr "**uv**"
 
 #: src/installation.md:7
-msgid "Latest"
-msgstr ""
+msgid "0.5.14 or newer"
+msgstr "0.5.14 이상"
 
 #: src/installation.md:7
 msgid "`curl -LsSf https://astral.sh/uv/install.sh \\| sh`"
-msgstr ""
+msgstr "`curl -LsSf https://astral.sh/uv/install.sh \\| sh`"
 
 #: src/installation.md:8
 msgid "**Rust**"
-msgstr ""
+msgstr "**Rust**"
 
 #: src/installation.md:8
 msgid "1.85+"
-msgstr ""
+msgstr "1.85+"
 
 #: src/installation.md:8
 msgid "`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \\| sh`"
-msgstr ""
+msgstr "`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \\| sh`"
 
 #: src/installation.md:10
 msgid "Install via Cargo"
-msgstr ""
+msgstr "Cargo로 설치"
 
 #: src/installation.md:16
 msgid "The binary is installed to `~/.cargo/bin/scoop`."
-msgstr ""
+msgstr "바이너리는 `~/.cargo/bin/scoop`에 설치됩니다."
 
 #: src/installation.md:18
 msgid "Upgrade"
-msgstr ""
+msgstr "업그레이드"
 
 #: src/installation.md:20
 msgid "To upgrade scoop to the latest version:"
-msgstr ""
+msgstr "scoop를 최신 버전으로 업그레이드하려면:"
 
 #: src/installation.md:26
 msgid ""
 "This overwrites the existing binary in `~/.cargo/bin/scoop`. Your virtual "
 "environments in `~/.scoop/` are preserved."
-msgstr ""
+msgstr "`~/.cargo/bin/scoop`의 기존 바이너리를 덮어씁니다. `~/.scoop/`의 가상 환경은 그대로 유지됩니다."
 
 #: src/installation.md:28
 msgid "Verify the upgrade:"
-msgstr ""
+msgstr "업그레이드 확인:"
 
 #: src/installation.md:34
 msgid "Verify Installation"
-msgstr ""
+msgstr "설치 확인"
 
 #: src/installation.md:37
-msgid "# scoop 0.11.0\n"
-msgstr ""
+msgid "# scoop 0.14.1\n"
+msgstr "# scoop 0.14.1\n"
 
 #: src/installation.md:41 src/python-management.md:175
 #: src/development/testing.md:384 src/development/code-quality.md:420
 msgid "Troubleshooting"
-msgstr ""
+msgstr "문제 해결"
 
 #: src/installation.md:43
 msgid "`scoop: command not found`"
-msgstr ""
+msgstr "`scoop: command not found`"
 
 #: src/installation.md:45
 msgid "Ensure `~/.cargo/bin` is in your PATH:"
-msgstr ""
+msgstr "`~/.cargo/bin`이 PATH에 포함되어 있는지 확인하세요:"
 
 #: src/installation.md:48
 msgid "# Add to ~/.zshrc or ~/.bashrc\n"
-msgstr ""
+msgstr "# ~/.zshrc 또는 ~/.bashrc에 추가\n"
 
 #: src/installation.md:49
 msgid "\"$HOME/.cargo/bin:$PATH\""
-msgstr ""
+msgstr "\"$HOME/.cargo/bin:$PATH\""
 
 #: src/installation.md:52
 msgid "Then restart your terminal or run:"
-msgstr ""
+msgstr "이후 터미널을 재시작하거나 다음을 실행하세요:"
 
 #: src/installation.md:55
 msgid "# or ~/.bashrc\n"
-msgstr ""
+msgstr "# 또는 ~/.bashrc\n"
 
 #: src/installation.md:58
 msgid "uv not found"
-msgstr ""
+msgstr "uv를 찾을 수 없음"
 
 #: src/installation.md:60
 msgid "scoop requires uv to be installed and available in PATH. Verify:"
-msgstr ""
+msgstr "scoop는 uv가 설치되어 있고 PATH에서 사용 가능해야 합니다. 확인 방법:"
 
 #: src/installation.md:66
 msgid "If not installed, run:"
-msgstr ""
+msgstr "설치되어 있지 않다면 다음을 실행하세요:"
 
 #: src/installation.md:72 src/quick-start.md:111
 msgid "Next Steps"
-msgstr ""
+msgstr "다음 단계"
 
 #: src/installation.md:74
 msgid ""
 "After installation, set up [Shell Integration](shell-integration.md) to "
 "enable auto-activation and tab completion."
-msgstr ""
+msgstr "설치 후 [셸 통합](shell-integration.md)을 설정하여 자동 활성화와 탭 완성 기능을 사용하세요."
 
 #: src/quick-start.md:3
 msgid "This guide walks you through the basic scoop workflow."
-msgstr ""
+msgstr "이 가이드에서는 scoop의 기본 워크플로를 안내합니다."
 
 #: src/quick-start.md:5
 msgid "1. Set Up Shell Integration"
-msgstr ""
+msgstr "1. 셸 통합 설정"
 
 #: src/quick-start.md:7
 msgid "**Zsh** (macOS default):"
-msgstr ""
+msgstr "**Zsh** (macOS 기본값):"
 
 #: src/quick-start.md:10 src/shell-integration.md:48
 msgid "'eval \"$(scoop init zsh)\"'"
-msgstr ""
+msgstr "'eval \"$(scoop init zsh)\"'"
 
 #: src/quick-start.md:14
 msgid "**Bash**:"
-msgstr ""
+msgstr "**Bash**:"
 
 #: src/quick-start.md:17 src/shell-integration.md:55
 msgid "'eval \"$(scoop init bash)\"'"
-msgstr ""
+msgstr "'eval \"$(scoop init bash)\"'"
 
 #: src/quick-start.md:21
 msgid "**Fish**:"
-msgstr ""
+msgstr "**Fish**:"
 
 #: src/quick-start.md:24 src/shell-integration.md:62
 msgid "'eval (scoop init fish)'"
-msgstr ""
+msgstr "'eval (scoop init fish)'"
 
 #: src/quick-start.md:28
 msgid "**PowerShell**:"
-msgstr ""
+msgstr "**PowerShell**:"
 
 #: src/quick-start.md:35
 msgid "2. Install Python"
-msgstr ""
+msgstr "2. Python 설치"
 
 #: src/quick-start.md:38 src/python-management.md:20
 msgid "# Install latest Python\n"
-msgstr ""
+msgstr "# 최신 Python 설치\n"
 
 #: src/quick-start.md:40
 msgid "# Verify installation\n"
-msgstr ""
+msgstr "# 설치 확인\n"
 
 #: src/quick-start.md:45
 msgid "3. Create a Virtual Environment"
-msgstr ""
+msgstr "3. 가상 환경 생성"
 
 #: src/quick-start.md:51
 msgid ""
 "This creates a virtual environment at `~/.scoop/virtualenvs/myproject/`."
-msgstr ""
+msgstr "`~/.scoop/virtualenvs/myproject/`에 가상 환경을 생성합니다."
 
 #: src/quick-start.md:53
 msgid ""
 "If Python 3.12 isn't installed yet, add `--install-python` to install it on "
 "demand:"
-msgstr ""
+msgstr "Python 3.12가 아직 설치되지 않은 경우, `--install-python`을 추가하면 필요 시 자동으로 설치됩니다:"
 
 #: src/quick-start.md:59
 msgid "4. Use the Environment"
-msgstr ""
+msgstr "4. 환경 사용"
 
 #: src/quick-start.md:66
 msgid "This:"
-msgstr ""
+msgstr "이 명령은:"
 
 #: src/quick-start.md:67
 msgid "Creates `.scoop-version` file in the current directory"
-msgstr ""
+msgstr "현재 디렉터리에 `.scoop-version` 파일을 생성합니다"
 
 #: src/quick-start.md:68
 msgid "Activates the environment (prompt shows `(myproject)`)"
-msgstr ""
+msgstr "환경을 활성화합니다 (프롬프트에 `(myproject)`가 표시됩니다)"
 
 #: src/quick-start.md:70
 msgid "5. Work With Your Environment"
-msgstr ""
+msgstr "5. 환경에서 작업하기"
 
 #: src/quick-start.md:74
 msgid "# If the file is in a different location:\n"
-msgstr ""
+msgstr "# 파일이 다른 위치에 있는 경우:\n"
 
 #: src/quick-start.md:77
 msgid "# Verify installed packages\n"
-msgstr ""
+msgstr "# 설치된 패키지 확인\n"
 
 #: src/quick-start.md:82
 msgid "6. Auto-Activation"
-msgstr ""
+msgstr "6. 자동 활성화"
 
 #: src/quick-start.md:84
 msgid ""
 "Once configured, entering a directory with `.scoop-version` automatically "
 "activates the environment:"
-msgstr ""
+msgstr "설정이 완료되면 `.scoop-version` 파일이 있는 디렉터리에 진입할 때 환경이 자동으로 활성화됩니다:"
 
 #: src/quick-start.md:87
 msgid "# (myproject) appears in prompt automatically\n"
-msgstr ""
+msgstr "# 프롬프트에 (myproject)가 자동으로 표시됩니다\n"
 
-#: src/quick-start.md:91 src/development/contributing.md:83
+#: src/quick-start.md:91 src/development/contributing.md:87
 msgid "Common Commands"
-msgstr ""
+msgstr "자주 쓰는 명령어"
 
 #: src/quick-start.md:93
 msgid "Task"
-msgstr ""
+msgstr "작업"
 
 #: src/quick-start.md:93 src/commands/index.md:7 src/commands/migrate.md:306
 #: src/commands/verify.md:42 src/api.md:709 src/llms.md:19
 msgid "Command"
-msgstr ""
+msgstr "명령어"
 
 #: src/quick-start.md:95
 msgid "List environments"
-msgstr ""
+msgstr "환경 목록 보기"
 
 #: src/quick-start.md:95 src/llms.md:21
 msgid "`scoop list`"
-msgstr ""
+msgstr "`scoop list`"
 
 #: src/quick-start.md:96
 msgid "List Python versions"
-msgstr ""
+msgstr "Python 버전 목록 보기"
 
 #: src/quick-start.md:96 src/llms.md:22
 msgid "`scoop list --pythons`"
-msgstr ""
+msgstr "`scoop list --pythons`"
 
 #: src/quick-start.md:97
 msgid "Show environment info"
-msgstr ""
+msgstr "환경 정보 보기"
 
 #: src/quick-start.md:97
 msgid "`scoop info myproject`"
-msgstr ""
+msgstr "`scoop info myproject`"
 
 #: src/quick-start.md:98
 msgid "Remove environment"
-msgstr ""
+msgstr "환경 삭제"
 
 #: src/quick-start.md:98
 msgid "`scoop remove myproject`"
-msgstr ""
+msgstr "`scoop remove myproject`"
 
 #: src/quick-start.md:99
 msgid "Check installation"
-msgstr ""
+msgstr "설치 상태 확인"
 
 #: src/quick-start.md:99 src/llms.md:42
 msgid "`scoop doctor`"
-msgstr ""
+msgstr "`scoop doctor`"
 
 #: src/quick-start.md:101 src/development/code-quality.md:51
 msgid "IDE Integration"
-msgstr ""
+msgstr "IDE 통합"
 
 #: src/quick-start.md:103
 msgid "Create a `.venv` symlink for IDE compatibility:"
-msgstr ""
+msgstr "IDE 호환성을 위해 `.venv` 심볼릭 링크를 생성하세요:"
 
 #: src/quick-start.md:109
 msgid ""
 "This creates `.venv` pointing to the scoop environment, recognized by VS "
 "Code, PyCharm, etc."
 msgstr ""
+"`.venv`가 scoop 환경을 가리키도록 심볼릭 링크를 생성합니다. VS Code, PyCharm 등에서 자동으로 인식됩니다."
 
 #: src/quick-start.md:113
 msgid ""
 "See [Shell Integration](shell-integration.md) for advanced configuration"
-msgstr ""
+msgstr "고급 설정은 [셸 통합](shell-integration.md)을 참조하세요"
 
 #: src/quick-start.md:114
 msgid "See [Commands](commands/README.md) for full command reference"
-msgstr ""
+msgstr "전체 명령어 레퍼런스는 [명령어](commands/README.md)를 참조하세요"
 
 #: src/shell-integration.md:3
 msgid ""
 "scoop uses a shell wrapper pattern (like pyenv) where the CLI outputs shell "
 "code that gets evaluated by the shell."
 msgstr ""
+"scoop는 pyenv와 같은 셸 래퍼 패턴을 사용합니다. CLI가 셸 코드를 출력하면 셸이 이를 `eval`로 실행하는 방식입니다."
 
 #: src/shell-integration.md:5
 msgid "How It Works"
-msgstr ""
+msgstr "동작 방식"
 
 #: src/shell-integration.md:14
 msgid "The `scoop` shell function wraps the CLI binary:"
-msgstr ""
+msgstr "`scoop` 셸 함수는 CLI 바이너리를 래핑합니다:"
 
 #: src/shell-integration.md:18
 msgid "\"$1\""
-msgstr ""
+msgstr "\"$1\""
 
 #: src/shell-integration.md:20 src/shell-integration.md:23
 #: src/shell-integration.md:37
 msgid "\"$@\""
-msgstr ""
+msgstr "\"$@\""
 
 #: src/shell-integration.md:21 src/development/docs-translation.md:59
 #: src/development/testing.md:255
 msgid "\"\""
-msgstr ""
+msgstr "\"\""
 
 #: src/shell-integration.md:24 src/shell-integration.md:26
 msgid "\"$arg\""
-msgstr ""
+msgstr "\"$arg\""
 
 #: src/shell-integration.md:29
 msgid "\"$name\""
-msgstr ""
+msgstr "\"$name\""
 
 #: src/shell-integration.md:30
 msgid "\"$(command scoop activate \"$name\")\""
-msgstr ""
+msgstr "\"$(command scoop activate \"$name\")\""
 
 #: src/shell-integration.md:34
 msgid "\"$(command scoop \"$@\")\""
-msgstr ""
+msgstr "\"$(command scoop \"$@\")\""
 
 #: src/shell-integration.md:43 src/commands/init.md:17
 #: src/development/contributing.md:11 src/development/code-quality.md:138
 msgid "Setup"
-msgstr ""
+msgstr "설정"
 
 #: src/shell-integration.md:45 src/shell-integration.md:208 src/faq.md:229
 msgid "Zsh"
-msgstr ""
+msgstr "Zsh"
 
 #: src/shell-integration.md:52 src/shell-integration.md:209 src/faq.md:228
 msgid "Bash"
-msgstr ""
+msgstr "Bash"
 
 #: src/shell-integration.md:59 src/shell-integration.md:210 src/faq.md:230
 msgid "Fish"
-msgstr ""
+msgstr "Fish"
 
 #: src/shell-integration.md:66 src/shell-integration.md:211 src/faq.md:231
 msgid "PowerShell"
-msgstr ""
+msgstr "PowerShell"
 
 #: src/shell-integration.md:74
 msgid "Auto-Activation"
-msgstr ""
+msgstr "자동 활성화"
 
 #: src/shell-integration.md:76
 msgid ""
 "When enabled, scoop automatically activates environments based on version "
 "files."
-msgstr ""
+msgstr "활성화하면 scoop가 버전 파일을 기반으로 환경을 자동으로 활성화합니다."
 
 #: src/shell-integration.md:78
 msgid "**Zsh**: Uses `chpwd` hook (runs on directory change)"
-msgstr ""
+msgstr "**Zsh**: `chpwd` 훅 사용 (디렉터리 변경 시 실행)"
 
 #: src/shell-integration.md:85
 msgid "**Bash**: Uses `PROMPT_COMMAND`"
-msgstr ""
+msgstr "**Bash**: `PROMPT_COMMAND` 사용"
 
 #: src/shell-integration.md:88
 msgid "\"_scoop_hook;$PROMPT_COMMAND\""
-msgstr ""
+msgstr "\"_scoop_hook;$PROMPT_COMMAND\""
 
 #: src/shell-integration.md:91
 msgid "**Fish**: Uses `--on-variable PWD` event handler"
-msgstr ""
+msgstr "**Fish**: `--on-variable PWD` 이벤트 핸들러 사용"
 
 #: src/shell-integration.md:95
 msgid "# Check for version file and activate/deactivate\n"
-msgstr ""
+msgstr "# 버전 파일 확인 후 활성화/비활성화\n"
 
 #: src/shell-integration.md:99
 msgid ""
 "The hook checks for version files and activates/deactivates accordingly."
-msgstr ""
+msgstr "훅은 버전 파일을 확인하고 그에 따라 환경을 활성화하거나 비활성화합니다."
 
 #: src/shell-integration.md:101
 msgid "Version Resolution Priority"
-msgstr ""
+msgstr "버전 결정 우선순위"
 
 #: src/shell-integration.md:103
 msgid "scoop checks these sources in order (first match wins):"
-msgstr ""
+msgstr "scoop는 다음 소스를 순서대로 확인합니다 (처음 일치하는 항목이 우선 적용됩니다):"
 
 #: src/shell-integration.md:105 src/commands/shell.md:39
 msgid "Priority"
-msgstr ""
+msgstr "우선순위"
 
 #: src/shell-integration.md:105 src/commands/migrate.md:28
 msgid "Source"
-msgstr ""
+msgstr "소스"
 
 #: src/shell-integration.md:105
 msgid "Set by"
-msgstr ""
+msgstr "설정 방법"
 
 #: src/shell-integration.md:107 src/shell-integration.md:133
 #: src/shell-integration.md:141 src/faq.md:104 src/commands/which.md:49
-#: src/commands/sync.md:116 src/commands/export.md:72 src/commands/import.md:75
-#: src/commands/clone.md:74 src/api.md:709 src/llms.md:109
+#: src/commands/sync.md:116 src/commands/export.md:72
+#: src/commands/import.md:75 src/commands/clone.md:74 src/api.md:709
+#: src/llms.md:111
 msgid "1"
-msgstr ""
+msgstr "1"
 
 #: src/shell-integration.md:107
 msgid "`SCOOP_VERSION` env var"
-msgstr ""
+msgstr "`SCOOP_VERSION` 환경 변수"
 
 #: src/shell-integration.md:107
 msgid "`scoop shell`"
-msgstr ""
+msgstr "`scoop shell`"
 
 #: src/shell-integration.md:108 src/api.md:709
 msgid "2"
-msgstr ""
+msgstr "2"
 
 #: src/shell-integration.md:108
 msgid "`.scoop-version` file"
-msgstr ""
+msgstr "`.scoop-version` 파일"
 
 #: src/shell-integration.md:108
 msgid "`scoop use` (walks parent directories)"
-msgstr ""
+msgstr "`scoop use` (부모 디렉터리를 순서대로 탐색)"
 
 #: src/shell-integration.md:109 src/shell-integration.md:178 src/api.md:709
 msgid "3"
-msgstr ""
+msgstr "3"
 
 #: src/shell-integration.md:109
 msgid "`~/.scoop/version` file"
-msgstr ""
+msgstr "`~/.scoop/version` 파일"
 
 #: src/shell-integration.md:109
 msgid "`scoop use --global`"
-msgstr ""
+msgstr "`scoop use --global`"
 
 #: src/shell-integration.md:111
 msgid "The \"system\" Value"
-msgstr ""
+msgstr "\"system\" 값"
 
 #: src/shell-integration.md:113
 msgid ""
 "When any source contains the value `system`, scoop deactivates the current "
 "virtual environment and uses the system Python."
 msgstr ""
+"어떤 소스든 `system` 값이 포함되어 있으면 scoop는 현재 가상 환경을 비활성화하고 시스템 Python을 사용합니다."
 
 #: src/shell-integration.md:116
 msgid "# Write \"system\" to .scoop-version\n"
-msgstr ""
+msgstr "# .scoop-version에 \"system\" 기록\n"
 
 #: src/shell-integration.md:117
 msgid "# Set SCOOP_VERSION=system (this terminal only)\n"
-msgstr ""
+msgstr "# SCOOP_VERSION=system 설정 (현재 터미널에만 적용)\n"
 
-#: src/shell-integration.md:120 src/commands/index.md:45
+#: src/shell-integration.md:120 src/commands/index.md:46
 msgid "Environment Variables"
-msgstr ""
+msgstr "환경 변수"
 
-#: src/shell-integration.md:122 src/commands/index.md:47 src/commands/run.md:26
+#: src/shell-integration.md:122 src/commands/index.md:48
+#: src/commands/run.md:26
 msgid "Variable"
-msgstr ""
+msgstr "변수"
 
 #: src/shell-integration.md:122 src/commands/index.md:7
-#: src/commands/index.md:38 src/commands/index.md:47 src/commands/list.md:15
+#: src/commands/index.md:39 src/commands/index.md:48 src/commands/list.md:15
 #: src/commands/create.md:13 src/commands/create.md:20 src/commands/use.md:15
 #: src/commands/use.md:21 src/commands/remove.md:15 src/commands/remove.md:21
 #: src/commands/install.md:13 src/commands/install.md:19
@@ -885,228 +891,233 @@ msgstr ""
 #: src/commands/doctor.md:13 src/commands/info.md:16 src/commands/info.md:22
 #: src/commands/which.md:14 src/commands/which.md:20 src/commands/run.md:17
 #: src/commands/sync.md:14 src/commands/export.md:14 src/commands/export.md:20
-#: src/commands/import.md:14 src/commands/import.md:20 src/commands/clone.md:14
-#: src/commands/clone.md:21 src/commands/migrate.md:20
-#: src/commands/migrate.md:36 src/commands/gc.md:77 src/commands/prune.md:21
-#: src/commands/diff.md:35 src/commands/lang.md:23 src/commands/lang.md:29
-#: src/commands/init.md:13 src/commands/shell.md:21 src/commands/shell.md:27
-#: src/commands/completions.md:13 src/commands/man.md:20 src/commands/man.md:26
-#: src/development/code-quality.md:103 src/development/code-quality.md:202
-#: src/llms.md:19 src/examples.md:5
+#: src/commands/import.md:14 src/commands/import.md:20
+#: src/commands/clone.md:14 src/commands/clone.md:21
+#: src/commands/migrate.md:20 src/commands/migrate.md:36 src/commands/gc.md:77
+#: src/commands/prune.md:21 src/commands/diff.md:35 src/commands/lang.md:23
+#: src/commands/lang.md:29 src/commands/self.md:13 src/commands/init.md:13
+#: src/commands/shell.md:21 src/commands/shell.md:27
+#: src/commands/completions.md:13 src/commands/man.md:20
+#: src/commands/man.md:26 src/development/code-quality.md:103
+#: src/development/code-quality.md:202 src/llms.md:19 src/examples.md:5
 msgid "Description"
-msgstr ""
+msgstr "설명"
 
-#: src/shell-integration.md:122 src/commands/index.md:47
+#: src/shell-integration.md:122 src/commands/index.md:48
 #: src/commands/create.md:13 src/commands/install.md:13
 msgid "Default"
-msgstr ""
+msgstr "기본값"
 
-#: src/shell-integration.md:124 src/commands/index.md:49
+#: src/shell-integration.md:124 src/commands/index.md:50
 msgid "`SCOOP_HOME`"
-msgstr ""
+msgstr "`SCOOP_HOME`"
 
 #: src/shell-integration.md:124
 msgid "Base directory"
-msgstr ""
+msgstr "기본 디렉터리"
 
-#: src/shell-integration.md:124 src/commands/index.md:49
+#: src/shell-integration.md:124 src/commands/index.md:50
 msgid "`~/.scoop`"
-msgstr ""
+msgstr "`~/.scoop`"
 
-#: src/shell-integration.md:125
+#: src/shell-integration.md:125 src/commands/index.md:54
 msgid "`SCOOP_VERSION`"
-msgstr ""
+msgstr "`SCOOP_VERSION`"
 
 #: src/shell-integration.md:125
 msgid "Override version (highest priority)"
-msgstr ""
+msgstr "버전 재정의 (최우선 순위)"
 
 #: src/shell-integration.md:125 src/shell-integration.md:126
-#: src/commands/index.md:50 src/commands/index.md:52
+#: src/commands/index.md:51 src/commands/index.md:53 src/commands/index.md:54
+#: src/commands/index.md:55 src/commands/index.md:56
 msgid "(unset)"
-msgstr ""
+msgstr "(미설정)"
 
-#: src/shell-integration.md:126 src/commands/index.md:50
+#: src/shell-integration.md:126 src/commands/index.md:51
 msgid "`SCOOP_NO_AUTO`"
-msgstr ""
+msgstr "`SCOOP_NO_AUTO`"
 
-#: src/shell-integration.md:126 src/commands/index.md:50
+#: src/shell-integration.md:126 src/commands/index.md:51
 msgid "Disable auto-activation"
-msgstr ""
+msgstr "자동 활성화 비활성화"
 
-#: src/shell-integration.md:127 src/commands/run.md:29
+#: src/shell-integration.md:127 src/commands/index.md:55
+#: src/commands/run.md:29
 msgid "`SCOOP_ACTIVE`"
-msgstr ""
+msgstr "`SCOOP_ACTIVE`"
 
 #: src/shell-integration.md:127
 msgid "Currently active environment"
-msgstr ""
+msgstr "현재 활성화된 환경"
 
 #: src/shell-integration.md:127
 msgid "(set by scoop)"
-msgstr ""
+msgstr "(scoop가 자동으로 설정)"
 
-#: src/shell-integration.md:128
+#: src/shell-integration.md:128 src/commands/index.md:56
 msgid "`SCOOP_RESOLVE_MAX_DEPTH`"
-msgstr ""
+msgstr "`SCOOP_RESOLVE_MAX_DEPTH`"
 
 #: src/shell-integration.md:128
 msgid "Limit parent directory traversal"
-msgstr ""
+msgstr "부모 디렉터리 탐색 깊이 제한"
 
 #: src/shell-integration.md:128
 msgid "(unlimited)"
-msgstr ""
+msgstr "(제한 없음)"
 
 #: src/shell-integration.md:130
 msgid "Disable Auto-Activation"
-msgstr ""
+msgstr "자동 활성화 끄기"
 
 #: src/shell-integration.md:136
 msgid "Temporary and Project-Scoped Control"
-msgstr ""
+msgstr "임시 및 프로젝트 단위 제어"
 
 #: src/shell-integration.md:138
 msgid ""
 "Disable only in the current shell session (does not affect global settings):"
-msgstr ""
+msgstr "현재 셸 세션에서만 비활성화합니다 (전역 설정에는 영향을 주지 않습니다):"
 
 #: src/shell-integration.md:141
 msgid "# ...work without auto-activation...\n"
-msgstr ""
+msgstr "# ...자동 활성화 없이 작업...\n"
 
 #: src/shell-integration.md:146
 msgid ""
 "For one project directory, use local version files instead of global "
 "settings:"
-msgstr ""
+msgstr "특정 프로젝트 디렉터리에서는 전역 설정 대신 로컬 버전 파일을 사용하세요:"
 
 #: src/shell-integration.md:150
 msgid "# Keep auto-activation, but force system Python in this project only\n"
-msgstr ""
+msgstr "# 자동 활성화는 유지하되, 이 프로젝트에서만 시스템 Python 강제 사용\n"
 
 #: src/shell-integration.md:153
 msgid "# Or pin a specific environment for this project only\n"
-msgstr ""
+msgstr "# 또는 이 프로젝트에서만 특정 환경 고정\n"
 
 #: src/shell-integration.md:158
 msgid "For temporary per-terminal overrides without changing files:"
-msgstr ""
+msgstr "파일을 변경하지 않고 터미널별로 임시 재정의하려면:"
 
 #: src/shell-integration.md:161
 msgid "# this terminal only\n"
-msgstr ""
+msgstr "# 현재 터미널에만 적용\n"
 
 #: src/shell-integration.md:163
 msgid "# return to file-based behavior\n"
-msgstr ""
+msgstr "# 파일 기반 동작으로 복원\n"
 
 #: src/shell-integration.md:166
 msgid "Custom Home Directory"
-msgstr ""
+msgstr "커스텀 홈 디렉터리"
 
 #: src/shell-integration.md:169
 msgid "/custom/path"
-msgstr ""
+msgstr "/custom/path"
 
 #: src/shell-integration.md:172
 msgid "Network Filesystem Optimization"
-msgstr ""
+msgstr "네트워크 파일시스템 최적화"
 
 #: src/shell-integration.md:174
 msgid ""
 "For slow network filesystems (NFS, SSHFS), limit directory traversal depth:"
-msgstr ""
+msgstr "느린 네트워크 파일시스템(NFS, SSHFS)에서는 디렉터리 탐색 깊이를 제한하세요:"
 
 #: src/shell-integration.md:177
 msgid "# Only check current directory and up to 3 parents\n"
-msgstr ""
+msgstr "# 현재 디렉터리 및 최대 3단계 부모 디렉터리까지만 확인\n"
 
 #: src/shell-integration.md:179
 msgid "# Only check current directory (fastest)\n"
-msgstr ""
+msgstr "# 현재 디렉터리만 확인 (가장 빠름)\n"
 
 #: src/shell-integration.md:181 src/commands/which.md:48
-#: src/commands/sync.md:115 src/commands/export.md:71 src/commands/import.md:74
-#: src/commands/clone.md:73 src/api.md:709
+#: src/commands/sync.md:115 src/commands/export.md:71
+#: src/commands/import.md:74 src/commands/clone.md:73 src/api.md:709
 msgid "0"
-msgstr ""
+msgstr "0"
 
 #: src/shell-integration.md:184
 msgid "Using with pyenv"
-msgstr ""
+msgstr "pyenv와 함께 사용하기"
 
 #: src/shell-integration.md:186
 msgid "Add scoop **after** pyenv in your shell config:"
-msgstr ""
+msgstr "셸 설정 파일에서 pyenv **다음에** scoop를 추가하세요:"
 
 #: src/shell-integration.md:189
 msgid "# ~/.zshrc\n"
-msgstr ""
+msgstr "# ~/.zshrc\n"
 
 #: src/shell-integration.md:190
 msgid "\"$(pyenv init -)\"       # 1. pyenv first\n"
-msgstr ""
+msgstr "\"$(pyenv init -)\"       # 1. pyenv 먼저\n"
 
 #: src/shell-integration.md:191
 msgid "\"$(scoop init zsh)\"     # 2. scoop second (takes precedence)\n"
-msgstr ""
+msgstr "\"$(scoop init zsh)\"     # 2. scoop 다음 (우선 적용)\n"
 
 #: src/shell-integration.md:194
 msgid "Tab Completion"
-msgstr ""
+msgstr "탭 완성"
 
 #: src/shell-integration.md:196
 msgid "Shell integration includes completion for:"
-msgstr ""
+msgstr "셸 통합에는 다음 항목에 대한 자동 완성이 포함됩니다:"
 
 #: src/shell-integration.md:197
 msgid "Commands and subcommands"
-msgstr ""
+msgstr "명령어 및 하위 명령어"
 
 #: src/shell-integration.md:198
 msgid "Environment names"
-msgstr ""
+msgstr "환경 이름"
 
 #: src/shell-integration.md:199
 msgid "Python versions"
-msgstr ""
+msgstr "Python 버전"
 
 #: src/shell-integration.md:200
 msgid "Command options"
-msgstr ""
+msgstr "명령어 옵션"
 
 #: src/shell-integration.md:202
 msgid "Completion is automatically enabled by `scoop init`."
-msgstr ""
+msgstr "`scoop init`을 실행하면 자동 완성이 자동으로 활성화됩니다."
 
 #: src/shell-integration.md:204
 msgid "Supported Shells"
-msgstr ""
+msgstr "지원 셸"
 
 #: src/shell-integration.md:206 src/faq.md:226
 msgid "Shell"
-msgstr ""
+msgstr "셸"
 
 #: src/shell-integration.md:206 src/commands/verify.md:18
 msgid "Status"
-msgstr ""
+msgstr "지원 상태"
 
 #: src/shell-integration.md:208 src/shell-integration.md:209
 #: src/shell-integration.md:210 src/shell-integration.md:211
 msgid "Full support (auto-activation, completion)"
-msgstr ""
+msgstr "완전 지원 (자동 활성화, 자동 완성)"
 
 #: src/python-management.md:3
 msgid ""
-"scoop delegates all Python installation and discovery to [uv](https://"
-"github.com/astral-sh/uv). This page explains how Python versions are found, "
-"installed, and used with scoop."
+"scoop delegates all Python installation and discovery to "
+"[uv](https://github.com/astral-sh/uv). This page explains how Python "
+"versions are found, installed, and used with scoop."
 msgstr ""
+"scoop는 Python 설치 및 탐색을 모두 [uv](https://github.com/astral-sh/uv)에 위임합니다. 이 "
+"페이지에서는 scoop에서 Python 버전을 찾고 설치하고 사용하는 방법을 설명합니다."
 
 #: src/python-management.md:5
 msgid "How Python Discovery Works"
-msgstr ""
+msgstr "Python 탐색 동작 방식"
 
 #: src/python-management.md:7
 msgid ""
@@ -1114,24 +1125,29 @@ msgid ""
 "environment with Python 3.12. uv searches for a matching Python in this "
 "order:"
 msgstr ""
+"`scoop create myenv 3.12`를 실행하면 scoop는 uv에게 Python 3.12로 가상 환경을 생성하도록 요청합니다."
+" uv는 다음 순서로 일치하는 Python을 탐색합니다:"
 
 #: src/python-management.md:9
 msgid ""
 "**uv-managed installations** in `~/.local/share/uv/python/` (installed via "
 "`scoop install` or `uv python install`)"
 msgstr ""
+"`~/.local/share/uv/python/`의 **uv 관리 설치** (`scoop install` 또는 `uv python "
+"install`로 설치된 것)"
 
 #: src/python-management.md:10
 msgid ""
 "**System Python on PATH** — executables named `python`, `python3`, or "
 "`python3.x`"
 msgstr ""
+"**PATH의 시스템 Python** — `python`, `python3`, 또는 `python3.x`라는 이름의 실행 파일"
 
 #: src/python-management.md:11
 msgid ""
-"**Platform-specific locations** — Windows registry, Microsoft Store (Windows "
-"only)"
-msgstr ""
+"**Platform-specific locations** — Windows registry, Microsoft Store (Windows"
+" only)"
+msgstr "**플랫폼별 위치** — Windows 레지스트리, Microsoft Store (Windows 전용)"
 
 #: src/python-management.md:13
 msgid ""
@@ -1139,79 +1155,89 @@ msgid ""
 "version. For system Pythons, uv uses the **first compatible** version found "
 "on PATH."
 msgstr ""
+"**핵심 동작:** 관리 Python의 경우 uv는 일치하는 **가장 최신** 버전을 선호합니다. 시스템 Python의 경우 PATH에서"
+" 찾은 **첫 번째 호환** 버전을 사용합니다."
 
 #: src/python-management.md:15
 msgid "Installing Python Versions"
-msgstr ""
+msgstr "Python 버전 설치"
 
 #: src/python-management.md:17
 msgid "Via scoop (recommended)"
-msgstr ""
+msgstr "scoop로 설치 (권장)"
 
 #: src/python-management.md:22
 msgid "# Install specific minor version (latest patch)\n"
-msgstr ""
+msgstr "# 특정 마이너 버전 설치 (최신 패치)\n"
 
 #: src/python-management.md:25
 msgid "# Install exact version\n"
-msgstr ""
+msgstr "# 정확한 버전 설치\n"
 
 #: src/python-management.md:28
 msgid "# List installed versions\n"
-msgstr ""
+msgstr "# 설치된 버전 목록 보기\n"
 
 #: src/python-management.md:33
 msgid "Behind the scenes"
-msgstr ""
+msgstr "내부 동작"
 
 #: src/python-management.md:35
 msgid ""
 "`scoop install 3.12` runs `uv python install 3.12` internally. uv downloads "
-"a standalone Python build from the [python-build-standalone](https://"
-"github.com/indygreg/python-build-standalone) project and stores it in "
-"`~/.local/share/uv/python/`."
+"a standalone Python build from the [python-build-"
+"standalone](https://github.com/indygreg/python-build-standalone) project and"
+" stores it in `~/.local/share/uv/python/`."
 msgstr ""
+"`scoop install 3.12`는 내부적으로 `uv python install 3.12`를 실행합니다. uv는 [python-"
+"build-standalone](https://github.com/indygreg/python-build-standalone) "
+"프로젝트에서 독립형 Python 빌드를 다운로드하여 `~/.local/share/uv/python/`에 저장합니다."
 
 #: src/python-management.md:37
 msgid "Using System Python"
-msgstr ""
+msgstr "시스템 Python 사용"
 
 #: src/python-management.md:39
 msgid ""
 "scoop can use Python versions already installed on your system (via "
 "Homebrew, apt, the OS, etc.) — no `scoop install` needed."
 msgstr ""
+"scoop는 시스템에 이미 설치된 Python 버전(Homebrew, apt, OS 기본 등)을 사용할 수 있습니다. `scoop "
+"install`이 필요하지 않습니다."
 
 #: src/python-management.md:42
 msgid "# Check what Python versions uv can find on your system\n"
-msgstr ""
+msgstr "# uv가 시스템에서 찾을 수 있는 Python 버전 확인\n"
 
 #: src/python-management.md:44 src/python-management.md:150 src/faq.md:278
-#: src/commands/install.md:54
+#: src/commands/install.md:55
 msgid "# Example output:\n"
-msgstr ""
+msgstr "# 출력 예시:\n"
 
-#: src/python-management.md:46 src/faq.md:280 src/commands/install.md:56
+#: src/python-management.md:46 src/faq.md:280 src/commands/install.md:57
 msgid "# cpython-3.12.8    ~/.local/share/uv/python/...     (managed)\n"
-msgstr ""
+msgstr "# cpython-3.12.8    ~/.local/share/uv/python/...     (관리됨)\n"
 
 #: src/python-management.md:48
 msgid "# cpython-3.11.5    /usr/bin/python3.11               (system)\n"
-msgstr ""
+msgstr "# cpython-3.11.5    /usr/bin/python3.11               (시스템)\n"
 
 #: src/python-management.md:50
 msgid "# Create environment using system Python 3.13\n"
-msgstr ""
+msgstr "# 시스템 Python 3.13으로 환경 생성\n"
 
 #: src/python-management.md:56
 msgid ""
-"If the version you request matches a system Python, uv will use it. You only "
-"need `scoop install` if the version is not already available on your system."
+"If the version you request matches a system Python, uv will use it. You only"
+" need `scoop install` if the version is not already available on your "
+"system."
 msgstr ""
+"요청한 버전이 시스템 Python과 일치하면 uv가 이를 사용합니다. 시스템에 해당 버전이 없을 때만 `scoop install`이 "
+"필요합니다."
 
 #: src/python-management.md:58
 msgid "Using Custom Python Installations"
-msgstr ""
+msgstr "커스텀 Python 설치 사용"
 
 #: src/python-management.md:60
 msgid ""
@@ -1219,674 +1245,694 @@ msgid ""
 "GraalPy) in a non-standard location, you can point scoop directly to the "
 "executable."
 msgstr ""
+"비표준 위치에 직접 빌드한 Python이나 대체 인터프리터(PyPy, GraalPy)가 있는 경우, 실행 파일을 scoop에 직접 지정할"
+" 수 있습니다."
 
 #: src/python-management.md:62
 msgid "When the required version is not in default sources"
-msgstr ""
+msgstr "필요한 버전이 기본 소스에 없는 경우"
 
 #: src/python-management.md:64
 msgid ""
 "If `scoop install <version>` and normal uv discovery do not provide the "
 "interpreter you need, integrate your own Python using one of these patterns:"
 msgstr ""
+"`scoop install <version>`과 일반적인 uv 탐색으로 원하는 인터프리터를 찾을 수 없다면, 다음 방법 중 하나로 직접 "
+"Python을 통합하세요:"
 
 #: src/python-management.md:67
 msgid ""
-"**Direct path (recommended):** `scoop create <env> --python-path /path/to/"
-"python`"
-msgstr ""
+"**Direct path (recommended):** `scoop create <env> --python-path "
+"/path/to/python`"
+msgstr "**직접 경로 지정 (권장):** `scoop create <env> --python-path /path/to/python`"
 
 #: src/python-management.md:68
 msgid ""
 "**PATH-based discovery:** add your Python to `PATH`, then run `scoop create "
 "<env> <version>`"
 msgstr ""
+"**PATH 기반 탐색:** Python을 `PATH`에 추가한 후 `scoop create <env> <version>` 실행"
 
 #: src/python-management.md:70
 msgid "Use --python-path (recommended)"
-msgstr ""
+msgstr "--python-path 사용 (권장)"
 
 #: src/python-management.md:72
 msgid "The simplest approach is to pass the Python executable path directly:"
-msgstr ""
+msgstr "가장 간단한 방법은 Python 실행 파일 경로를 직접 전달하는 것입니다:"
 
 #: src/python-management.md:75
 msgid "# Custom Python built from source\n"
-msgstr ""
+msgstr "# 소스에서 직접 빌드한 Python\n"
 
-#: src/python-management.md:77 src/faq.md:261 src/commands/create.md:90
+#: src/python-management.md:77 src/faq.md:261 src/commands/create.md:91
 msgid "# PyPy interpreter\n"
-msgstr ""
+msgstr "# PyPy 인터프리터\n"
 
-#: src/python-management.md:80 src/faq.md:264 src/commands/create.md:93
+#: src/python-management.md:80 src/faq.md:264 src/commands/create.md:94
 msgid "# GraalPy\n"
-msgstr ""
+msgstr "# GraalPy\n"
 
 #: src/python-management.md:85
 msgid ""
 "scoop validates the path, auto-detects the version, and stores the custom "
 "path in metadata."
-msgstr ""
+msgstr "scoop는 경로를 검증하고 버전을 자동으로 감지하며, 커스텀 경로를 메타데이터에 저장합니다."
 
 #: src/python-management.md:88
 msgid "# Verify what was integrated\n"
-msgstr ""
+msgstr "# 통합된 내용 확인\n"
 
-#: src/python-management.md:89 src/commands/create.md:106
+#: src/python-management.md:89 src/commands/create.md:107
 msgid "# Name:         debug-env\n"
-msgstr ""
+msgstr "# Name:         debug-env\n"
 
-#: src/python-management.md:91 src/commands/create.md:108
+#: src/python-management.md:91 src/commands/create.md:109
 msgid "# Python Path:  /opt/python-debug/bin/python3\n"
-msgstr ""
+msgstr "# Python Path:  /opt/python-debug/bin/python3\n"
 
 #: src/python-management.md:95
 msgid ""
 "Metadata is stored in `~/.scoop/virtualenvs/<name>/.scoop-metadata.json` "
 "(`python_path` field). See [create command](commands/create.md) for details."
 msgstr ""
+"메타데이터는 `~/.scoop/virtualenvs/<name>/.scoop-metadata.json`(`python_path` 필드)에"
+" 저장됩니다. 자세한 내용은 [create 명령어](commands/create.md)를 참조하세요."
 
 #: src/python-management.md:98
 msgid "Alternative: Add custom Python to PATH"
-msgstr ""
+msgstr "대안: PATH에 커스텀 Python 추가"
 
 #: src/python-management.md:100
 msgid ""
 "You can also add the Python to your `PATH` so uv discovers it automatically:"
-msgstr ""
+msgstr "Python을 `PATH`에 추가하면 uv가 자동으로 탐색합니다:"
 
 #: src/python-management.md:103
 msgid "# Example: custom Python built from source in /opt/python-debug/\n"
-msgstr ""
+msgstr "# 예시: /opt/python-debug/에 소스 빌드한 커스텀 Python\n"
 
-#: src/python-management.md:104 src/faq.md:183 src/faq.md:291 src/llms.md:152
+#: src/python-management.md:104 src/faq.md:183 src/faq.md:291 src/llms.md:154
 msgid "\"/opt/python-debug/bin:$PATH\""
-msgstr ""
+msgstr "\"/opt/python-debug/bin:$PATH\""
 
 #: src/python-management.md:105
 msgid "# Verify uv can find it\n"
-msgstr ""
+msgstr "# uv가 찾을 수 있는지 확인\n"
 
 #: src/python-management.md:107
 msgid "# cpython-3.13.0    /opt/python-debug/bin/python3.13\n"
-msgstr ""
+msgstr "# cpython-3.13.0    /opt/python-debug/bin/python3.13\n"
 
 #: src/python-management.md:109
 msgid "# Now scoop can use it\n"
-msgstr ""
+msgstr "# 이제 scoop에서 사용 가능\n"
 
 #: src/python-management.md:114
 msgid "Use UV_PYTHON_INSTALL_DIR"
-msgstr ""
+msgstr "UV_PYTHON_INSTALL_DIR 사용"
 
 #: src/python-management.md:116
 msgid "For managed Python installations in a custom location:"
-msgstr ""
+msgstr "커스텀 위치에 관리형 Python을 설치하려면:"
 
 #: src/python-management.md:119
 msgid "# Store uv-managed Pythons in a custom directory\n"
-msgstr ""
+msgstr "# uv 관리 Python을 커스텀 디렉터리에 저장\n"
 
 #: src/python-management.md:120
 msgid "/opt/shared-pythons"
-msgstr ""
+msgstr "/opt/shared-pythons"
 
 #: src/python-management.md:121
 msgid "# Install Python to the custom location\n"
-msgstr ""
+msgstr "# 커스텀 위치에 Python 설치\n"
 
 #: src/python-management.md:124
 msgid "# All team members can share the same Python installations\n"
-msgstr ""
+msgstr "# 팀원 전체가 동일한 Python 설치를 공유할 수 있음\n"
 
 #: src/python-management.md:128
 msgid "Python preference settings"
-msgstr ""
+msgstr "Python 우선순위 설정"
 
 #: src/python-management.md:130
 msgid "Control whether uv prefers managed or system Python:"
-msgstr ""
+msgstr "uv가 관리형 Python과 시스템 Python 중 어느 쪽을 선호할지 제어합니다:"
 
 #: src/python-management.md:133
 msgid "# Use only uv-managed Python (ignore system Python)\n"
-msgstr ""
+msgstr "# uv 관리 Python만 사용 (시스템 Python 무시)\n"
 
 #: src/python-management.md:134
 msgid "only-managed"
-msgstr ""
+msgstr "only-managed"
 
 #: src/python-management.md:135
 msgid "# Use only system Python (ignore uv-managed)\n"
-msgstr ""
+msgstr "# 시스템 Python만 사용 (uv 관리 무시)\n"
 
 #: src/python-management.md:138
 msgid "# Prefer system Python over managed (default: managed first)\n"
-msgstr ""
+msgstr "# 관리형보다 시스템 Python 우선 사용 (기본값: 관리형 우선)\n"
 
 #: src/python-management.md:143
 msgid "Migrating from Other Tools"
-msgstr ""
+msgstr "다른 도구에서 마이그레이션"
 
 #: src/python-management.md:145
 msgid ""
 "If you have existing virtual environments in pyenv, conda, or "
 "virtualenvwrapper, scoop can migrate them:"
 msgstr ""
+"pyenv, conda, 또는 virtualenvwrapper에 기존 가상 환경이 있다면 scoop로 마이그레이션할 수 있습니다:"
 
 #: src/python-management.md:148 src/faq.md:302
 msgid "# See what can be migrated\n"
-msgstr ""
+msgstr "# 마이그레이션 가능한 항목 확인\n"
 
 #: src/python-management.md:152
 msgid "#   myproject (Python 3.12.0)\n"
-msgstr ""
+msgstr "#   myproject (Python 3.12.0)\n"
 
 #: src/python-management.md:154 src/faq.md:305
 msgid "# conda:\n"
-msgstr ""
+msgstr "# conda:\n"
 
 #: src/python-management.md:157 src/faq.md:308
 msgid "# Migrate a specific environment\n"
-msgstr ""
+msgstr "# 특정 환경 마이그레이션\n"
 
 #: src/python-management.md:160 src/faq.md:311
 msgid "# Migrate everything at once\n"
-msgstr ""
+msgstr "# 모든 환경 한 번에 마이그레이션\n"
 
 #: src/python-management.md:165
 msgid "The migration process:"
-msgstr ""
+msgstr "마이그레이션 과정:"
 
 #: src/python-management.md:166
 msgid ""
-"Discovers environments from pyenv (`~/.pyenv/versions/`), conda (`conda info "
-"--envs`), or virtualenvwrapper (`$WORKON_HOME`)"
+"Discovers environments from pyenv (`~/.pyenv/versions/`), conda (`conda info"
+" --envs`), or virtualenvwrapper (`$WORKON_HOME`)"
 msgstr ""
+"pyenv(`~/.pyenv/versions/`), conda(`conda info --envs`), 또는 "
+"virtualenvwrapper(`$WORKON_HOME`)에서 환경을 탐색합니다"
 
 #: src/python-management.md:167
 msgid "Creates a new scoop environment with the same Python version"
-msgstr ""
+msgstr "동일한 Python 버전으로 새 scoop 환경을 생성합니다"
 
 #: src/python-management.md:168
 msgid "Reinstalls packages using uv for improved performance"
-msgstr ""
+msgstr "성능 향상을 위해 uv를 사용하여 패키지를 재설치합니다"
 
 #: src/python-management.md:169
 msgid ""
 "Preserves originals by default (use `--delete-source` to remove source envs "
 "after success)"
-msgstr ""
+msgstr "기본적으로 원본을 보존합니다 (성공 후 소스 환경을 삭제하려면 `--delete-source` 사용)"
 
 #: src/python-management.md:171
 msgid ""
-"`scoop migrate all` runs migrations in parallel across CPU cores via [rayon]"
-"(https://crates.io/crates/rayon) — typically 4-8× faster than sequential. "
-"Single-env (`migrate @env`) and `--dry-run` stay sequential for predictable "
-"output."
+"`scoop migrate all` runs migrations in parallel across CPU cores via "
+"[rayon](https://crates.io/crates/rayon) — typically 4-8× faster than "
+"sequential. Single-env (`migrate @env`) and `--dry-run` stay sequential for "
+"predictable output."
 msgstr ""
+"`scoop migrate all`은 [rayon](https://crates.io/crates/rayon)을 통해 CPU 코어 전체에 "
+"걸쳐 병렬로 마이그레이션을 실행합니다. 일반적으로 순차 실행보다 4~8배 빠릅니다. 단일 환경(`migrate @env`)과 "
+"`--dry-run`은 예측 가능한 출력을 위해 순차적으로 실행됩니다."
 
 #: src/python-management.md:173
 msgid "See [migrate command](commands/migrate.md) for details."
-msgstr ""
+msgstr "자세한 내용은 [migrate 명령어](commands/migrate.md)를 참조하세요."
 
 #: src/python-management.md:177
 msgid "Python version not found"
-msgstr ""
+msgstr "Python 버전을 찾을 수 없음"
 
 #: src/python-management.md:180
 msgid "# Error: Python 3.14 not found\n"
-msgstr ""
+msgstr "# Error: Python 3.14 not found\n"
 
 #: src/python-management.md:182
 msgid "# Solution 1: Install it via scoop\n"
-msgstr ""
+msgstr "# 해결 방법 1: scoop로 설치\n"
 
 #: src/python-management.md:185
 msgid "# Solution 2: Check what's available\n"
-msgstr ""
+msgstr "# 해결 방법 2: 사용 가능한 버전 확인\n"
 
 #: src/python-management.md:191
 msgid "Invalid custom Python path"
-msgstr ""
+msgstr "유효하지 않은 커스텀 Python 경로"
 
 #: src/python-management.md:194
 msgid "# Example custom path flow\n"
-msgstr ""
+msgstr "# 커스텀 경로 사용 예시\n"
 
 #: src/python-management.md:196
 msgid "# Verify the binary exists and runs\n"
-msgstr ""
+msgstr "# 바이너리가 존재하고 실행 가능한지 확인\n"
 
 #: src/python-management.md:201
 msgid ""
-"If the path is invalid or not executable, provide a valid Python binary path "
-"and retry."
-msgstr ""
+"If the path is invalid or not executable, provide a valid Python binary path"
+" and retry."
+msgstr "경로가 유효하지 않거나 실행할 수 없는 경우, 유효한 Python 바이너리 경로를 입력하고 다시 시도하세요."
 
 #: src/python-management.md:203
 msgid "Verify custom integration end-to-end"
-msgstr ""
+msgstr "커스텀 통합을 엔드-투-엔드로 검증하기"
 
 #: src/python-management.md:206
 msgid "# 1) Confirm uv can see your interpreter (PATH-based flow)\n"
-msgstr ""
+msgstr "# 1) uv가 인터프리터를 인식할 수 있는지 확인 (PATH 기반 방식)\n"
 
 #: src/python-management.md:208
 msgid "# 2) Confirm scoop recorded the interpreter path\n"
-msgstr ""
+msgstr "# 2) scoop이 인터프리터 경로를 기록했는지 확인\n"
 
 #: src/python-management.md:211
 msgid "# 3) Diagnose broken links or metadata issues\n"
-msgstr ""
+msgstr "# 3) 깨진 링크나 메타데이터 문제 진단\n"
 
 #: src/python-management.md:216
 msgid "Using a different Python than expected"
-msgstr ""
+msgstr "예상과 다른 Python이 사용되는 경우"
 
 #: src/python-management.md:219
 msgid "# Check which Python uv would select for a version\n"
-msgstr ""
+msgstr "# 버전에 대해 uv가 선택할 Python 확인\n"
 
 #: src/python-management.md:220
 msgid "# /opt/homebrew/bin/python3.12\n"
-msgstr ""
+msgstr "# /opt/homebrew/bin/python3.12\n"
 
 #: src/python-management.md:222
 msgid "# Check all available 3.12 installations\n"
-msgstr ""
+msgstr "# 사용 가능한 3.12 설치 목록 전체 확인\n"
 
 #: src/python-management.md:224
 msgid "# cpython-3.12.8    /opt/homebrew/bin/python3.12     (system)\n"
-msgstr ""
+msgstr "# cpython-3.12.8    /opt/homebrew/bin/python3.12     (system)\n"
 
 #: src/python-management.md:229
 msgid "Verify environment's Python"
-msgstr ""
+msgstr "환경에서 사용하는 Python 확인"
 
 #: src/python-management.md:232
 msgid "# Check what Python an environment uses\n"
-msgstr ""
+msgstr "# 환경이 사용하는 Python 확인\n"
 
 #: src/python-management.md:233
 msgid "# Name:    myenv\n"
-msgstr ""
+msgstr "# Name:    myenv\n"
 
 #: src/python-management.md:235
 msgid "# Path:    ~/.scoop/virtualenvs/myenv\n"
-msgstr ""
+msgstr "# Path:    ~/.scoop/virtualenvs/myenv\n"
 
 #: src/python-management.md:239
 msgid "Removing Python Versions"
-msgstr ""
+msgstr "Python 버전 제거"
 
 #: src/python-management.md:241
 msgid "Quick: Cascade removal (recommended)"
-msgstr ""
+msgstr "빠른 방법: 연쇄 제거 (권장)"
 
 #: src/python-management.md:243
 msgid ""
 "Use `--cascade` to automatically remove all environments using a Python "
 "version:"
-msgstr ""
+msgstr "`--cascade`를 사용하면 해당 Python 버전을 사용하는 모든 환경을 자동으로 제거합니다:"
 
 #: src/python-management.md:246
 msgid "# Remove Python 3.12 and all environments using it\n"
-msgstr ""
+msgstr "# Python 3.12와 이를 사용하는 모든 환경 제거\n"
 
 #: src/python-management.md:248
 msgid "# Skip confirmation prompt\n"
-msgstr ""
+msgstr "# 확인 프롬프트 건너뛰기\n"
 
 #: src/python-management.md:253
 msgid "Preview affected environments"
-msgstr ""
+msgstr "영향받는 환경 미리 보기"
 
 #: src/python-management.md:255
 msgid ""
 "Before uninstalling, you can check which environments would be affected:"
-msgstr ""
+msgstr "제거하기 전에 어떤 환경이 영향을 받는지 미리 확인할 수 있습니다:"
 
 #: src/python-management.md:258
 msgid "# Filter environments by Python version\n"
-msgstr ""
+msgstr "# Python 버전으로 환경 필터링\n"
 
 #: src/python-management.md:259 src/python-management.md:270
-#: src/commands/remove.md:52
+#: src/commands/remove.md:53
 msgid "#   myproject      3.12.1\n"
-msgstr ""
+msgstr "#   myproject      3.12.1\n"
 
 #: src/python-management.md:264
 msgid "Manual workflow"
-msgstr ""
+msgstr "수동 작업 흐름"
 
-#: src/python-management.md:266 src/commands/uninstall.md:106
+#: src/python-management.md:266 src/commands/uninstall.md:107
 msgid "If you prefer manual control (without `--cascade`):"
-msgstr ""
+msgstr "`--cascade` 없이 직접 제어하고 싶은 경우:"
 
 #: src/python-management.md:269
 msgid "# 1. Identify environments using the target Python version\n"
-msgstr ""
+msgstr "# 1. 대상 Python 버전을 사용하는 환경 파악\n"
 
 #: src/python-management.md:273
 msgid "# 2. Remove or recreate affected environments\n"
-msgstr ""
+msgstr "# 2. 영향받는 환경 제거 또는 재생성\n"
 
 #: src/python-management.md:276
 msgid "# Or recreate with a different version:\n"
-msgstr ""
+msgstr "# 또는 다른 버전으로 재생성:\n"
 
 #: src/python-management.md:279
 msgid "# 3. Uninstall the Python version\n"
-msgstr ""
+msgstr "# 3. Python 버전 제거\n"
 
 #: src/python-management.md:282
 msgid "# 4. Verify everything is clean\n"
-msgstr ""
+msgstr "# 4. 모든 것이 정리되었는지 확인\n"
 
 #: src/python-management.md:284
 msgid "# Confirm Python removed\n"
-msgstr ""
+msgstr "# Python 제거 확인\n"
 
-#: src/python-management.md:285 src/commands/uninstall.md:146
+#: src/python-management.md:285 src/commands/uninstall.md:147
 msgid "# Check for broken environments\n"
-msgstr ""
+msgstr "# 깨진 환경 확인\n"
 
 #: src/python-management.md:288
 msgid "Recovery from accidental uninstall"
-msgstr ""
+msgstr "실수로 제거한 경우 복구"
 
 #: src/python-management.md:290
 msgid "If you uninstalled Python without cleaning up environments:"
-msgstr ""
+msgstr "환경 정리 없이 Python을 제거한 경우:"
 
-#: src/python-management.md:293 src/commands/uninstall.md:158
+#: src/python-management.md:293 src/commands/uninstall.md:159
 msgid "# Detect broken environments\n"
-msgstr ""
+msgstr "# 깨진 환경 감지\n"
 
 #: src/python-management.md:294
 msgid "#   ⚠ Environment 'myproject': Python symlink broken\n"
-msgstr ""
+msgstr "#   ⚠ Environment 'myproject': Python symlink broken\n"
 
 #: src/python-management.md:296
 msgid "# Fix by reinstalling the Python version\n"
-msgstr ""
+msgstr "# Python 버전을 재설치하여 수정\n"
 
 #: src/python-management.md:300
 msgid "# Or remove the broken environments and start fresh\n"
-msgstr ""
+msgstr "# 또는 깨진 환경을 제거하고 새로 시작\n"
 
 #: src/python-management.md:305
 msgid ""
-"See [uninstall command](commands/uninstall.md) and [doctor command](commands/"
-"doctor.md) for details."
+"See [uninstall command](commands/uninstall.md) and [doctor "
+"command](commands/doctor.md) for details."
 msgstr ""
+"자세한 내용은 [uninstall 명령어](commands/uninstall.md)와 [doctor "
+"명령어](commands/doctor.md)를 참조하세요."
 
 #: src/python-management.md:309
 msgid "Scenario"
-msgstr ""
+msgstr "시나리오"
 
 #: src/python-management.md:309
 msgid "What to do"
-msgstr ""
+msgstr "방법"
 
 #: src/python-management.md:311
 msgid "Standard Python version"
-msgstr ""
+msgstr "표준 Python 버전"
 
 #: src/python-management.md:311
 msgid "`scoop install 3.12` then `scoop create myenv 3.12`"
-msgstr ""
+msgstr "`scoop install 3.12` then `scoop create myenv 3.12`"
 
 #: src/python-management.md:312
 msgid "System Python (Homebrew, apt)"
-msgstr ""
+msgstr "시스템 Python (Homebrew, apt)"
 
 #: src/python-management.md:312
 msgid "Just `scoop create myenv 3.12` — uv finds it automatically"
-msgstr ""
+msgstr "`scoop create myenv 3.12`만 실행하면 됩니다 — uv가 자동으로 찾아줍니다"
 
 #: src/python-management.md:313
 msgid "Custom Python executable"
-msgstr ""
+msgstr "커스텀 Python 실행 파일"
 
 #: src/python-management.md:313
 msgid "`scoop create myenv --python-path /path/to/python`"
-msgstr ""
+msgstr "`scoop create myenv --python-path /path/to/python`"
 
 #: src/python-management.md:314
 msgid "Custom Python in non-standard path"
-msgstr ""
+msgstr "비표준 경로의 커스텀 Python"
 
 #: src/python-management.md:314
 msgid "Add to `PATH`, then `scoop create myenv <version>`"
-msgstr ""
+msgstr "`PATH`에 추가한 후 `scoop create myenv <version>` 실행"
 
 #: src/python-management.md:315
 msgid "PyPy or alternative interpreter"
-msgstr ""
+msgstr "PyPy 또는 대체 인터프리터"
 
 #: src/python-management.md:315
 msgid "`scoop create myenv --python-path /opt/pypy/bin/pypy3`"
-msgstr ""
+msgstr "`scoop create myenv --python-path /opt/pypy/bin/pypy3`"
 
 #: src/python-management.md:316
 msgid "Existing pyenv/conda environments"
-msgstr ""
+msgstr "기존 pyenv/conda 환경"
 
 #: src/python-management.md:316 src/llms.md:51
 msgid "`scoop migrate all`"
-msgstr ""
+msgstr "`scoop migrate all`"
 
 #: src/python-management.md:317
 msgid "Shared Python installations"
-msgstr ""
+msgstr "공유 Python 설치"
 
 #: src/python-management.md:317
 msgid "Set `UV_PYTHON_INSTALL_DIR`"
-msgstr ""
+msgstr "`UV_PYTHON_INSTALL_DIR` 설정"
 
 #: src/python-management.md:318
 msgid "Force system-only Python"
-msgstr ""
+msgstr "시스템 Python만 강제 사용"
 
 #: src/python-management.md:318
 msgid "Set `UV_PYTHON_PREFERENCE=only-system`"
-msgstr ""
+msgstr "`UV_PYTHON_PREFERENCE=only-system` 설정"
 
 #: src/python-management.md:319
 msgid "Uninstall Python + cleanup envs"
-msgstr ""
+msgstr "Python 제거 + 환경 정리"
 
 #: src/python-management.md:319
 msgid "`scoop uninstall 3.12 --cascade` (or manual workflow)"
-msgstr ""
+msgstr "`scoop uninstall 3.12 --cascade` (또는 수동 방식)"
 
 #: src/python-management.md:320
 msgid "Find envs using a Python version"
-msgstr ""
+msgstr "Python 버전을 사용하는 환경 찾기"
 
 #: src/python-management.md:320
 msgid "`scoop list --python-version 3.12`"
-msgstr ""
+msgstr "`scoop list --python-version 3.12`"
 
 #: src/python-management.md:321
 msgid "Fix broken environments"
-msgstr ""
+msgstr "깨진 환경 수정"
 
 #: src/python-management.md:321
 msgid "`scoop doctor --fix` (after reinstalling the Python version)"
-msgstr ""
+msgstr "`scoop doctor --fix` (Python 버전 재설치 후)"
 
 #: src/faq.md:1
 msgid "Frequently Asked Questions"
-msgstr ""
+msgstr "자주 묻는 질문"
 
 #: src/faq.md:3
 msgid "What's the difference between scoop and pyenv?"
-msgstr ""
+msgstr "scoop과 pyenv의 차이점은 무엇인가요?"
 
 #: src/faq.md:5
 msgid ""
 "While both tools help you manage Python, they focus on different parts of "
 "the workflow:"
-msgstr ""
+msgstr "두 도구 모두 Python 관리를 돕지만, 각기 다른 부분에 초점을 맞추고 있습니다:"
 
 #: src/faq.md:7
 msgid "**pyenv** is primarily a _version manager_. It focuses on:"
-msgstr ""
+msgstr "**pyenv**는 주로 _버전 관리자_입니다. 다음에 초점을 맞춥니다:"
 
 #: src/faq.md:8
 msgid ""
 "Installing multiple versions of the Python interpreter (e.g., 3.9.0, 3.12.1)"
-msgstr ""
+msgstr "여러 버전의 Python 인터프리터 설치 (예: 3.9.0, 3.12.1)"
 
 #: src/faq.md:9
 msgid "Switching between them globally or per folder"
-msgstr ""
+msgstr "전역 또는 폴더별로 버전 전환"
 
 #: src/faq.md:11
 msgid ""
-"**scoop** is an _environment and workflow manager_ powered by [uv](https://"
-"github.com/astral-sh/uv). It focuses on:"
+"**scoop** is an _environment and workflow manager_ powered by "
+"[uv](https://github.com/astral-sh/uv). It focuses on:"
 msgstr ""
+"**scoop**은 [uv](https://github.com/astral-sh/uv) 기반의 _환경 및 워크플로우 관리자_입니다. "
+"다음에 초점을 맞춥니다:"
 
 #: src/faq.md:12
 msgid "Creating and managing isolated virtual environments"
-msgstr ""
+msgstr "격리된 가상 환경 생성 및 관리"
 
 #: src/faq.md:13
 msgid "Fast project-specific environment workflows"
-msgstr ""
+msgstr "프로젝트별 빠른 환경 워크플로우"
 
 #: src/faq.md:15
 msgid ""
-"**Summary:** You might use pyenv to install Python 3.11 on your machine, but "
-"you use scoop to actually build and run your application within a lightning-"
-"fast virtual environment using that Python version."
+"**Summary:** You might use pyenv to install Python 3.11 on your machine, but"
+" you use scoop to actually build and run your application within a "
+"lightning-fast virtual environment using that Python version."
 msgstr ""
+"**요약:** pyenv로 Python 3.11을 설치하고, scoop으로 그 Python 버전을 사용하는 빠른 가상 환경에서 실제로 "
+"애플리케이션을 빌드하고 실행합니다."
 
 #: src/faq.md:17
 msgid ""
 "How do I set Python 3.11.0 as the global default for all new shells and "
 "environments?"
-msgstr ""
+msgstr "Python 3.11.0을 모든 새 쉘과 환경의 전역 기본값으로 설정하려면 어떻게 하나요?"
 
 #: src/faq.md:19
 msgid "Use this workflow:"
-msgstr ""
+msgstr "다음 방법을 따르세요:"
 
 #: src/faq.md:22
 msgid "# 1) Install Python 3.11.0 (skip if already available on your system)\n"
-msgstr ""
+msgstr "# 1) Python 3.11.0 설치 (시스템에 이미 있으면 건너뛰기)\n"
 
 #: src/faq.md:24
 msgid "# 2) Create an environment that uses 3.11.0\n"
-msgstr ""
+msgstr "# 2) 3.11.0을 사용하는 환경 생성\n"
 
 #: src/faq.md:27
 msgid "# 3) Make that environment the global default\n"
-msgstr ""
+msgstr "# 3) 해당 환경을 전역 기본값으로 설정\n"
 
 #: src/faq.md:32
 msgid "Important details:"
-msgstr ""
+msgstr "중요 사항:"
 
 #: src/faq.md:34
 msgid ""
 "`--global` stores an environment name in `~/.scoop/version`, not a raw "
 "version like `3.11.0`."
-msgstr ""
+msgstr "`--global`은 `3.11.0`과 같은 원시 버전이 아닌 환경 이름을 `~/.scoop/version`에 저장합니다."
 
 #: src/faq.md:35
 msgid ""
-"This global default is applied in new shells and directories without a local "
-"`.scoop-version`."
-msgstr ""
+"This global default is applied in new shells and directories without a local"
+" `.scoop-version`."
+msgstr "이 전역 기본값은 로컬 `.scoop-version`이 없는 새 쉘과 디렉토리에 적용됩니다."
 
 #: src/faq.md:36
 msgid ""
 "Priority is: `SCOOP_VERSION` env var > local `.scoop-version` > global "
 "`~/.scoop/version`."
 msgstr ""
+"우선순위: `SCOOP_VERSION` 환경 변수 > 로컬 `.scoop-version` > 전역 `~/.scoop/version`."
 
 #: src/faq.md:38
 msgid "To remove the global default later:"
-msgstr ""
+msgstr "나중에 전역 기본값을 제거하려면:"
 
 #: src/faq.md:44
 msgid ""
 "How do I create a new virtual environment for a project, explicitly "
 "specifying Python 3.9.5?"
-msgstr ""
+msgstr "Python 3.9.5를 명시적으로 지정하여 프로젝트용 새 가상 환경을 만들려면 어떻게 하나요?"
 
 #: src/faq.md:46
 msgid "Use this end-to-end workflow:"
-msgstr ""
+msgstr "다음 엔드-투-엔드 방법을 따르세요:"
 
 #: src/faq.md:49
 msgid "# 1) Install Python 3.9.5 (skip if already available on your system)\n"
-msgstr ""
+msgstr "# 1) Python 3.9.5 설치 (시스템에 이미 있으면 건너뛰기)\n"
 
 #: src/faq.md:51
 msgid "# 2) Create a new project environment with that exact version\n"
-msgstr ""
+msgstr "# 2) 정확한 버전으로 새 프로젝트 환경 생성\n"
 
 #: src/faq.md:54
 msgid "# 3) Verify which Python the environment uses\n"
-msgstr ""
+msgstr "# 3) 환경이 사용하는 Python 확인\n"
 
 #: src/faq.md:59
 msgid "If creation fails because `3.9.5` is not found, run:"
-msgstr ""
+msgstr "`3.9.5`를 찾을 수 없어 생성에 실패하면 다음을 실행하세요:"
 
 #: src/faq.md:66
 msgid "Then install the exact version and retry:"
-msgstr ""
+msgstr "그런 다음 정확한 버전을 설치하고 재시도하세요:"
 
 #: src/faq.md:73
 msgid ""
 "How do I uninstall a specific Python version and all its associated virtual "
 "environments managed by scoop?"
-msgstr ""
+msgstr "특정 Python 버전과 scoop이 관리하는 관련 가상 환경을 모두 제거하려면 어떻게 하나요?"
 
 #: src/faq.md:75
 msgid ""
-"Use `--cascade` to remove both the Python version and every environment that "
-"depends on it:"
-msgstr ""
+"Use `--cascade` to remove both the Python version and every environment that"
+" depends on it:"
+msgstr "`--cascade`를 사용하면 Python 버전과 이에 의존하는 모든 환경을 함께 제거합니다:"
 
 #: src/faq.md:78
 msgid "# 1) Optional: preview affected environments\n"
-msgstr ""
+msgstr "# 1) 선택 사항: 영향받는 환경 미리 보기\n"
 
 #: src/faq.md:80
 msgid "# 2) Remove Python 3.12 and all associated environments\n"
-msgstr ""
+msgstr "# 2) Python 3.12와 관련 환경 모두 제거\n"
 
-#: src/faq.md:83 src/commands/uninstall.md:47
+#: src/faq.md:83 src/commands/uninstall.md:48
 msgid "# 3) Verify cleanup\n"
-msgstr ""
+msgstr "# 3) 정리 확인\n"
 
 #: src/faq.md:89 src/faq.md:136
 msgid "Useful variants:"
-msgstr ""
+msgstr "유용한 변형:"
 
 #: src/faq.md:91
 msgid "Non-interactive mode: `scoop uninstall 3.12 --cascade --force`"
-msgstr ""
+msgstr "비대화형 모드: `scoop uninstall 3.12 --cascade --force`"
 
 #: src/faq.md:92
 msgid "JSON output for automation: `scoop uninstall 3.12 --cascade --json`"
-msgstr ""
+msgstr "자동화를 위한 JSON 출력: `scoop uninstall 3.12 --cascade --json`"
 
 #: src/faq.md:94
 msgid "Important detail:"
-msgstr ""
+msgstr "중요 사항:"
 
 #: src/faq.md:96
 msgid ""
 "Without `--cascade`, environments are not removed and can become broken."
-msgstr ""
+msgstr "`--cascade` 없이는 환경이 제거되지 않아 깨질 수 있습니다."
 
 #: src/faq.md:98
 msgid ""
@@ -1894,136 +1940,140 @@ msgid ""
 "disable or customize its behavior for a specific project or directory "
 "without affecting global settings?"
 msgstr ""
+"Scoop-uv의 자동 활성화 기능을 사용할 때, 전역 설정에 영향을 주지 않고 특정 프로젝트나 디렉토리에서 이 동작을 일시적으로 "
+"비활성화하거나 커스터마이즈하려면 어떻게 하나요?"
 
 #: src/faq.md:100
 msgid "Use one of these local or temporary patterns:"
-msgstr ""
+msgstr "다음 로컬 또는 임시 방법 중 하나를 사용하세요:"
 
 #: src/faq.md:103
 msgid "# Option 1) Disable auto-activation only in the current shell session\n"
-msgstr ""
+msgstr "# Option 1) 현재 쉘 세션에서만 자동 활성화 비활성화\n"
 
 #: src/faq.md:104
 msgid "# ...work here...\n"
-msgstr ""
+msgstr "# ...work here...\n"
 
 #: src/faq.md:107
 msgid "# Option 2) For one project directory, force system Python locally\n"
-msgstr ""
+msgstr "# Option 2) 특정 프로젝트 디렉토리에서 시스템 Python 로컬 강제 사용\n"
 
 #: src/faq.md:111
 msgid ""
 "# Option 3) For one project directory, pin a specific environment locally\n"
-msgstr ""
+msgstr "# Option 3) 특정 프로젝트 디렉토리에서 특정 환경 로컬 고정\n"
 
 #: src/faq.md:114
-msgid ""
-"# Option 4) Temporary override in this terminal only (no file changes)\n"
-msgstr ""
+msgid "# Option 4) Temporary override in this terminal only (no file changes)\n"
+msgstr "# Option 4) 이 터미널에서만 임시 재정의 (파일 변경 없음)\n"
 
 #: src/faq.md:116
 msgid "# ...test...\n"
-msgstr ""
+msgstr "# ...test...\n"
 
 #: src/faq.md:121 src/commands/migrate.md:74
 msgid "Notes:"
-msgstr ""
+msgstr "참고:"
 
 #: src/faq.md:123
 msgid "These approaches avoid `--global`, so global defaults are unchanged."
-msgstr ""
+msgstr "이 방법들은 `--global`을 사용하지 않으므로 전역 기본값이 변경되지 않습니다."
 
 #: src/faq.md:124
 msgid ""
 "`.scoop-version` changes from `scoop use ...` are local to the project "
 "directory (and inherited by subdirectories)."
 msgstr ""
+"`scoop use ...`로 변경한 `.scoop-version`은 프로젝트 디렉토리에 로컬로 적용됩니다 (하위 디렉토리에도 "
+"상속됩니다)."
 
 #: src/faq.md:125
 msgid "`scoop shell ...` affects only the current terminal session."
-msgstr ""
+msgstr "`scoop shell ...`은 현재 터미널 세션에만 영향을 미칩니다."
 
 #: src/faq.md:127
 msgid ""
 "Once a Scoop-uv environment is active, how would you install project "
 "dependencies from a `requirements.txt` file into it?"
 msgstr ""
+"Scoop-uv 환경이 활성화된 상태에서 `requirements.txt` 파일의 프로젝트 의존성을 설치하려면 어떻게 하나요?"
 
 #: src/faq.md:129
 msgid "Run pip inside the active environment:"
-msgstr ""
+msgstr "활성화된 환경 안에서 pip을 실행하세요:"
 
 #: src/faq.md:132
 msgid "# Prompt shows active environment, e.g. (myproject)\n"
-msgstr ""
+msgstr "# 프롬프트에 활성 환경 표시, 예: (myproject)\n"
 
 #: src/faq.md:138
 msgid "Different file location: `pip install -r path/to/requirements.txt`"
-msgstr ""
+msgstr "다른 파일 위치: `pip install -r path/to/requirements.txt`"
 
 #: src/faq.md:139
 msgid "Verify installed dependencies: `pip list`"
-msgstr ""
+msgstr "설치된 의존성 확인: `pip list`"
 
 #: src/faq.md:141
 msgid ""
 "If `requirements.txt` is in the project root, run the command from that "
 "directory."
-msgstr ""
+msgstr "`requirements.txt`가 프로젝트 루트에 있다면 해당 디렉토리에서 명령을 실행하세요."
 
 #: src/faq.md:143
 msgid ""
 "How can a developer list all Python versions and their associated virtual "
 "environments currently managed by Scoop-uv?"
-msgstr ""
+msgstr "개발자가 Scoop-uv가 현재 관리 중인 모든 Python 버전과 관련 가상 환경을 나열하려면 어떻게 하나요?"
 
 #: src/faq.md:145
 msgid "Use this sequence:"
-msgstr ""
+msgstr "다음 순서를 따르세요:"
 
 #: src/faq.md:148
 msgid "# 1) Show all managed Python versions\n"
-msgstr ""
+msgstr "# 1) 관리 중인 Python 버전 전체 표시\n"
 
 #: src/faq.md:150
 msgid "# 2) Show all environments and their Python versions\n"
-msgstr ""
+msgstr "# 2) 모든 환경과 Python 버전 표시\n"
 
 #: src/faq.md:153
 msgid "# 3) Show environments for one specific Python version\n"
-msgstr ""
+msgstr "# 3) 특정 Python 버전의 환경 표시\n"
 
 #: src/faq.md:158
 msgid "For automation:"
-msgstr ""
+msgstr "자동화를 위해:"
 
 #: src/faq.md:160
 msgid "Use `--json` for machine-readable output."
-msgstr ""
+msgstr "기계 가독 출력에는 `--json`을 사용하세요."
 
 #: src/faq.md:161
 msgid "Use `--bare` for name-only output in shell scripts."
-msgstr ""
+msgstr "쉘 스크립트에서 이름만 출력하려면 `--bare`를 사용하세요."
 
 #: src/faq.md:163
 msgid ""
 "Example script to iterate each Python version and print associated "
 "environments:"
-msgstr ""
+msgstr "각 Python 버전을 순회하며 관련 환경을 출력하는 예제 스크립트:"
 
 #: src/faq.md:167 src/commands/list.md:82
 msgid "\"== Python $v ==\""
-msgstr ""
+msgstr "\"== Python $v ==\""
 
 #: src/faq.md:168 src/commands/list.md:83
 msgid "\"$v\""
-msgstr ""
+msgstr "\"$v\""
 
 #: src/faq.md:172
 msgid ""
-"If no versions or environments exist yet, these commands simply return empty "
-"results."
-msgstr ""
+"If no versions or environments exist yet, these commands simply return empty"
+" results."
+msgstr "버전이나 환경이 아직 없으면 이 명령들은 빈 결과를 반환합니다."
 
 #: src/faq.md:174
 msgid ""
@@ -2031,82 +2081,86 @@ msgid ""
 "uv's default sources, how could a developer integrate a custom or pre-"
 "existing Python installation into Scoop-uv's management system?"
 msgstr ""
+"프로젝트에 Scoop-uv의 기본 소스에서 바로 제공하지 않는 Python 버전이 필요한 경우, 커스텀 또는 기존 Python 설치를 "
+"Scoop-uv 관리 시스템에 통합하려면 어떻게 하나요?"
 
 #: src/faq.md:176
 msgid "Use one of these two approaches:"
-msgstr ""
+msgstr "다음 두 가지 방법 중 하나를 사용하세요:"
 
 #: src/faq.md:179
 msgid "# Option 1) Recommended: point directly to a Python executable\n"
-msgstr ""
+msgstr "# Option 1) 권장: Python 실행 파일을 직접 지정\n"
 
 #: src/faq.md:181
 msgid ""
 "# Option 2) Add custom Python to PATH, then use normal version selection\n"
-msgstr ""
+msgstr "# Option 2) 커스텀 Python을 PATH에 추가한 후 일반 버전 선택 사용\n"
 
 #: src/faq.md:187
 msgid "Validation and diagnostics:"
-msgstr ""
+msgstr "검증 및 진단:"
 
 #: src/faq.md:190
 msgid "# confirm interpreter discovery\n"
-msgstr ""
+msgstr "# 인터프리터 검색 확인\n"
 
 #: src/faq.md:191
 msgid "# confirm selected Python + Python Path\n"
-msgstr ""
+msgstr "# 선택된 Python + Python 경로 확인\n"
 
 #: src/faq.md:192
 msgid "# detect broken links/metadata issues\n"
-msgstr ""
+msgstr "# 깨진 링크/메타데이터 문제 감지\n"
 
 #: src/faq.md:195
 msgid "Where scoop stores this integration:"
-msgstr ""
+msgstr "scoop이 이 통합 정보를 저장하는 위치:"
 
 #: src/faq.md:197
 msgid ""
 "Environment metadata file: `~/.scoop/virtualenvs/myenv/.scoop-metadata.json`"
-msgstr ""
+msgstr "환경 메타데이터 파일: `~/.scoop/virtualenvs/myenv/.scoop-metadata.json`"
 
 #: src/faq.md:198
 msgid "Custom interpreter path is recorded in the `python_path` field."
-msgstr ""
+msgstr "커스텀 인터프리터 경로는 `python_path` 필드에 기록됩니다."
 
 #: src/faq.md:200
 msgid "Can I use scoop with conda environments?"
-msgstr ""
+msgstr "scoop을 conda 환경과 함께 사용할 수 있나요?"
 
 #: src/faq.md:202
 msgid "Not directly. They serve different purposes and operate independently:"
-msgstr ""
+msgstr "직접 사용은 불가합니다. 두 도구는 서로 다른 목적으로 독립적으로 동작합니다:"
 
 #: src/faq.md:204
 msgid "**conda** is a _package and environment manager_. It handles:"
-msgstr ""
+msgstr "**conda**는 _패키지 및 환경 관리자_입니다. 다음을 담당합니다:"
 
 #: src/faq.md:205
 msgid "Its own binaries and non-Python dependencies"
-msgstr ""
+msgstr "자체 바이너리와 비Python 의존성"
 
 #: src/faq.md:206
 msgid "Heavy data science libraries (MKL, CUDA, cuDNN, etc.)"
-msgstr ""
+msgstr "무거운 데이터 과학 라이브러리 (MKL, CUDA, cuDNN 등)"
 
 #: src/faq.md:208
 msgid ""
-"**scoop** is a _lightweight environment manager_ powered by [uv](https://"
-"github.com/astral-sh/uv). It:"
+"**scoop** is a _lightweight environment manager_ powered by "
+"[uv](https://github.com/astral-sh/uv). It:"
 msgstr ""
+"**scoop**은 [uv](https://github.com/astral-sh/uv) 기반의 _경량 환경 관리자_입니다. 다음을 "
+"지원합니다:"
 
 #: src/faq.md:209
 msgid "Leverages your existing Python installations"
-msgstr ""
+msgstr "기존 Python 설치를 활용합니다"
 
 #: src/faq.md:210
 msgid "Creates fast, portable virtual environments"
-msgstr ""
+msgstr "빠르고 이식성 높은 가상 환경을 생성합니다"
 
 #: src/faq.md:212
 msgid ""
@@ -2114,78 +2168,80 @@ msgid ""
 "→ conda. For almost everything else → scoop (significantly faster and more "
 "portable)."
 msgstr ""
+"**언제 무엇을 사용할까:** 비Python 라이브러리가 필요한 무거운 데이터 과학 작업 → conda. 그 외 대부분의 경우 → "
+"scoop (훨씬 빠르고 이식성이 높습니다)."
 
 #: src/faq.md:214
 msgid "How do I uninstall scoop completely?"
-msgstr ""
+msgstr "scoop을 완전히 제거하려면 어떻게 하나요?"
 
 #: src/faq.md:216
 msgid "To remove scoop from your system:"
-msgstr ""
+msgstr "시스템에서 scoop을 제거하려면:"
 
 #: src/faq.md:218
 msgid "1. Delete the data folder"
-msgstr ""
+msgstr "1. 데이터 폴더 삭제"
 
 #: src/faq.md:222
 msgid "2. Remove the shell hook"
-msgstr ""
+msgstr "2. 쉘 hook 제거"
 
 #: src/faq.md:224
 msgid "Edit your shell config file and remove the scoop init line:"
-msgstr ""
+msgstr "쉘 설정 파일을 편집하여 scoop init 줄을 제거하세요:"
 
 #: src/faq.md:226
 msgid "Config File"
-msgstr ""
+msgstr "설정 파일"
 
 #: src/faq.md:226
 msgid "Line to Remove"
-msgstr ""
+msgstr "제거할 줄"
 
 #: src/faq.md:228
 msgid "`~/.bashrc`"
-msgstr ""
+msgstr "`~/.bashrc`"
 
 #: src/faq.md:228
 msgid "`eval \"$(scoop init bash)\"`"
-msgstr ""
+msgstr "`eval \"$(scoop init bash)\"`"
 
 #: src/faq.md:229
 msgid "`~/.zshrc`"
-msgstr ""
+msgstr "`~/.zshrc`"
 
 #: src/faq.md:229
 msgid "`eval \"$(scoop init zsh)\"`"
-msgstr ""
+msgstr "`eval \"$(scoop init zsh)\"`"
 
 #: src/faq.md:230
 msgid "`~/.config/fish/config.fish`"
-msgstr ""
+msgstr "`~/.config/fish/config.fish`"
 
 #: src/faq.md:230
 msgid "`eval (scoop init fish)`"
-msgstr ""
+msgstr "`eval (scoop init fish)`"
 
 #: src/faq.md:231
 msgid "`$PROFILE`"
-msgstr ""
+msgstr "`$PROFILE`"
 
 #: src/faq.md:231
 msgid "`Invoke-Expression (& scoop init powershell)`"
-msgstr ""
+msgstr "`Invoke-Expression (& scoop init powershell)`"
 
 #: src/faq.md:233
 msgid "3. (Optional) Remove config"
-msgstr ""
+msgstr "3. (선택 사항) 설정 제거"
 
 #: src/faq.md:237
 msgid "4. Restart your terminal"
-msgstr ""
+msgstr "4. 터미널 재시작"
 
 #: src/faq.md:239
 msgid "Does scoop work on Windows?"
-msgstr ""
+msgstr "scoop이 Windows에서도 동작하나요?"
 
 #: src/faq.md:241
 msgid ""
@@ -2193,60 +2249,66 @@ msgid ""
 "Windows PowerShell 5.1+). Shell integration including auto-activation and "
 "tab completion works fully."
 msgstr ""
+"scoop은 Windows에서 **PowerShell**을 지원합니다 (PowerShell Core 7.x+ 및 Windows "
+"PowerShell 5.1+ 모두). 자동 활성화와 탭 완성을 포함한 쉘 통합이 완전히 동작합니다."
 
 #: src/faq.md:248
 msgid ""
 "**Note:** Command Prompt (cmd.exe) is not supported. Use PowerShell for the "
 "full scoop experience."
 msgstr ""
+"**참고:** Command Prompt (cmd.exe)는 지원하지 않습니다. scoop의 모든 기능을 사용하려면 PowerShell을"
+" 이용하세요."
 
 #: src/faq.md:250
 msgid "Can I use a custom or pre-existing Python with scoop?"
-msgstr ""
+msgstr "scoop에서 커스텀 또는 기존 Python을 사용할 수 있나요?"
 
 #: src/faq.md:252
 msgid "Yes, in two ways:"
-msgstr ""
+msgstr "네, 두 가지 방법으로 가능합니다:"
 
 #: src/faq.md:254
 msgid "Option 1: Use --python-path (recommended for custom builds)"
-msgstr ""
+msgstr "Option 1: --python-path 사용 (커스텀 빌드에 권장)"
 
 #: src/faq.md:256
 msgid "Point directly to any Python executable:"
-msgstr ""
+msgstr "임의의 Python 실행 파일을 직접 지정하세요:"
 
 #: src/faq.md:259
 msgid "# Custom-built Python\n"
-msgstr ""
+msgstr "# 커스텀 빌드된 Python\n"
 
 #: src/faq.md:269
 msgid ""
 "scoop validates the path, auto-detects the version, and stores it in "
 "metadata."
-msgstr ""
+msgstr "scoop은 경로를 검증하고, 버전을 자동으로 감지하여 메타데이터에 저장합니다."
 
 #: src/faq.md:271
 msgid "Option 2: System Python via uv discovery"
-msgstr ""
+msgstr "Option 2: uv 검색을 통한 시스템 Python"
 
 #: src/faq.md:273
 msgid ""
-"scoop uses [uv](https://github.com/astral-sh/uv) for Python discovery, which "
-"automatically finds Python installations on your system:"
+"scoop uses [uv](https://github.com/astral-sh/uv) for Python discovery, which"
+" automatically finds Python installations on your system:"
 msgstr ""
+"scoop은 Python 검색에 [uv](https://github.com/astral-sh/uv)를 사용하며, 시스템에 설치된 "
+"Python을 자동으로 찾습니다:"
 
 #: src/faq.md:276
 msgid "# Check what Python versions uv can discover\n"
-msgstr ""
+msgstr "# uv가 검색할 수 있는 Python 버전 확인\n"
 
 #: src/faq.md:283
 msgid "# Use a system-installed Python directly (no scoop install needed)\n"
-msgstr ""
+msgstr "# 시스템에 설치된 Python 직접 사용 (scoop install 불필요)\n"
 
 #: src/faq.md:288
 msgid "For a custom Python in a non-standard location, add it to your `PATH`:"
-msgstr ""
+msgstr "비표준 위치의 커스텀 Python은 `PATH`에 추가하세요:"
 
 #: src/faq.md:295
 msgid ""
@@ -2254,59 +2316,65 @@ msgid ""
 "on Python discovery, system Python, custom interpreters, and environment "
 "variables."
 msgstr ""
+"**참고:** Python 검색, 시스템 Python, 커스텀 인터프리터, 환경 변수에 대한 전체 가이드는 [Python "
+"Management](python-management.md)를 참조하세요."
 
 #: src/faq.md:297
 msgid "Can I migrate environments from pyenv or conda?"
-msgstr ""
+msgstr "pyenv나 conda 환경을 마이그레이션할 수 있나요?"
 
 #: src/faq.md:299
 msgid ""
 "Yes. scoop can discover and migrate existing environments from pyenv-"
 "virtualenv, conda, and virtualenvwrapper:"
 msgstr ""
+"네. scoop은 pyenv-virtualenv, conda, virtualenvwrapper의 기존 환경을 검색하고 마이그레이션할 수 "
+"있습니다:"
 
 #: src/faq.md:303
 msgid "# pyenv-virtualenv:\n"
-msgstr ""
+msgstr "# pyenv-virtualenv:\n"
 
 #: src/faq.md:316
 msgid ""
-"The original environments are preserved by default. Use `--delete-source` to "
-"remove source envs after successful migration. See [migrate command]"
-"(commands/migrate.md) for details."
+"The original environments are preserved by default. Use `--delete-source` to"
+" remove source envs after successful migration. See [migrate "
+"command](commands/migrate.md) for details."
 msgstr ""
+"기본적으로 원본 환경은 보존됩니다. 마이그레이션 성공 후 소스 환경을 삭제하려면 `--delete-source`를 사용하세요. 자세한 "
+"내용은 [migrate 명령어](commands/migrate.md)를 참조하세요."
 
 #: src/commands/index.md:1
 msgid "Command Reference"
-msgstr ""
+msgstr "명령어 참조"
 
 #: src/commands/index.md:3
 msgid "Complete reference for all scoop commands."
-msgstr ""
+msgstr "모든 scoop 명령어에 대한 완전한 참조 문서입니다."
 
 #: src/commands/index.md:5
 msgid "Commands Overview"
-msgstr ""
+msgstr "명령어 개요"
 
 #: src/commands/index.md:7
 msgid "Aliases"
-msgstr ""
+msgstr "별칭"
 
 #: src/commands/index.md:9
 msgid "[`scoop list`](list.md)"
-msgstr ""
+msgstr "[`scoop list`](list.md)"
 
 #: src/commands/index.md:9
 msgid "`ls`"
-msgstr ""
+msgstr "`ls`"
 
 #: src/commands/index.md:9
 msgid "List virtualenvs or Python versions"
-msgstr ""
+msgstr "virtualenv 또는 Python 버전 목록 표시"
 
 #: src/commands/index.md:10
 msgid "[`scoop create`](create.md)"
-msgstr ""
+msgstr "[`scoop create`](create.md)"
 
 #: src/commands/index.md:10 src/commands/index.md:11 src/commands/index.md:13
 #: src/commands/index.md:14 src/commands/index.md:15 src/commands/index.md:16
@@ -2315,317 +2383,343 @@ msgstr ""
 #: src/commands/index.md:23 src/commands/index.md:24 src/commands/index.md:25
 #: src/commands/index.md:26 src/commands/index.md:27 src/commands/index.md:28
 #: src/commands/index.md:29 src/commands/index.md:30 src/commands/index.md:31
-#: src/commands/index.md:32 src/commands/create.md:15
+#: src/commands/index.md:32 src/commands/index.md:33 src/commands/create.md:15
 msgid "\\-"
-msgstr ""
+msgstr "\\-"
 
 #: src/commands/index.md:10
 msgid "Create virtualenv"
-msgstr ""
+msgstr "virtualenv 생성"
 
 #: src/commands/index.md:11
 msgid "[`scoop use`](use.md)"
-msgstr ""
+msgstr "[`scoop use`](use.md)"
 
 #: src/commands/index.md:11 src/llms.md:26
 msgid "Set + activate environment"
-msgstr ""
+msgstr "환경 설정 및 활성화"
 
 #: src/commands/index.md:12
 msgid "[`scoop remove`](remove.md)"
-msgstr ""
+msgstr "[`scoop remove`](remove.md)"
 
 #: src/commands/index.md:12
 msgid "`rm`, `delete`"
-msgstr ""
+msgstr "`rm`, `delete`"
 
 #: src/commands/index.md:12
 msgid "Remove virtualenv"
-msgstr ""
+msgstr "가상 환경 제거"
 
 #: src/commands/index.md:13
 msgid "[`scoop install`](install.md)"
-msgstr ""
+msgstr "[`scoop install`](install.md)"
 
 #: src/commands/index.md:13 src/llms.md:33
 msgid "Install Python version"
-msgstr ""
+msgstr "Python 버전 설치"
 
 #: src/commands/index.md:14
 msgid "[`scoop uninstall`](uninstall.md)"
-msgstr ""
+msgstr "[`scoop uninstall`](uninstall.md)"
 
 #: src/commands/index.md:14
 msgid "Uninstall Python version"
-msgstr ""
+msgstr "Python 버전 제거"
 
 #: src/commands/index.md:15
 msgid "[`scoop doctor`](doctor.md)"
-msgstr ""
+msgstr "[`scoop doctor`](doctor.md)"
 
 #: src/commands/index.md:15
 msgid "Diagnose installation"
-msgstr ""
+msgstr "설치 상태 진단"
 
 #: src/commands/index.md:16
 msgid "[`scoop info`](info.md)"
-msgstr ""
+msgstr "[`scoop info`](info.md)"
 
 #: src/commands/index.md:16
 msgid "Show virtualenv details"
-msgstr ""
+msgstr "가상 환경 상세 정보 표시"
 
 #: src/commands/index.md:17
 msgid "[`scoop status`](status.md)"
-msgstr ""
+msgstr "[`scoop status`](status.md)"
 
 #: src/commands/index.md:17
 msgid "Summarise the currently active env"
-msgstr ""
+msgstr "현재 활성 환경 요약 표시"
 
 #: src/commands/index.md:18
 msgid "[`scoop which`](which.md)"
-msgstr ""
+msgstr "[`scoop which`](which.md)"
 
 #: src/commands/index.md:18
 msgid "Resolve an executable inside an env"
-msgstr ""
+msgstr "환경 내 실행 파일 경로 확인"
 
 #: src/commands/index.md:19
 msgid "[`scoop run`](run.md)"
-msgstr ""
+msgstr "[`scoop run`](run.md)"
 
 #: src/commands/index.md:19
 msgid "Run a command inside an env without activating"
-msgstr ""
+msgstr "환경을 활성화하지 않고 명령 실행"
 
 #: src/commands/index.md:20
 msgid "[`scoop sync`](sync.md)"
-msgstr ""
+msgstr "[`scoop sync`](sync.md)"
 
 #: src/commands/index.md:20
 msgid "Apply `.scoop.toml` declaratively"
-msgstr ""
+msgstr "`.scoop.toml`을 선언적으로 적용"
 
 #: src/commands/index.md:21
 msgid "[`scoop export`](export.md)"
-msgstr ""
+msgstr "[`scoop export`](export.md)"
 
 #: src/commands/index.md:21
 msgid "Write a portable JSON snapshot of an env"
-msgstr ""
+msgstr "환경의 이식 가능한 JSON 스냅샷 작성"
 
 #: src/commands/index.md:22
 msgid "[`scoop import`](import.md)"
-msgstr ""
+msgstr "[`scoop import`](import.md)"
 
 #: src/commands/index.md:22
 msgid "Recreate an env from an export file (or stdin)"
-msgstr ""
+msgstr "내보낸 파일(또는 stdin)에서 환경 재생성"
 
 #: src/commands/index.md:23
 msgid "[`scoop clone`](clone.md)"
-msgstr ""
+msgstr "[`scoop clone`](clone.md)"
 
 #: src/commands/index.md:23
 msgid "Duplicate an env (with or without packages)"
-msgstr ""
+msgstr "환경 복제 (패키지 포함 여부 선택 가능)"
 
 #: src/commands/index.md:24
 msgid "[`scoop migrate`](migrate.md)"
-msgstr ""
+msgstr "[`scoop migrate`](migrate.md)"
 
 #: src/commands/index.md:24
 msgid "Migrate from pyenv/conda/venvwrapper"
-msgstr ""
+msgstr "pyenv/conda/venvwrapper에서 마이그레이션"
 
 #: src/commands/index.md:25
 msgid "[`scoop gc`](gc.md)"
-msgstr ""
+msgstr "[`scoop gc`](gc.md)"
 
 #: src/commands/index.md:25
 msgid "Garbage-collect orphan virtualenvs"
-msgstr ""
+msgstr "고아 가상 환경 가비지 컬렉션"
 
 #: src/commands/index.md:26
 msgid "[`scoop prune`](prune.md)"
-msgstr ""
+msgstr "[`scoop prune`](prune.md)"
 
 #: src/commands/index.md:26
 msgid "Prune the uv cache"
-msgstr ""
+msgstr "uv 캐시 정리"
 
 #: src/commands/index.md:27
 msgid "[`scoop verify`](verify.md)"
-msgstr ""
+msgstr "[`scoop verify`](verify.md)"
 
 #: src/commands/index.md:27
 msgid "Per-env health diagnosis (6 checks)"
-msgstr ""
+msgstr "환경별 상태 진단 (6가지 검사)"
 
 #: src/commands/index.md:28
 msgid "[`scoop lang`](lang.md)"
-msgstr ""
+msgstr "[`scoop lang`](lang.md)"
 
 #: src/commands/index.md:28
 msgid "Get/set display language"
-msgstr ""
+msgstr "표시 언어 조회/설정"
 
 #: src/commands/index.md:29
 msgid "[`scoop shell`](shell.md)"
-msgstr ""
+msgstr "[`scoop shell`](shell.md)"
 
 #: src/commands/index.md:29 src/llms.md:44
 msgid "Set shell-specific env (temporary)"
-msgstr ""
+msgstr "셸 전용 환경 설정 (임시)"
 
 #: src/commands/index.md:30
 msgid "[`scoop init`](init.md)"
-msgstr ""
+msgstr "[`scoop init`](init.md)"
 
 #: src/commands/index.md:30
 msgid "Shell init script"
-msgstr ""
+msgstr "셸 초기화 스크립트"
 
 #: src/commands/index.md:31
 msgid "[`scoop completions`](completions.md)"
-msgstr ""
+msgstr "[`scoop completions`](completions.md)"
 
 #: src/commands/index.md:31
 msgid "Completion script"
-msgstr ""
+msgstr "자동 완성 스크립트"
 
 #: src/commands/index.md:32
 msgid "[`scoop man`](man.md)"
-msgstr ""
+msgstr "[`scoop man`](man.md)"
 
 #: src/commands/index.md:32
 msgid "Generate man pages (for distro packagers)"
-msgstr ""
+msgstr "man 페이지 생성 (배포 패키지 관리자용)"
 
-#: src/commands/index.md:34
+#: src/commands/index.md:33
+msgid "[`scoop self update`](self.md)"
+msgstr "[`scoop self update`](self.md)"
+
+#: src/commands/index.md:33
+msgid "Reinstall scoop from crates.io (update or pin version)"
+msgstr "crates.io에서 scoop 재설치 (업데이트 또는 버전 고정)"
+
+#: src/commands/index.md:35
 msgid "Global Options"
-msgstr ""
+msgstr "전역 옵션"
 
-#: src/commands/index.md:36
+#: src/commands/index.md:37
 msgid "Available for all commands:"
-msgstr ""
+msgstr "모든 명령에 사용 가능합니다:"
 
-#: src/commands/index.md:38 src/commands/list.md:15 src/commands/create.md:20
+#: src/commands/index.md:39 src/commands/list.md:15 src/commands/create.md:20
 #: src/commands/use.md:21 src/commands/remove.md:21 src/commands/install.md:19
 #: src/commands/uninstall.md:19 src/commands/doctor.md:13
 #: src/commands/info.md:22 src/commands/which.md:20 src/commands/sync.md:14
-#: src/commands/export.md:20 src/commands/import.md:20 src/commands/clone.md:21
-#: src/commands/migrate.md:36 src/commands/gc.md:77 src/commands/prune.md:21
-#: src/commands/diff.md:35 src/commands/lang.md:29 src/commands/shell.md:27
-#: src/commands/man.md:26
+#: src/commands/export.md:20 src/commands/import.md:20
+#: src/commands/clone.md:21 src/commands/migrate.md:36 src/commands/gc.md:77
+#: src/commands/prune.md:21 src/commands/diff.md:35 src/commands/lang.md:29
+#: src/commands/self.md:13 src/commands/shell.md:27 src/commands/man.md:26
 msgid "Option"
-msgstr ""
-
-#: src/commands/index.md:40
-msgid "`-q`, `--quiet`"
-msgstr ""
-
-#: src/commands/index.md:40
-msgid "Suppress all output"
-msgstr ""
+msgstr "옵션"
 
 #: src/commands/index.md:41
+msgid "`-q`, `--quiet`"
+msgstr "`-q`, `--quiet`"
+
+#: src/commands/index.md:41
+msgid "Suppress all output"
+msgstr "모든 출력 억제"
+
+#: src/commands/index.md:42
 msgid "`--no-color`"
-msgstr ""
+msgstr "`--no-color`"
 
-#: src/commands/index.md:41 src/commands/index.md:52
+#: src/commands/index.md:42 src/commands/index.md:53
 msgid "Disable colored output"
-msgstr ""
+msgstr "컬러 출력 비활성화"
 
-#: src/commands/index.md:42
+#: src/commands/index.md:43
 msgid "`-h`, `--help`"
-msgstr ""
+msgstr "`-h`, `--help`"
 
-#: src/commands/index.md:42
+#: src/commands/index.md:43
 msgid "Show help message"
-msgstr ""
+msgstr "도움말 표시"
 
-#: src/commands/index.md:43
+#: src/commands/index.md:44
 msgid "`-V`, `--version`"
-msgstr ""
+msgstr "`-V`, `--version`"
 
-#: src/commands/index.md:43
+#: src/commands/index.md:44
 msgid "Show version"
-msgstr ""
+msgstr "버전 표시"
 
-#: src/commands/index.md:49
+#: src/commands/index.md:50
 msgid "Base directory for scoop"
-msgstr ""
-
-#: src/commands/index.md:51
-msgid "`SCOOP_LANG`"
-msgstr ""
-
-#: src/commands/index.md:51
-msgid "Display language (en, ko, ja, pt-BR)"
-msgstr ""
-
-#: src/commands/index.md:51
-msgid "System locale"
-msgstr ""
+msgstr "scoop의 기본 디렉터리"
 
 #: src/commands/index.md:52
+msgid "`SCOOP_LANG`"
+msgstr "`SCOOP_LANG`"
+
+#: src/commands/index.md:52
+msgid "Display language (en, ko, ja, pt-BR)"
+msgstr "표시 언어 (en, ko, ja, pt-BR)"
+
+#: src/commands/index.md:52
+msgid "System locale"
+msgstr "시스템 로케일"
+
+#: src/commands/index.md:53
 msgid "`NO_COLOR`"
-msgstr ""
+msgstr "`NO_COLOR`"
 
 #: src/commands/index.md:54
-msgid "Directory Layout"
-msgstr ""
+msgid ""
+"Shell-session override; highest-priority version selector (set by `scoop "
+"shell`)"
+msgstr "셸 세션 오버라이드; 가장 높은 우선순위의 버전 선택자 (`scoop shell`로 설정)"
+
+#: src/commands/index.md:55
+msgid ""
+"Name of the currently active environment (set by the activation script; read"
+" by `status`/`which`/`run`)"
+msgstr "현재 활성 환경의 이름 (활성화 스크립트로 설정; `status`/`which`/`run`에서 참조)"
 
 #: src/commands/index.md:56
+msgid ""
+"Caps the parent-directory walk when resolving `.scoop-version` (0 = current "
+"dir only; unset = unlimited)"
+msgstr "`.scoop-version` 탐색 시 부모 디렉터리 탐색 횟수 제한 (0 = 현재 디렉터리만; 미설정 = 무제한)"
+
+#: src/commands/index.md:58
+msgid "Directory Layout"
+msgstr "디렉터리 구조"
+
+#: src/commands/index.md:60
 msgid "Location"
-msgstr ""
+msgstr "위치"
 
-#: src/commands/index.md:56 src/development/architecture.md:81
-#: src/development/architecture.md:315
+#: src/commands/index.md:60 src/development/architecture.md:85
+#: src/development/architecture.md:319
 msgid "Purpose"
-msgstr ""
+msgstr "용도"
 
-#: src/commands/index.md:58
+#: src/commands/index.md:62
 msgid "`~/.scoop/virtualenvs/`"
-msgstr ""
+msgstr "`~/.scoop/virtualenvs/`"
 
-#: src/commands/index.md:58
+#: src/commands/index.md:62
 msgid "Virtual environments storage"
-msgstr ""
+msgstr "가상 환경 저장소"
 
-#: src/commands/index.md:59
+#: src/commands/index.md:63
 msgid "`~/.scoop/version`"
-msgstr ""
+msgstr "`~/.scoop/version`"
 
-#: src/commands/index.md:59
+#: src/commands/index.md:63
 msgid "Global default environment"
-msgstr ""
+msgstr "전역 기본 환경"
 
-#: src/commands/index.md:60
+#: src/commands/index.md:64
 msgid "`.scoop-version`"
-msgstr ""
+msgstr "`.scoop-version`"
 
-#: src/commands/index.md:60
+#: src/commands/index.md:64
 msgid "Local environment preference"
-msgstr ""
+msgstr "로컬 환경 설정"
 
-#: src/commands/index.md:61
+#: src/commands/index.md:65
 msgid "`.venv`"
-msgstr ""
+msgstr "`.venv`"
 
-#: src/commands/index.md:61
+#: src/commands/index.md:65
 msgid "Symlink to active environment (with `--link`)"
-msgstr ""
+msgstr "활성 환경에 대한 심볼릭 링크 (`--link` 사용 시)"
 
 #: src/commands/list.md:3
 msgid "List all virtual environments or installed Python versions."
-msgstr ""
+msgstr "모든 가상 환경 또는 설치된 Python 버전을 나열합니다."
 
 #: src/commands/list.md:5
 msgid "**Aliases:** `ls`"
-msgstr ""
+msgstr "**별칭:** `ls`"
 
 #: src/commands/list.md:7 src/commands/create.md:5 src/commands/use.md:5
 #: src/commands/remove.md:7 src/commands/install.md:5
@@ -2634,1233 +2728,1283 @@ msgstr ""
 #: src/commands/sync.md:6 src/commands/export.md:6 src/commands/import.md:5
 #: src/commands/clone.md:6 src/commands/migrate.md:5 src/commands/gc.md:5
 #: src/commands/prune.md:5 src/commands/verify.md:5 src/commands/diff.md:8
-#: src/commands/lang.md:5 src/commands/init.md:5 src/commands/shell.md:7
-#: src/commands/completions.md:5 src/commands/man.md:5
+#: src/commands/lang.md:5 src/commands/self.md:5 src/commands/init.md:5
+#: src/commands/shell.md:7 src/commands/completions.md:5 src/commands/man.md:5
 #: src/development/code-quality.md:180
 msgid "Usage"
-msgstr ""
+msgstr "사용법"
 
 #: src/commands/list.md:13 src/commands/create.md:18 src/commands/use.md:19
 #: src/commands/remove.md:19 src/commands/install.md:17
 #: src/commands/uninstall.md:17 src/commands/doctor.md:11
 #: src/commands/info.md:20 src/commands/which.md:18 src/commands/sync.md:12
-#: src/commands/export.md:18 src/commands/import.md:18 src/commands/clone.md:19
-#: src/commands/migrate.md:34 src/commands/gc.md:75 src/commands/prune.md:19
-#: src/commands/diff.md:33 src/commands/lang.md:27 src/commands/shell.md:25
-#: src/commands/man.md:24
+#: src/commands/export.md:18 src/commands/import.md:18
+#: src/commands/clone.md:19 src/commands/migrate.md:34 src/commands/gc.md:75
+#: src/commands/prune.md:19 src/commands/diff.md:33 src/commands/lang.md:27
+#: src/commands/self.md:11 src/commands/shell.md:25 src/commands/man.md:24
 msgid "Options"
-msgstr ""
+msgstr "옵션"
 
 #: src/commands/list.md:17
 msgid "`--pythons`"
-msgstr ""
+msgstr "`--pythons`"
 
 #: src/commands/list.md:17
 msgid "Show Python versions instead of virtualenvs"
-msgstr ""
+msgstr "가상 환경 대신 Python 버전 표시"
 
 #: src/commands/list.md:18
 msgid "`--python-version <VERSION>`"
-msgstr ""
+msgstr "`--python-version <VERSION>`"
 
 #: src/commands/list.md:18
 msgid "Filter environments by Python version (e.g., `3.12`)"
-msgstr ""
+msgstr "Python 버전으로 환경 필터링 (예: `3.12`)"
 
 #: src/commands/list.md:19
 msgid "`--sort <MODE>`"
-msgstr ""
+msgstr "`--sort <MODE>`"
 
 #: src/commands/list.md:19
 msgid "Sort order: `name` (default), `created`, `last-used`"
-msgstr ""
+msgstr "정렬 순서: `name` (기본값), `created`, `last-used`"
 
 #: src/commands/list.md:20
 msgid "`--bare`"
-msgstr ""
+msgstr "`--bare`"
 
 #: src/commands/list.md:20
-msgid "Output names only (for scripting)"
-msgstr ""
+msgid "Output names only (for scripting); hidden from `--help`"
+msgstr "이름만 출력 (스크립팅용); `--help`에서 숨겨짐"
 
-#: src/commands/list.md:21 src/commands/doctor.md:16 src/commands/info.md:26
-#: src/commands/which.md:23 src/commands/sync.md:18 src/commands/import.md:24
-#: src/commands/clone.md:25 src/commands/migrate.md:39 src/commands/gc.md:82
-#: src/commands/prune.md:23 src/commands/diff.md:37 src/commands/lang.md:33
+#: src/commands/list.md:21 src/commands/create.md:25 src/commands/use.md:27
+#: src/commands/remove.md:24 src/commands/install.md:23
+#: src/commands/uninstall.md:23 src/commands/doctor.md:16
+#: src/commands/info.md:26 src/commands/which.md:23 src/commands/sync.md:18
+#: src/commands/import.md:24 src/commands/clone.md:25
+#: src/commands/migrate.md:39 src/commands/gc.md:82 src/commands/prune.md:23
+#: src/commands/diff.md:37 src/commands/lang.md:33 src/commands/self.md:18
 #: src/commands/man.md:28
 msgid "`--json`"
-msgstr ""
+msgstr "`--json`"
 
 #: src/commands/list.md:21 src/commands/info.md:26 src/commands/which.md:23
 #: src/commands/sync.md:18 src/commands/import.md:24 src/commands/clone.md:25
 #: src/commands/gc.md:82 src/commands/lang.md:33
 msgid "Output as JSON"
-msgstr ""
+msgstr "JSON 형식으로 출력"
 
 #: src/commands/list.md:23
 msgid "Sort"
-msgstr ""
+msgstr "정렬"
 
 #: src/commands/list.md:25
 msgid "`--sort` reorders the output without changing what's shown:"
-msgstr ""
+msgstr "`--sort`는 표시 항목을 변경하지 않고 출력 순서만 바꿉니다:"
 
 #: src/commands/list.md:27
 msgid "Mode"
-msgstr ""
+msgstr "모드"
 
 #: src/commands/list.md:27
 msgid "Order"
-msgstr ""
+msgstr "정렬 기준"
 
 #: src/commands/list.md:27
 msgid "Tie-break"
-msgstr ""
+msgstr "동점 처리"
 
 #: src/commands/list.md:29 src/commands/create.md:15 src/commands/use.md:17
 #: src/commands/remove.md:17 src/commands/info.md:18 src/commands/export.md:16
 #: src/commands/shell.md:23
 msgid "`name`"
-msgstr ""
+msgstr "`name`"
 
 #: src/commands/list.md:29
 msgid "Alphabetical (default, back-compat)"
-msgstr ""
+msgstr "알파벳 순 (기본값, 하위 호환)"
 
 #: src/commands/list.md:29 src/api.md:711 src/api.md:712 src/api.md:713
 #: src/api.md:714 src/api.md:715
 msgid "—"
-msgstr ""
+msgstr "—"
 
 #: src/commands/list.md:30
 msgid "`created`"
-msgstr ""
+msgstr "`created`"
 
 #: src/commands/list.md:30
 msgid "Newest `created_at` first"
-msgstr ""
+msgstr "가장 최근 `created_at` 먼저"
 
 #: src/commands/list.md:30 src/commands/list.md:31
 msgid "Name (asc)"
-msgstr ""
+msgstr "이름 (오름차순)"
 
 #: src/commands/list.md:31
 msgid "`last-used`"
-msgstr ""
+msgstr "`last-used`"
 
 #: src/commands/list.md:31
 msgid "Most recently activated first"
-msgstr ""
+msgstr "가장 최근 활성화된 항목 먼저"
 
 #: src/commands/list.md:33
 msgid ""
-"Envs missing the relevant timestamp (`created_at` / `last_used`) sort to the "
-"**end** of the list, with name-order tie-break — so legacy or never-"
+"Envs missing the relevant timestamp (`created_at` / `last_used`) sort to the"
+" **end** of the list, with name-order tie-break — so legacy or never-"
 "activated envs don't bury the interesting ones. `last_used` populates when "
 "an env is actually activated: `scoop activate`, shell-hook auto-activation "
 "triggered by `scoop use`, `scoop run`, or `scoop shell`. `scoop use` on its "
 "own only writes the version file and does not touch metadata; the touch "
 "fires when the shell wrapper sources the activate script afterwards."
 msgstr ""
+"관련 타임스탬프(`created_at` / `last_used`)가 없는 환경은 목록의 **끝**으로 정렬되며, 동점 시에는 이름 순으로"
+" 처리됩니다 — 레거시 환경이나 한 번도 활성화되지 않은 환경이 중요한 항목을 가리지 않도록 하기 위함입니다. `last_used`는 "
+"환경이 실제로 활성화될 때 채워집니다: `scoop activate`, `scoop use`·`scoop run`·`scoop "
+"shell`로 트리거되는 셸 훅 자동 활성화가 이에 해당합니다. `scoop use` 단독 실행은 버전 파일만 기록할 뿐 메타데이터는 "
+"건드리지 않습니다; 타임스탬프는 셸 래퍼가 이후 활성화 스크립트를 소싱할 때 기록됩니다."
 
 #: src/commands/list.md:42
 msgid ""
 "`--sort` is mutually exclusive with `--pythons` (which lists Python "
 "installations, not environments)."
 msgstr ""
+"`--sort`와 `--pythons`는 함께 사용할 수 없습니다 (후자는 환경이 아닌 Python 설치 목록을 나열합니다)."
 
 #: src/commands/list.md:48
 msgid "# List all virtualenvs\n"
-msgstr ""
+msgstr "# 모든 가상 환경 나열\n"
 
 #: src/commands/list.md:49
 msgid "# List installed Python versions\n"
-msgstr ""
+msgstr "# 설치된 Python 버전 나열\n"
 
 #: src/commands/list.md:50
 msgid "# Names only, one per line\n"
-msgstr ""
+msgstr "# 이름만, 한 줄에 하나씩\n"
 
 #: src/commands/list.md:51
 msgid "# JSON output\n"
-msgstr ""
+msgstr "# JSON 출력\n"
 
 #: src/commands/list.md:52
 msgid "# Filter by Python version\n"
-msgstr ""
+msgstr "# Python 버전으로 필터링\n"
 
 #: src/commands/list.md:54
 msgid "# Show only 3.12.x environments\n"
-msgstr ""
+msgstr "# 3.12.x 환경만 표시\n"
 
 #: src/commands/list.md:55
 msgid "# Show all Python 3.x environments\n"
-msgstr ""
+msgstr "# 모든 Python 3.x 환경 표시\n"
 
 #: src/commands/list.md:56
 msgid "# Exact version match\n"
-msgstr ""
+msgstr "# 정확한 버전 일치\n"
 
 #: src/commands/list.md:57
 msgid "# Sort\n"
-msgstr ""
+msgstr "# 정렬\n"
 
 #: src/commands/list.md:59
 msgid "# Newest envs first\n"
-msgstr ""
+msgstr "# 최신 환경 먼저\n"
 
 #: src/commands/list.md:60
 msgid "# Recently active envs first\n"
-msgstr ""
+msgstr "# 최근 활성화된 환경 먼저\n"
 
 #: src/commands/list.md:63
 msgid "List Python Versions with Associated Environments"
-msgstr ""
+msgstr "Python 버전과 연결된 환경 나열"
 
 #: src/commands/list.md:65
 msgid "Use this workflow to see both sides of the mapping:"
-msgstr ""
+msgstr "이 워크플로를 사용하면 매핑의 양쪽을 모두 확인할 수 있습니다:"
 
 #: src/commands/list.md:68
 msgid "# 1) List installed Python versions managed by scoop/uv\n"
-msgstr ""
+msgstr "# 1) scoop/uv가 관리하는 설치된 Python 버전 나열\n"
 
 #: src/commands/list.md:70
 msgid "# 2) List all virtual environments with their Python versions\n"
-msgstr ""
+msgstr "# 2) 모든 가상 환경과 해당 Python 버전 나열\n"
 
 #: src/commands/list.md:73
 msgid "# 3) Show environments associated with a specific Python version\n"
-msgstr ""
+msgstr "# 3) 특정 Python 버전에 연결된 환경 표시\n"
 
 #: src/commands/list.md:78
 msgid "For scripting, combine `--bare` with per-version filtering:"
-msgstr ""
+msgstr "스크립팅 시에는 `--bare`와 버전별 필터링을 함께 사용하세요:"
 
 #: src/commands/list.md:87
 msgid "You can also use `--json` for machine-readable output:"
-msgstr ""
+msgstr "머신 판독 가능한 출력이 필요할 때는 `--json`을 사용할 수도 있습니다:"
 
 #: src/commands/list.md:94
 msgid "Version Filtering"
-msgstr ""
+msgstr "버전 필터링"
 
 #: src/commands/list.md:96
 msgid ""
 "The `--python-version` option uses prefix matching to filter environments:"
-msgstr ""
+msgstr "`--python-version` 옵션은 접두사 매칭으로 환경을 필터링합니다:"
 
-#: src/commands/list.md:99 src/commands/remove.md:39
-#: src/commands/uninstall.md:112 src/commands/uninstall.md:159
+#: src/commands/list.md:99 src/commands/remove.md:40
+#: src/commands/uninstall.md:113 src/commands/uninstall.md:160
 #: src/commands/doctor.md:49 src/commands/doctor.md:58
 msgid "# Output:\n"
-msgstr ""
+msgstr "# 출력:\n"
 
 #: src/commands/list.md:101
 msgid "#   webapp         3.12.0\n"
-msgstr ""
+msgstr "#   webapp         3.12.0\n"
 
 #: src/commands/list.md:106
 msgid ""
 "This is useful for identifying environments before uninstalling a Python "
 "version:"
-msgstr ""
+msgstr "Python 버전을 제거하기 전에 환경을 확인할 때 유용합니다:"
 
 #: src/commands/list.md:109
 msgid "# See which environments will be affected\n"
-msgstr ""
+msgstr "# 영향받을 환경 확인\n"
 
 #: src/commands/list.md:111
 msgid "# Then uninstall with cascade\n"
-msgstr ""
+msgstr "# 이후 cascade로 제거\n"
 
 #: src/commands/list.md:116
 msgid ""
 "**Note:** `--python-version` cannot be combined with `--pythons` (which "
 "lists Python installations, not environments)."
 msgstr ""
+"**참고:** `--python-version`은 `--pythons`와 함께 사용할 수 없습니다 (후자는 환경이 아닌 Python 설치"
+" 목록을 나열합니다)."
 
 #: src/commands/list.md:118
 msgid "Empty Results"
-msgstr ""
+msgstr "결과 없음"
 
 #: src/commands/list.md:120
 msgid ""
-"If no Python versions are installed, `scoop list --pythons` shows no entries."
-msgstr ""
+"If no Python versions are installed, `scoop list --pythons` shows no "
+"entries."
+msgstr "Python 버전이 설치되어 있지 않으면 `scoop list --pythons`는 항목을 표시하지 않습니다."
 
 #: src/commands/list.md:121
 msgid "If no environments exist, `scoop list` shows no entries."
-msgstr ""
+msgstr "환경이 없으면 `scoop list`는 항목을 표시하지 않습니다."
 
 #: src/commands/list.md:122
 msgid ""
 "If no environments match a filter, `scoop list --python-version <VERSION>` "
 "shows no entries."
 msgstr ""
+"필터와 일치하는 환경이 없으면 `scoop list --python-version <VERSION>`은 항목을 표시하지 않습니다."
 
 #: src/commands/create.md:3
 msgid "Create a new virtual environment."
-msgstr ""
+msgstr "새 가상 환경을 생성합니다."
 
 #: src/commands/create.md:11 src/commands/use.md:13 src/commands/remove.md:13
 #: src/commands/install.md:11 src/commands/uninstall.md:11
 #: src/commands/info.md:14 src/commands/which.md:12 src/commands/run.md:15
-#: src/commands/export.md:12 src/commands/import.md:12 src/commands/clone.md:12
-#: src/commands/lang.md:21 src/commands/init.md:11 src/commands/shell.md:19
-#: src/commands/completions.md:11 src/commands/man.md:18
+#: src/commands/export.md:12 src/commands/import.md:12
+#: src/commands/clone.md:12 src/commands/lang.md:21 src/commands/init.md:11
+#: src/commands/shell.md:19 src/commands/completions.md:11
+#: src/commands/man.md:18
 msgid "Arguments"
-msgstr ""
+msgstr "인수"
 
 #: src/commands/create.md:13 src/commands/use.md:15 src/commands/remove.md:15
 #: src/commands/install.md:13 src/commands/uninstall.md:13
 #: src/commands/info.md:16 src/commands/which.md:14 src/commands/run.md:17
-#: src/commands/export.md:14 src/commands/import.md:14 src/commands/clone.md:14
-#: src/commands/lang.md:23 src/commands/init.md:13 src/commands/shell.md:21
-#: src/commands/completions.md:13 src/commands/man.md:20
+#: src/commands/export.md:14 src/commands/import.md:14
+#: src/commands/clone.md:14 src/commands/lang.md:23 src/commands/init.md:13
+#: src/commands/shell.md:21 src/commands/completions.md:13
+#: src/commands/man.md:20
 msgid "Argument"
-msgstr ""
+msgstr "인수"
 
 #: src/commands/create.md:13 src/commands/use.md:15 src/commands/remove.md:15
 #: src/commands/install.md:13 src/commands/uninstall.md:13
 #: src/commands/info.md:16 src/commands/which.md:14 src/commands/run.md:17
-#: src/commands/export.md:14 src/commands/import.md:14 src/commands/clone.md:14
-#: src/commands/init.md:13 src/commands/shell.md:21
+#: src/commands/export.md:14 src/commands/import.md:14
+#: src/commands/clone.md:14 src/commands/init.md:13 src/commands/shell.md:21
 #: src/commands/completions.md:13
 msgid "Required"
-msgstr ""
+msgstr "필수 여부"
 
 #: src/commands/create.md:15 src/commands/remove.md:17
 #: src/commands/uninstall.md:15 src/commands/info.md:18
 #: src/commands/which.md:16 src/commands/run.md:19 src/commands/run.md:20
-#: src/commands/export.md:16 src/commands/import.md:16 src/commands/clone.md:16
-#: src/commands/clone.md:17 src/commands/init.md:15
+#: src/commands/export.md:16 src/commands/import.md:16
+#: src/commands/clone.md:16 src/commands/clone.md:17 src/commands/init.md:15
 #: src/commands/completions.md:15
 msgid "Yes"
-msgstr ""
+msgstr "예"
 
 #: src/commands/create.md:15
 msgid "Name for the new virtualenv"
-msgstr ""
+msgstr "새 가상 환경의 이름"
 
 #: src/commands/create.md:16
 msgid "`python-version`"
-msgstr ""
+msgstr "`python-version`"
 
 #: src/commands/create.md:16 src/commands/use.md:17 src/commands/install.md:15
 #: src/commands/shell.md:23
 msgid "No"
-msgstr ""
+msgstr "아니오"
 
 #: src/commands/create.md:16
 msgid "`3` (latest)"
-msgstr ""
+msgstr "`3` (latest)"
 
 #: src/commands/create.md:16 src/commands/install.md:15
 msgid "Python version (e.g., `3.12`, `3.11.8`)"
-msgstr ""
+msgstr "Python 버전 (예: `3.12`, `3.11.8`)"
 
 #: src/commands/create.md:22 src/commands/remove.md:23
 #: src/commands/uninstall.md:22
 msgid "`--force`, `-f`"
-msgstr ""
+msgstr "`--force`, `-f`"
 
 #: src/commands/create.md:22
 msgid "Overwrite existing virtualenv"
-msgstr ""
+msgstr "기존 가상 환경 덮어쓰기"
 
 #: src/commands/create.md:23
 msgid "`--python-path <PATH>`"
-msgstr ""
+msgstr "`--python-path <PATH>`"
 
 #: src/commands/create.md:23
 msgid "Use a specific Python executable instead of version discovery"
-msgstr ""
+msgstr "버전 탐색 대신 특정 Python 실행 파일 사용"
 
 #: src/commands/create.md:24
 msgid "`--install-python`"
-msgstr ""
+msgstr "`--install-python`"
 
 #: src/commands/create.md:24
 msgid ""
 "Install the requested Python version first if it's not already available "
 "(conflicts with `--python-path`)"
-msgstr ""
+msgstr "요청한 Python 버전이 없으면 먼저 설치합니다 (`--python-path`와 충돌)"
 
-#: src/commands/create.md:29
-msgid "# Create with Python 3.12\n"
-msgstr ""
+#: src/commands/create.md:25 src/commands/use.md:27 src/commands/remove.md:24
+#: src/commands/install.md:23 src/commands/uninstall.md:23
+#: src/commands/self.md:18
+msgid "Output result as JSON"
+msgstr "결과를 JSON으로 출력"
 
 #: src/commands/create.md:30
-msgid "# Create with latest Python\n"
-msgstr ""
+msgid "# Create with Python 3.12\n"
+msgstr "# Python 3.12로 생성\n"
 
 #: src/commands/create.md:31
-msgid "# Overwrite if exists\n"
-msgstr ""
+msgid "# Create with latest Python\n"
+msgstr "# 최신 Python으로 생성\n"
 
 #: src/commands/create.md:32
+msgid "# Overwrite if exists\n"
+msgstr "# 이미 있으면 덮어쓰기\n"
+
+#: src/commands/create.md:33
 msgid "# Auto-install Python first if the version is missing\n"
-msgstr ""
+msgstr "# 버전이 없으면 Python 자동 설치 후 진행\n"
 
-#: src/commands/create.md:35
+#: src/commands/create.md:36
 msgid "# Use a specific Python executable\n"
-msgstr ""
+msgstr "# 특정 Python 실행 파일 사용\n"
 
-#: src/commands/create.md:41 src/llms.md:77
+#: src/commands/create.md:42 src/llms.md:79
 msgid "Create a Project Environment with Python 3.9.5"
-msgstr ""
+msgstr "Python 3.9.5로 프로젝트 환경 생성"
 
-#: src/commands/create.md:44
+#: src/commands/create.md:45
 msgid "# Install exact Python version (skip if already available)\n"
-msgstr ""
+msgstr "# 정확한 Python 버전 설치 (이미 있으면 건너뜀)\n"
 
-#: src/commands/create.md:46
+#: src/commands/create.md:47
 msgid "# Create a new project environment using that exact version\n"
-msgstr ""
+msgstr "# 해당 정확한 버전으로 새 프로젝트 환경 생성\n"
 
-#: src/commands/create.md:49
+#: src/commands/create.md:50
 msgid "# Verify the environment uses Python 3.9.5\n"
-msgstr ""
+msgstr "# 환경이 Python 3.9.5를 사용하는지 확인\n"
 
-#: src/commands/create.md:54
+#: src/commands/create.md:55
 msgid ""
 "If `3.9.5` is not available, install it first with `scoop install 3.9.5`, "
 "then check discovery with `uv python list` and `scoop list --pythons`."
 msgstr ""
+"`3.9.5`가 없으면 먼저 `scoop install 3.9.5`로 설치한 뒤, `uv python list`와 `scoop list "
+"--pythons`로 탐색 결과를 확인하세요."
 
-#: src/commands/create.md:57
+#: src/commands/create.md:58
 msgid "Python Version Resolution"
-msgstr ""
+msgstr "Python 버전 탐색"
 
-#: src/commands/create.md:59
+#: src/commands/create.md:60
 msgid ""
 "scoop delegates Python discovery to [uv](https://github.com/astral-sh/uv). "
 "The `python-version` argument is passed to `uv venv --python`, which "
 "searches for a match in:"
 msgstr ""
-
-#: src/commands/create.md:61
-msgid "uv-managed Python installations"
-msgstr ""
+"scoop는 Python 탐색을 [uv](https://github.com/astral-sh/uv)에 위임합니다. `python-"
+"version` 인수는 `uv venv --python`에 전달되며, 다음 위치에서 일치하는 버전을 검색합니다:"
 
 #: src/commands/create.md:62
-msgid "System Python on `PATH` (Homebrew, apt, pyenv, etc.)"
-msgstr ""
+msgid "uv-managed Python installations"
+msgstr "uv가 관리하는 Python 설치본"
 
 #: src/commands/create.md:63
+msgid "System Python on `PATH` (Homebrew, apt, pyenv, etc.)"
+msgstr "`PATH`의 시스템 Python (Homebrew, apt, pyenv 등)"
+
+#: src/commands/create.md:64
 msgid "Platform-specific locations (Windows only)"
-msgstr ""
+msgstr "플랫폼별 위치 (Windows 전용)"
 
-#: src/commands/create.md:66
+#: src/commands/create.md:67
 msgid "# Uses uv-managed Python 3.12 (if installed via scoop install)\n"
-msgstr ""
+msgstr "# uv가 관리하는 Python 3.12 사용 (scoop install로 설치한 경우)\n"
 
-#: src/commands/create.md:68
+#: src/commands/create.md:69
 msgid "# Also works with system Python — no scoop install needed\n"
-msgstr ""
+msgstr "# 시스템 Python에서도 동작 — scoop install 불필요\n"
 
-#: src/commands/create.md:72
+#: src/commands/create.md:73
 msgid "# Check what Python versions are available\n"
-msgstr ""
+msgstr "# 사용 가능한 Python 버전 확인\n"
 
-#: src/commands/create.md:78
+#: src/commands/create.md:79
 msgid ""
 "**Tip:** If the version isn't found, install it first with `scoop install "
 "3.12`. See [Python Management](../python-management.md) for custom Python "
 "paths."
 msgstr ""
+"**팁:** 버전을 찾을 수 없으면 먼저 `scoop install 3.12`로 설치하세요. 커스텀 Python 경로는 [Python "
+"관리](../python-management.md)를 참고하세요."
 
-#: src/commands/create.md:80
+#: src/commands/create.md:81
 msgid "Custom Python Executable"
-msgstr ""
+msgstr "커스텀 Python 실행 파일"
 
-#: src/commands/create.md:82
+#: src/commands/create.md:83
 msgid ""
 "Use `--python-path` to create a virtualenv with a specific Python binary. "
 "This is useful for:"
-msgstr ""
-
-#: src/commands/create.md:83
-msgid "Custom-built Python (debug builds, optimized builds)"
-msgstr ""
+msgstr "`--python-path`를 사용하면 특정 Python 바이너리로 가상 환경을 만들 수 있습니다. 다음 경우에 유용합니다:"
 
 #: src/commands/create.md:84
-msgid "Alternative interpreters (PyPy, GraalPy)"
-msgstr ""
+msgid "Custom-built Python (debug builds, optimized builds)"
+msgstr "커스텀 빌드 Python (디버그 빌드, 최적화 빌드)"
 
 #: src/commands/create.md:85
+msgid "Alternative interpreters (PyPy, GraalPy)"
+msgstr "대체 인터프리터 (PyPy, GraalPy)"
+
+#: src/commands/create.md:86
 msgid "Python installations in non-standard locations"
-msgstr ""
+msgstr "비표준 위치의 Python 설치본"
 
-#: src/commands/create.md:88
+#: src/commands/create.md:89
 msgid "# Debug build from source\n"
-msgstr ""
-
-#: src/commands/create.md:98
-msgid "The path must point to a valid, executable Python binary. scoop will:"
-msgstr ""
+msgstr "# 소스에서 빌드한 디버그 빌드\n"
 
 #: src/commands/create.md:99
-msgid "Validate the path (exists, is a file, is executable)"
-msgstr ""
+msgid "The path must point to a valid, executable Python binary. scoop will:"
+msgstr "경로는 유효하고 실행 가능한 Python 바이너리를 가리켜야 합니다. scoop는 다음을 수행합니다:"
 
 #: src/commands/create.md:100
-msgid "Auto-detect the Python version from the binary"
-msgstr ""
+msgid "Validate the path (exists, is a file, is executable)"
+msgstr "경로 유효성 검사 (존재 여부, 파일 여부, 실행 가능 여부)"
 
 #: src/commands/create.md:101
-msgid "Store the custom path in the environment's metadata"
-msgstr ""
+msgid "Auto-detect the Python version from the binary"
+msgstr "바이너리에서 Python 버전 자동 감지"
 
-#: src/commands/create.md:103
+#: src/commands/create.md:102
+msgid "Store the custom path in the environment's metadata"
+msgstr "커스텀 경로를 환경 메타데이터에 저장"
+
+#: src/commands/create.md:104
 msgid "You can verify the custom path with `scoop info`:"
-msgstr ""
+msgstr "`scoop info`로 커스텀 경로를 확인할 수 있습니다:"
 
 #: src/commands/use.md:3
 msgid "Set a virtual environment for the current directory and activate it."
-msgstr ""
+msgstr "현재 디렉터리의 가상 환경을 설정하고 활성화합니다."
 
 #: src/commands/use.md:17
 msgid "Name of the virtualenv, or `system` for system Python"
-msgstr ""
+msgstr "가상 환경 이름, 또는 시스템 Python을 사용하려면 `system`"
 
 #: src/commands/use.md:23 src/commands/shell.md:29
 msgid "`--unset`"
-msgstr ""
+msgstr "`--unset`"
 
 #: src/commands/use.md:23
 msgid "Remove version file (local or global)"
-msgstr ""
+msgstr "버전 파일 제거 (로컬 또는 전역)"
 
 #: src/commands/use.md:24
 msgid "`--global`, `-g`"
-msgstr ""
+msgstr "`--global`, `-g`"
 
 #: src/commands/use.md:24 src/llms.md:27
 msgid "Set as global default"
-msgstr ""
+msgstr "전역 기본값으로 설정"
 
 #: src/commands/use.md:25
 msgid "`--link`"
-msgstr ""
+msgstr "`--link`"
 
 #: src/commands/use.md:25
 msgid "Create `.venv` symlink for IDE compatibility"
-msgstr ""
+msgstr "IDE 호환성을 위한 `.venv` 심볼릭 링크 생성"
 
 #: src/commands/use.md:26
 msgid "`--no-link`"
-msgstr ""
+msgstr "`--no-link`"
 
 #: src/commands/use.md:26
 msgid "Do not create `.venv` symlink (default)"
-msgstr ""
+msgstr "`.venv` 심볼릭 링크를 생성하지 않음 (기본값)"
 
-#: src/commands/use.md:28 src/commands/shell.md:32
+#: src/commands/use.md:29 src/commands/self.md:20 src/commands/shell.md:32
 msgid "Behavior"
-msgstr ""
-
-#: src/commands/use.md:30
-msgid "Creates `.scoop-version` file in current directory"
-msgstr ""
+msgstr "동작"
 
 #: src/commands/use.md:31
-msgid "Immediately activates the environment (if shell hook installed)"
-msgstr ""
+msgid "Creates `.scoop-version` file in current directory"
+msgstr "현재 디렉터리에 `.scoop-version` 파일 생성"
 
 #: src/commands/use.md:32
-msgid "With `--global`: writes to `~/.scoop/version`"
-msgstr ""
+msgid "Immediately activates the environment (if shell hook installed)"
+msgstr "즉시 환경 활성화 (셸 훅이 설치된 경우)"
 
 #: src/commands/use.md:33
+msgid "With `--global`: writes to `~/.scoop/version`"
+msgstr "`--global` 사용 시: `~/.scoop/version`에 기록"
+
+#: src/commands/use.md:34
 msgid "With `--link`: creates `.venv -> ~/.scoop/virtualenvs/<name>`"
-msgstr ""
+msgstr "`--link` 사용 시: `.venv -> ~/.scoop/virtualenvs/<name>` 생성"
 
-#: src/commands/use.md:35
+#: src/commands/use.md:36
 msgid "Special Value: `system`"
-msgstr ""
+msgstr "특수 값: `system`"
 
-#: src/commands/use.md:37
+#: src/commands/use.md:38
 msgid "Using `system` as the name tells scoop to use the system Python:"
-msgstr ""
+msgstr "이름으로 `system`을 지정하면 scoop가 시스템 Python을 사용하도록 지시합니다:"
 
-#: src/commands/use.md:40 src/commands/use.md:68
+#: src/commands/use.md:41 src/commands/use.md:69
 msgid "# Use system Python in this directory\n"
-msgstr ""
+msgstr "# 이 디렉터리에서 시스템 Python 사용\n"
 
-#: src/commands/use.md:41
+#: src/commands/use.md:42
 msgid "# Use system Python as global default\n"
-msgstr ""
+msgstr "# 시스템 Python을 전역 기본값으로 설정\n"
 
-#: src/commands/use.md:44
+#: src/commands/use.md:45
 msgid ""
-"This writes the literal string `system` to the version file, which the shell "
-"hook interprets as \"deactivate any virtual environment.\""
-msgstr ""
+"This writes the literal string `system` to the version file, which the shell"
+" hook interprets as \"deactivate any virtual environment.\""
+msgstr "이렇게 하면 버전 파일에 리터럴 문자열 `system`이 기록되며, 셸 훅은 이를 \"모든 가상 환경을 비활성화\"로 해석합니다."
 
-#: src/commands/use.md:46
+#: src/commands/use.md:47
 msgid "The `--unset` Flag"
-msgstr ""
+msgstr "`--unset` 플래그"
 
-#: src/commands/use.md:48
+#: src/commands/use.md:49
 msgid "Removes the version file entirely:"
-msgstr ""
-
-#: src/commands/use.md:51
-msgid "# Delete .scoop-version in current directory\n"
-msgstr ""
+msgstr "버전 파일을 완전히 제거합니다:"
 
 #: src/commands/use.md:52
-msgid "# Delete ~/.scoop/version\n"
-msgstr ""
+msgid "# Delete .scoop-version in current directory\n"
+msgstr "# 현재 디렉터리의 .scoop-version 삭제\n"
 
-#: src/commands/use.md:55
+#: src/commands/use.md:53
+msgid "# Delete ~/.scoop/version\n"
+msgstr "# ~/.scoop/version 삭제\n"
+
+#: src/commands/use.md:56
 msgid ""
 "After unsetting, scoop falls back to the next priority level in version "
 "resolution."
-msgstr ""
+msgstr "해제 후, scoop는 버전 결정 시 다음 우선순위 단계로 폴백합니다."
 
-#: src/commands/use.md:60
+#: src/commands/use.md:61
 msgid "# Use a virtual environment in this directory\n"
-msgstr ""
+msgstr "# 이 디렉터리에서 가상 환경 사용\n"
 
-#: src/commands/use.md:62
+#: src/commands/use.md:63
 msgid "# Also create .venv symlink (for IDE support)\n"
-msgstr ""
+msgstr "# .venv 심볼릭 링크도 생성 (IDE 지원용)\n"
 
-#: src/commands/use.md:65
+#: src/commands/use.md:66
 msgid "# Set global default environment\n"
-msgstr ""
+msgstr "# 전역 기본 환경 설정\n"
 
-#: src/commands/use.md:71
+#: src/commands/use.md:72
 msgid "# Use system Python globally\n"
-msgstr ""
+msgstr "# 전역으로 시스템 Python 사용\n"
 
-#: src/commands/use.md:74
+#: src/commands/use.md:75
 msgid "# Remove local version setting\n"
-msgstr ""
+msgstr "# 로컬 버전 설정 제거\n"
 
-#: src/commands/use.md:77
+#: src/commands/use.md:78
 msgid "# Remove global version setting\n"
-msgstr ""
+msgstr "# 전역 버전 설정 제거\n"
 
-#: src/commands/use.md:82
+#: src/commands/use.md:83
 msgid "Set Python 3.11.0 as Global Default"
-msgstr ""
+msgstr "Python 3.11.0을 전역 기본값으로 설정"
 
-#: src/commands/use.md:84
+#: src/commands/use.md:85
 msgid ""
 "`--global` stores an environment name, not a raw Python version string. "
-"Create an environment with Python 3.11.0, then set that environment globally:"
+"Create an environment with Python 3.11.0, then set that environment "
+"globally:"
 msgstr ""
+"`--global`은 원시 Python 버전 문자열이 아닌 환경 이름을 저장합니다. Python 3.11.0으로 환경을 만든 뒤, 해당 "
+"환경을 전역으로 설정하세요:"
 
-#: src/commands/use.md:93
+#: src/commands/use.md:94
 msgid ""
 "This writes `py311` to `~/.scoop/version`, which is used in new shell "
 "sessions and directories that do not have a local `.scoop-version`."
 msgstr ""
+"이렇게 하면 `~/.scoop/version`에 `py311`이 기록되며, 로컬 `.scoop-version`이 없는 새 셸 세션과 "
+"디렉터리에서 사용됩니다."
 
-#: src/commands/use.md:96
+#: src/commands/use.md:97
 msgid ""
 "If a local `.scoop-version` file or `SCOOP_VERSION` environment variable is "
 "present, it takes precedence over the global setting."
-msgstr ""
+msgstr "로컬 `.scoop-version` 파일이나 `SCOOP_VERSION` 환경 변수가 있으면 전역 설정보다 우선합니다."
 
-#: src/commands/use.md:99
+#: src/commands/use.md:100
 msgid "Version File Format"
-msgstr ""
-
-#: src/commands/use.md:101
-msgid "The `.scoop-version` file contains a single line with either:"
-msgstr ""
+msgstr "버전 파일 형식"
 
 #: src/commands/use.md:102
-msgid "An environment name (e.g., `myproject`)"
-msgstr ""
+msgid "The `.scoop-version` file contains a single line with either:"
+msgstr "`.scoop-version` 파일은 다음 중 하나를 담은 한 줄로 이루어집니다:"
 
 #: src/commands/use.md:103
+msgid "An environment name (e.g., `myproject`)"
+msgstr "환경 이름 (예: `myproject`)"
+
+#: src/commands/use.md:104
 msgid "The literal string `system`"
-msgstr ""
+msgstr "리터럴 문자열 `system`"
 
 #: src/commands/remove.md:3
 msgid "Remove a virtual environment."
-msgstr ""
+msgstr "가상 환경을 제거합니다."
 
 #: src/commands/remove.md:5
 msgid "**Aliases:** `rm`, `delete`"
-msgstr ""
+msgstr "**별칭:** `rm`, `delete`"
 
 #: src/commands/remove.md:17
 msgid "Name of the virtualenv to remove"
-msgstr ""
+msgstr "제거할 가상 환경의 이름"
 
 #: src/commands/remove.md:23
 msgid "Skip confirmation prompt"
-msgstr ""
-
-#: src/commands/remove.md:28
-msgid "# Remove with confirmation\n"
-msgstr ""
+msgstr "확인 프롬프트 건너뜀"
 
 #: src/commands/remove.md:29
-msgid "# Remove without asking\n"
-msgstr ""
+msgid "# Remove with confirmation\n"
+msgstr "# 확인 후 제거\n"
 
 #: src/commands/remove.md:30
+msgid "# Remove without asking\n"
+msgstr "# 확인 없이 제거\n"
+
+#: src/commands/remove.md:31
 msgid "# Using alias\n"
-msgstr ""
+msgstr "# 별칭 사용\n"
 
-#: src/commands/remove.md:33
+#: src/commands/remove.md:34
 msgid "Check Before Removing"
-msgstr ""
+msgstr "제거 전 확인"
 
-#: src/commands/remove.md:35
+#: src/commands/remove.md:36
 msgid "To see details about an environment before removing it:"
-msgstr ""
+msgstr "환경을 제거하기 전에 상세 정보를 확인하려면:"
 
-#: src/commands/remove.md:38
+#: src/commands/remove.md:39
 msgid "# Show environment details (Python version, path, packages)\n"
-msgstr ""
+msgstr "# 환경 상세 정보 표시 (Python 버전, 경로, 패키지)\n"
 
-#: src/commands/remove.md:41
+#: src/commands/remove.md:42
 msgid "#   Python:  3.12.1\n"
-msgstr ""
+msgstr "#   Python:  3.12.1\n"
 
-#: src/commands/remove.md:46
+#: src/commands/remove.md:47
 msgid "Removing All Environments for a Python Version"
-msgstr ""
+msgstr "Python 버전에 해당하는 모든 환경 제거"
 
-#: src/commands/remove.md:48
+#: src/commands/remove.md:49
 msgid "To remove all environments that use a specific Python version:"
-msgstr ""
+msgstr "특정 Python 버전을 사용하는 모든 환경을 제거하려면:"
 
-#: src/commands/remove.md:51
+#: src/commands/remove.md:52
 msgid "# List environments to identify which use Python 3.12\n"
-msgstr ""
+msgstr "# Python 3.12를 사용하는 환경 파악을 위한 목록 확인\n"
 
-#: src/commands/remove.md:54
+#: src/commands/remove.md:55
 msgid "#   ml-env         3.11.8\n"
-msgstr ""
+msgstr "#   ml-env         3.11.8\n"
 
-#: src/commands/remove.md:56
+#: src/commands/remove.md:57
 msgid "# Remove each one\n"
-msgstr ""
+msgstr "# 각각 제거\n"
 
-#: src/commands/remove.md:60
+#: src/commands/remove.md:61
 msgid "# Then optionally uninstall the Python version itself\n"
-msgstr ""
+msgstr "# 이후 필요하면 Python 버전 자체도 제거\n"
 
-#: src/commands/remove.md:65
+#: src/commands/remove.md:66
 msgid ""
-"**See also:** [uninstall command](uninstall.md) for the complete workflow to "
-"uninstall a Python version and clean up associated environments."
+"**See also:** [uninstall command](uninstall.md) for the complete workflow to"
+" uninstall a Python version and clean up associated environments."
 msgstr ""
+"**관련 항목:** Python 버전 제거 및 관련 환경 정리를 위한 전체 워크플로는 [uninstall "
+"명령](uninstall.md)을 참고하세요."
 
 #: src/commands/install.md:3
 msgid "Install a Python version."
-msgstr ""
+msgstr "Python 버전을 설치합니다."
 
 #: src/commands/install.md:15 src/commands/uninstall.md:15
-#: src/development/architecture.md:85
+#: src/development/architecture.md:89
 msgid "`version`"
-msgstr ""
+msgstr "`version`"
 
 #: src/commands/install.md:15
 msgid "latest"
-msgstr ""
+msgstr "최신"
 
 #: src/commands/install.md:21
 msgid "`--latest`"
-msgstr ""
+msgstr "`--latest`"
 
 #: src/commands/install.md:21
 msgid "Install latest stable Python (default)"
-msgstr ""
+msgstr "최신 안정 Python 설치 (기본값)"
 
 #: src/commands/install.md:22
 msgid "`--stable`"
-msgstr ""
+msgstr "`--stable`"
 
 #: src/commands/install.md:22
 msgid "Install oldest fully-supported Python (3.10)"
-msgstr ""
+msgstr "완전 지원되는 가장 오래된 Python 설치 (3.10)"
 
-#: src/commands/install.md:24
+#: src/commands/install.md:25
 msgid "Version Resolution"
-msgstr ""
-
-#: src/commands/install.md:26
-msgid "No argument or `--latest`: installs latest Python 3.x"
-msgstr ""
+msgstr "버전 탐색"
 
 #: src/commands/install.md:27
-msgid "`--stable`: installs Python 3.10 (oldest with active security support)"
-msgstr ""
+msgid "No argument or `--latest`: installs latest Python 3.x"
+msgstr "인수 없음 또는 `--latest`: 최신 Python 3.x 설치"
 
 #: src/commands/install.md:28
-msgid "`3.12`: installs latest 3.12.x patch"
-msgstr ""
+msgid "`--stable`: installs Python 3.10 (oldest with active security support)"
+msgstr "`--stable`: Python 3.10 설치 (활성 보안 지원이 있는 가장 오래된 버전)"
 
 #: src/commands/install.md:29
-msgid "`3.12.3`: installs exact version"
-msgstr ""
+msgid "`3.12`: installs latest 3.12.x patch"
+msgstr "`3.12`: 최신 3.12.x 패치 설치"
 
-#: src/commands/install.md:34
-msgid "# Install latest\n"
-msgstr ""
+#: src/commands/install.md:30
+msgid "`3.12.3`: installs exact version"
+msgstr "`3.12.3`: 정확한 버전 설치"
 
 #: src/commands/install.md:35
-msgid "# Same as above\n"
-msgstr ""
+msgid "# Install latest\n"
+msgstr "# 최신 버전 설치\n"
 
 #: src/commands/install.md:36
-msgid "# Install Python 3.10\n"
-msgstr ""
+msgid "# Same as above\n"
+msgstr "# 위와 동일\n"
 
 #: src/commands/install.md:37
-msgid "# Install latest 3.12.x\n"
-msgstr ""
+msgid "# Install Python 3.10\n"
+msgstr "# Python 3.10 설치\n"
 
 #: src/commands/install.md:38
+msgid "# Install latest 3.12.x\n"
+msgstr "# 최신 3.12.x 설치\n"
+
+#: src/commands/install.md:39
 msgid "# Install exact 3.12.3\n"
-msgstr ""
+msgstr "# 정확히 3.12.3 설치\n"
 
-#: src/commands/install.md:41
+#: src/commands/install.md:42
 msgid ""
-"**Note:** Python versions are managed by [uv](https://github.com/astral-sh/"
-"uv)."
-msgstr ""
+"**Note:** Python versions are managed by [uv](https://github.com/astral-"
+"sh/uv)."
+msgstr "**참고:** Python 버전은 [uv](https://github.com/astral-sh/uv)가 관리합니다."
 
-#: src/commands/install.md:43
+#: src/commands/install.md:44
 msgid "Python Discovery"
-msgstr ""
+msgstr "Python 탐색"
 
-#: src/commands/install.md:45
+#: src/commands/install.md:46
 msgid ""
 "You don't always need `scoop install`. When you run `scoop create`, uv "
 "searches for a matching Python in this order:"
 msgstr ""
-
-#: src/commands/install.md:47
-msgid "**uv-managed** — installed via `scoop install` or `uv python install`"
-msgstr ""
+"`scoop install`이 항상 필요한 것은 아닙니다. `scoop create`를 실행하면 uv가 다음 순서로 일치하는 "
+"Python을 검색합니다:"
 
 #: src/commands/install.md:48
-msgid "**System PATH** — Homebrew, apt, pyenv, or any Python on your `PATH`"
-msgstr ""
+msgid "**uv-managed** — installed via `scoop install` or `uv python install`"
+msgstr "**uv가 관리하는 버전** — `scoop install` 또는 `uv python install`로 설치"
 
 #: src/commands/install.md:49
+msgid "**System PATH** — Homebrew, apt, pyenv, or any Python on your `PATH`"
+msgstr "**시스템 PATH** — Homebrew, apt, pyenv 또는 `PATH`에 있는 모든 Python"
+
+#: src/commands/install.md:50
 msgid "**Platform-specific** — Windows registry, Microsoft Store"
-msgstr ""
+msgstr "**플랫폼 전용** — Windows 레지스트리, Microsoft Store"
 
-#: src/commands/install.md:52
+#: src/commands/install.md:53
 msgid "# See all Python versions uv can find\n"
-msgstr ""
+msgstr "# uv가 찾을 수 있는 모든 Python 버전 확인\n"
 
-#: src/commands/install.md:59
+#: src/commands/install.md:60
 msgid "# Use system Python directly — no scoop install needed\n"
-msgstr ""
+msgstr "# 시스템 Python 직접 사용 — scoop install 불필요\n"
 
-#: src/commands/install.md:64
+#: src/commands/install.md:65
 msgid ""
-"If the requested version isn't found anywhere, `scoop create` will fail with "
-"an error. Use `scoop install <version>` to download it first."
+"If the requested version isn't found anywhere, `scoop create` will fail with"
+" an error. Use `scoop install <version>` to download it first."
 msgstr ""
+"요청한 버전을 어디서도 찾을 수 없으면 `scoop create`가 오류와 함께 실패합니다. 먼저 `scoop install "
+"<version>`으로 다운로드하세요."
 
-#: src/commands/install.md:66
+#: src/commands/install.md:67
 msgid ""
-"**See also:** [Python Management](../python-management.md) for custom Python "
-"paths, environment variables, and migration."
+"**See also:** [Python Management](../python-management.md) for custom Python"
+" paths, environment variables, and migration."
 msgstr ""
+"**참고:** 사용자 지정 Python 경로, 환경 변수, 마이그레이션에 대한 자세한 내용은 [Python 관리](../python-"
+"management.md)를 참조하세요."
 
 #: src/commands/uninstall.md:3
 msgid "Remove an installed Python version."
-msgstr ""
+msgstr "설치된 Python 버전을 제거합니다."
 
 #: src/commands/uninstall.md:15
 msgid "Python version to remove"
-msgstr ""
+msgstr "제거할 Python 버전"
 
 #: src/commands/uninstall.md:21
 msgid "`--cascade`"
-msgstr ""
+msgstr "`--cascade`"
 
 #: src/commands/uninstall.md:21
 msgid "Also remove all virtual environments using this Python version"
-msgstr ""
+msgstr "이 Python 버전을 사용하는 모든 가상 환경도 함께 제거합니다"
 
 #: src/commands/uninstall.md:22
 msgid "Skip confirmation for cascade removal (requires `--cascade`)"
-msgstr ""
-
-#: src/commands/uninstall.md:27
-msgid "# Remove Python 3.12\n"
-msgstr ""
+msgstr "cascade 제거 시 확인 프롬프트를 건너뜁니다 (`--cascade` 필요)"
 
 #: src/commands/uninstall.md:28
-msgid "# Remove specific version\n"
-msgstr ""
+msgid "# Remove Python 3.12\n"
+msgstr "# Python 3.12 제거\n"
 
 #: src/commands/uninstall.md:29
+msgid "# Remove specific version\n"
+msgstr "# 특정 버전 제거\n"
+
+#: src/commands/uninstall.md:30
 msgid "# Remove Python and all environments using it\n"
-msgstr ""
+msgstr "# Python 및 이를 사용하는 모든 환경 제거\n"
 
-#: src/commands/uninstall.md:32
+#: src/commands/uninstall.md:33
 msgid "# Remove without confirmation prompt\n"
-msgstr ""
+msgstr "# 확인 프롬프트 없이 제거\n"
 
-#: src/commands/uninstall.md:37
+#: src/commands/uninstall.md:38
 msgid "Uninstall a Python Version and All Associated Environments"
-msgstr ""
+msgstr "Python 버전 및 관련 환경 모두 제거"
 
-#: src/commands/uninstall.md:39
+#: src/commands/uninstall.md:40
 msgid "Recommended workflow for a full cleanup:"
-msgstr ""
+msgstr "전체 정리를 위한 권장 워크플로우:"
 
-#: src/commands/uninstall.md:42
+#: src/commands/uninstall.md:43
 msgid "# 1) Optional: preview which environments would be removed\n"
-msgstr ""
+msgstr "# 1) 선택 사항: 제거될 환경 미리보기\n"
 
-#: src/commands/uninstall.md:44
+#: src/commands/uninstall.md:45
 msgid "# 2) Remove Python 3.12 and all environments using it\n"
-msgstr ""
+msgstr "# 2) Python 3.12 및 이를 사용하는 모든 환경 제거\n"
 
-#: src/commands/uninstall.md:53
+#: src/commands/uninstall.md:54
 msgid "For non-interactive scripts, skip the confirmation prompt:"
-msgstr ""
+msgstr "비대화형 스크립트의 경우 확인 프롬프트를 건너뜁니다:"
 
-#: src/commands/uninstall.md:59
-msgid "If the target version is not installed, check available versions first:"
-msgstr ""
-
-#: src/commands/uninstall.md:65
-msgid "Cascade Removal"
-msgstr ""
-
-#: src/commands/uninstall.md:67
+#: src/commands/uninstall.md:60
 msgid ""
-"The `--cascade` flag automatically removes all virtual environments that use "
-"the target Python version before uninstalling it. This replaces the manual "
+"If the target version is not installed, check available versions first:"
+msgstr "대상 버전이 설치되어 있지 않으면 먼저 사용 가능한 버전을 확인하세요:"
+
+#: src/commands/uninstall.md:66
+msgid "Cascade Removal"
+msgstr "Cascade 제거"
+
+#: src/commands/uninstall.md:68
+msgid ""
+"The `--cascade` flag automatically removes all virtual environments that use"
+" the target Python version before uninstalling it. This replaces the manual "
 "multi-step workflow."
 msgstr ""
+"`--cascade` 플래그는 대상 Python 버전을 제거하기 전에 해당 버전을 사용하는 모든 가상 환경을 자동으로 삭제합니다. 이를 "
+"통해 수동 다단계 워크플로우를 대체할 수 있습니다."
 
-#: src/commands/uninstall.md:70
+#: src/commands/uninstall.md:71
 msgid "# Finding environments using Python 3.12...\n"
-msgstr ""
+msgstr "# Python 3.12를 사용하는 환경 검색 중...\n"
 
-#: src/commands/uninstall.md:72
+#: src/commands/uninstall.md:73
 msgid "#   - myproject\n"
-msgstr ""
+msgstr "#   - myproject\n"
 
-#: src/commands/uninstall.md:74
+#: src/commands/uninstall.md:75
 msgid "# Remove these environments and uninstall Python 3.12? [y/N]\n"
-msgstr ""
+msgstr "# 이 환경들을 제거하고 Python 3.12를 삭제하시겠습니까? [y/N]\n"
 
-#: src/commands/uninstall.md:76
+#: src/commands/uninstall.md:77
 msgid "# Removing webapp...\n"
-msgstr ""
+msgstr "# webapp 제거 중...\n"
 
-#: src/commands/uninstall.md:78
+#: src/commands/uninstall.md:79
 msgid "# ✓ Python 3.12 uninstalled\n"
-msgstr ""
+msgstr "# ✓ Python 3.12 삭제 완료\n"
 
-#: src/commands/uninstall.md:82
+#: src/commands/uninstall.md:83
 msgid "With `--force`, the confirmation prompt is skipped:"
-msgstr ""
+msgstr "`--force`를 사용하면 확인 프롬프트가 건너뛰어집니다:"
 
-#: src/commands/uninstall.md:88
+#: src/commands/uninstall.md:89
 msgid "With `--json`, the output includes the list of removed environments:"
-msgstr ""
+msgstr "`--json`을 사용하면 출력에 제거된 환경 목록이 포함됩니다:"
 
-#: src/commands/uninstall.md:91
+#: src/commands/uninstall.md:92
 msgid "# {\n"
-msgstr ""
+msgstr "# {\n"
 
-#: src/commands/uninstall.md:93 src/commands/info.md:56
+#: src/commands/uninstall.md:94 src/commands/info.md:56
 #: src/commands/status.md:54 src/commands/status.md:55 src/commands/sync.md:97
 #: src/commands/import.md:59 src/commands/clone.md:56
 #: src/commands/migrate.md:175 src/commands/migrate.md:186
 #: src/commands/migrate.md:194 src/commands/migrate.md:220
-#: src/commands/migrate.md:258 src/commands/gc.md:109 src/commands/verify.md:67
-#: src/commands/verify.md:76 src/commands/verify.md:77
-#: src/commands/verify.md:78 src/commands/verify.md:79
-#: src/commands/verify.md:80 src/commands/verify.md:81 src/commands/diff.md:108
-#: src/commands/diff.md:142 src/commands/lang.md:90
+#: src/commands/migrate.md:258 src/commands/gc.md:109
+#: src/commands/verify.md:67 src/commands/verify.md:76
+#: src/commands/verify.md:77 src/commands/verify.md:78
+#: src/commands/verify.md:79 src/commands/verify.md:80
+#: src/commands/verify.md:81 src/commands/diff.md:108 src/commands/diff.md:142
+#: src/commands/lang.md:90 src/commands/self.md:48 src/commands/self.md:54
 msgid "\"status\""
-msgstr ""
+msgstr "\"status\""
 
-#: src/commands/uninstall.md:93 src/commands/info.md:56
+#: src/commands/uninstall.md:94 src/commands/info.md:56
 #: src/commands/status.md:54 src/commands/sync.md:97 src/commands/import.md:59
 #: src/commands/clone.md:56 src/commands/migrate.md:175
 #: src/commands/migrate.md:220 src/commands/migrate.md:238
-#: src/commands/migrate.md:286 src/commands/gc.md:109 src/commands/verify.md:67
-#: src/commands/diff.md:108 src/commands/lang.md:90
+#: src/commands/migrate.md:286 src/commands/gc.md:109
+#: src/commands/verify.md:67 src/commands/diff.md:108 src/commands/lang.md:90
+#: src/commands/self.md:48
 msgid "\"success\""
-msgstr ""
+msgstr "\"success\""
 
-#: src/commands/uninstall.md:93
+#: src/commands/uninstall.md:94
 msgid "#   \"command\": \"uninstall\",\n"
-msgstr ""
+msgstr "#   \"command\": \"uninstall\",\n"
 
-#: src/commands/uninstall.md:95 src/commands/info.md:58
+#: src/commands/uninstall.md:96 src/commands/info.md:58
 #: src/commands/status.md:56 src/commands/sync.md:99 src/commands/import.md:61
 #: src/commands/clone.md:58 src/commands/migrate.md:177
 #: src/commands/migrate.md:222 src/commands/migrate.md:266
 #: src/commands/gc.md:111 src/commands/verify.md:69 src/commands/diff.md:110
-#: src/commands/diff.md:151 src/commands/lang.md:91
+#: src/commands/diff.md:151 src/commands/lang.md:92 src/commands/self.md:50
 msgid "\"data\""
-msgstr ""
+msgstr "\"data\""
 
-#: src/commands/uninstall.md:95
+#: src/commands/uninstall.md:96
 msgid "#     \"version\": \"3.12\",\n"
-msgstr ""
+msgstr "#     \"version\": \"3.12\",\n"
 
-#: src/commands/uninstall.md:97
+#: src/commands/uninstall.md:98
 msgid "\"removed_envs\""
-msgstr ""
+msgstr "\"removed_envs\""
 
-#: src/commands/uninstall.md:97 src/commands/info.md:59
+#: src/commands/uninstall.md:98 src/commands/info.md:59
 #: src/commands/sync.md:101 src/commands/export.md:41
 #: src/commands/migrate.md:181 src/commands/migrate.md:225 src/api.md:155
 msgid "\"myproject\""
-msgstr ""
+msgstr "\"myproject\""
 
-#: src/commands/uninstall.md:97 src/commands/migrate.md:270
+#: src/commands/uninstall.md:98 src/commands/migrate.md:270
 #: src/commands/diff.md:111 src/commands/diff.md:147
 msgid "\"webapp\""
-msgstr ""
+msgstr "\"webapp\""
 
-#: src/commands/uninstall.md:97
+#: src/commands/uninstall.md:98
 msgid "#   }\n"
-msgstr ""
+msgstr "#   }\n"
 
-#: src/commands/uninstall.md:102
+#: src/commands/uninstall.md:103
 msgid ""
 "**Note:** Without `--cascade`, uninstalling a Python version does **not** "
 "remove virtual environments that were created with it. Those environments "
 "will become broken. Use `--cascade` to handle this automatically, or follow "
 "the manual workflow below."
 msgstr ""
+"**참고:** `--cascade` 없이 Python 버전을 제거하면 해당 버전으로 생성된 가상 환경이 **삭제되지 않습니다**. 해당 "
+"환경들은 손상된 상태가 됩니다. 자동으로 처리하려면 `--cascade`를 사용하거나 아래의 수동 워크플로우를 따르세요."
 
-#: src/commands/uninstall.md:104
+#: src/commands/uninstall.md:105
 msgid "Manual Uninstall Workflow"
-msgstr ""
+msgstr "수동 제거 워크플로우"
 
-#: src/commands/uninstall.md:108
+#: src/commands/uninstall.md:109
 msgid "Step 1: Identify affected environments"
-msgstr ""
+msgstr "1단계: 영향받는 환경 파악"
 
-#: src/commands/uninstall.md:111
+#: src/commands/uninstall.md:112
 msgid "# List environments filtered by Python version\n"
-msgstr ""
+msgstr "# Python 버전으로 필터링된 환경 목록 조회\n"
 
-#: src/commands/uninstall.md:114
+#: src/commands/uninstall.md:115
 msgid "#   webapp         3.12.1\n"
-msgstr ""
+msgstr "#   webapp         3.12.1\n"
 
-#: src/commands/uninstall.md:116
+#: src/commands/uninstall.md:117
 msgid "# Or use JSON for scripting\n"
-msgstr ""
+msgstr "# 또는 스크립팅에 JSON 사용\n"
 
-#: src/commands/uninstall.md:121
+#: src/commands/uninstall.md:122
 msgid "Step 2: Handle affected environments"
-msgstr ""
+msgstr "2단계: 영향받는 환경 처리"
 
-#: src/commands/uninstall.md:124
+#: src/commands/uninstall.md:125
 msgid "# Option A: Remove the environment entirely\n"
-msgstr ""
+msgstr "# 옵션 A: 환경 완전 제거\n"
 
-#: src/commands/uninstall.md:126
+#: src/commands/uninstall.md:127
 msgid "# Option B: Recreate with a different Python version\n"
-msgstr ""
+msgstr "# 옵션 B: 다른 Python 버전으로 재생성\n"
 
-#: src/commands/uninstall.md:130
+#: src/commands/uninstall.md:131
 msgid "# Option C: Keep it (will be broken until you reinstall that Python)\n"
-msgstr ""
+msgstr "# 옵션 C: 유지 (해당 Python을 재설치하기 전까지 손상된 상태)\n"
 
-#: src/commands/uninstall.md:135
+#: src/commands/uninstall.md:136
 msgid "Step 3: Uninstall the Python version"
-msgstr ""
+msgstr "3단계: Python 버전 제거"
 
-#: src/commands/uninstall.md:141
+#: src/commands/uninstall.md:142
 msgid "Step 4: Verify"
-msgstr ""
+msgstr "4단계: 확인"
 
-#: src/commands/uninstall.md:144
+#: src/commands/uninstall.md:145
 msgid "# Confirm Python is removed\n"
-msgstr ""
+msgstr "# Python이 제거됐는지 확인\n"
 
-#: src/commands/uninstall.md:148
+#: src/commands/uninstall.md:149
 msgid "# If any issues found:\n"
-msgstr ""
+msgstr "# 문제 발견 시:\n"
 
-#: src/commands/uninstall.md:153
+#: src/commands/uninstall.md:154
 msgid "Recovery"
-msgstr ""
+msgstr "복구"
 
-#: src/commands/uninstall.md:155
+#: src/commands/uninstall.md:156
 msgid ""
 "If you uninstalled a Python version without cleaning up environments first:"
-msgstr ""
+msgstr "환경을 먼저 정리하지 않고 Python 버전을 제거한 경우:"
 
-#: src/commands/uninstall.md:161 src/commands/doctor.md:53
+#: src/commands/uninstall.md:162 src/commands/doctor.md:53
 #: src/commands/doctor.md:60 src/commands/migrate.md:137
 msgid "'myproject'"
-msgstr ""
+msgstr "'myproject'"
 
-#: src/commands/uninstall.md:162
+#: src/commands/uninstall.md:163
 msgid "# Option 1: Reinstall the Python version\n"
-msgstr ""
+msgstr "# 옵션 1: Python 버전 재설치\n"
 
-#: src/commands/uninstall.md:166
+#: src/commands/uninstall.md:167
 msgid "# Option 2: Recreate affected environments with a new version\n"
-msgstr ""
+msgstr "# 옵션 2: 새 버전으로 영향받은 환경 재생성\n"
 
 #: src/commands/doctor.md:3
 msgid "Check scoop installation health and diagnose issues."
-msgstr ""
+msgstr "scoop 설치 상태를 점검하고 문제를 진단합니다."
 
 #: src/commands/doctor.md:15
 msgid "`-v`, `--verbose`"
-msgstr ""
+msgstr "`-v`, `--verbose`"
 
 #: src/commands/doctor.md:15
 msgid "Show more details (can repeat: `-vv`)"
-msgstr ""
+msgstr "더 자세한 정보 표시 (반복 가능: `-vv`)"
 
 #: src/commands/doctor.md:16
 msgid "Output diagnostics as JSON"
-msgstr ""
+msgstr "진단 결과를 JSON으로 출력합니다"
 
 #: src/commands/doctor.md:17
 msgid "`--fix`"
-msgstr ""
+msgstr "`--fix`"
 
 #: src/commands/doctor.md:17
 msgid "Auto-fix issues where possible"
-msgstr ""
+msgstr "가능한 경우 문제를 자동으로 수정합니다"
 
 #: src/commands/doctor.md:19
 msgid "Checks Performed"
-msgstr ""
+msgstr "수행되는 검사 항목"
 
 #: src/commands/doctor.md:21 src/commands/verify.md:18
 msgid "Check"
-msgstr ""
+msgstr "검사 항목"
 
 #: src/commands/doctor.md:21
 msgid "What it verifies"
-msgstr ""
+msgstr "검증 내용"
 
 #: src/commands/doctor.md:23
 msgid "**uv installation**"
-msgstr ""
+msgstr "**uv 설치**"
 
 #: src/commands/doctor.md:23
 msgid "uv is installed and accessible"
-msgstr ""
+msgstr "uv가 설치되어 있고 접근 가능한 상태"
 
 #: src/commands/doctor.md:24
 msgid "**Shell integration**"
-msgstr ""
+msgstr "**Shell 통합**"
 
 #: src/commands/doctor.md:24
 msgid "Shell hook is properly configured"
-msgstr ""
+msgstr "Shell hook이 올바르게 구성되어 있음"
 
 #: src/commands/doctor.md:25
 msgid "**Environment integrity**"
-msgstr ""
+msgstr "**환경 무결성**"
 
 #: src/commands/doctor.md:25
 msgid "Python symlinks are valid, `pyvenv.cfg` exists"
-msgstr ""
+msgstr "Python 심볼릭 링크가 유효하고 `pyvenv.cfg`가 존재함"
 
 #: src/commands/doctor.md:26
 msgid "**Path configuration**"
-msgstr ""
+msgstr "**경로 구성**"
 
 #: src/commands/doctor.md:26
 msgid "`~/.scoop/` directory structure is correct"
-msgstr ""
+msgstr "`~/.scoop/` 디렉터리 구조가 올바름"
 
 #: src/commands/doctor.md:27
 msgid "**Version file validity**"
-msgstr ""
+msgstr "**버전 파일 유효성**"
 
 #: src/commands/doctor.md:27
 msgid "`.scoop-version` files reference existing environments"
-msgstr ""
+msgstr "`.scoop-version` 파일이 존재하는 환경을 참조함"
 
 #: src/commands/doctor.md:32
 msgid "# Quick health check\n"
-msgstr ""
+msgstr "# 빠른 상태 점검\n"
 
 #: src/commands/doctor.md:33
 msgid "# Verbose diagnostics\n"
-msgstr ""
+msgstr "# 상세 진단\n"
 
 #: src/commands/doctor.md:34
 msgid "# Fix what can be fixed\n"
-msgstr ""
+msgstr "# 수정 가능한 항목 수정\n"
 
 #: src/commands/doctor.md:35
 msgid "# JSON output for scripting\n"
-msgstr ""
+msgstr "# 스크립팅을 위한 JSON 출력\n"
 
 #: src/commands/doctor.md:38
 msgid "Environment Integrity"
-msgstr ""
+msgstr "환경 무결성"
 
 #: src/commands/doctor.md:40
 msgid "The doctor checks each virtual environment for:"
-msgstr ""
+msgstr "doctor 명령은 각 가상 환경에 대해 다음 항목을 검사합니다:"
 
 #: src/commands/doctor.md:42
 msgid ""
 "**Python symlink** — Does the `python` binary in the environment point to a "
 "valid Python installation?"
-msgstr ""
+msgstr "**Python 심볼릭 링크** — 환경 내 `python` 바이너리가 유효한 Python 설치를 가리키고 있습니까?"
 
 #: src/commands/doctor.md:43
 msgid ""
 "**pyvenv.cfg** — Does the environment's configuration file exist and "
 "reference a valid Python?"
-msgstr ""
+msgstr "**pyvenv.cfg** — 환경의 설정 파일이 존재하고 유효한 Python을 참조하고 있습니까?"
 
 #: src/commands/doctor.md:45
 msgid ""
 "Environments can become broken when their underlying Python version is "
 "uninstalled. Use `scoop doctor` to detect these issues:"
 msgstr ""
+"기반 Python 버전이 제거되면 환경이 손상될 수 있습니다. `scoop doctor`를 사용하여 이러한 문제를 감지하세요:"
 
 #: src/commands/doctor.md:48
 msgid "# After accidentally uninstalling Python 3.12:\n"
-msgstr ""
+msgstr "# Python 3.12를 실수로 제거한 후:\n"
 
 #: src/commands/doctor.md:51
 msgid "#   ✓ Shell: zsh integration active\n"
-msgstr ""
+msgstr "#   ✓ Shell: zsh 통합 활성화됨\n"
 
 #: src/commands/doctor.md:53
 msgid "#   ⚠ Environment 'webapp': Python symlink broken\n"
-msgstr ""
+msgstr "#   ⚠ 환경 'webapp': Python 심볼릭 링크 손상됨\n"
 
 #: src/commands/doctor.md:55
 msgid "# Auto-fix by recreating symlinks (requires Python to be reinstalled)\n"
-msgstr ""
+msgstr "# 심볼릭 링크 재생성으로 자동 수정 (Python 재설치 필요)\n"
 
 #: src/commands/doctor.md:60
 msgid "#   ✓ Fixed 'webapp': Python symlink restored\n"
-msgstr ""
+msgstr "#   ✓ 'webapp' 수정됨: Python 심볼릭 링크 복원됨\n"
 
 #: src/commands/doctor.md:64
 msgid ""
 "**Tip:** Run `scoop doctor` periodically or after uninstalling Python "
-"versions to catch broken environments early. See [uninstall command]"
-"(uninstall.md) for the safe uninstall workflow."
+"versions to catch broken environments early. See [uninstall "
+"command](uninstall.md) for the safe uninstall workflow."
 msgstr ""
+"**팁:** `scoop doctor`를 주기적으로 실행하거나 Python 버전 제거 후 실행하여 손상된 환경을 조기에 감지하세요. "
+"안전한 제거 워크플로우는 [uninstall 명령어](uninstall.md)를 참조하세요."
 
 #: src/commands/info.md:3
 msgid ""
@@ -3868,55 +4012,62 @@ msgid ""
 "[`scoop status`](status.md). Reads metadata, walks the directory for size, "
 "and shells out to the venv's own `pip` for a package list."
 msgstr ""
+"가상 환경에 대한 상세 정보를 표시합니다 — [`scoop status`](status.md)보다 더 많은 정보를 제공합니다. "
+"메타데이터를 읽고, 디렉터리 크기를 탐색하며, 환경 자체의 `pip`를 호출하여 패키지 목록을 가져옵니다."
 
 #: src/commands/info.md:18 src/commands/run.md:19
 msgid "Name of the virtualenv"
-msgstr ""
+msgstr "virtualenv 이름"
 
 #: src/commands/info.md:24
 msgid "`--all-packages`"
-msgstr ""
+msgstr "`--all-packages`"
 
 #: src/commands/info.md:24
 msgid "Show the full installed-package list (default: top 5)"
-msgstr ""
+msgstr "설치된 패키지 전체 목록 표시 (기본값: 상위 5개)"
 
 #: src/commands/info.md:25
 msgid "`--no-size`"
-msgstr ""
+msgstr "`--no-size`"
 
 #: src/commands/info.md:25
 msgid "Skip the directory-size walk"
-msgstr ""
+msgstr "디렉터리 크기 탐색을 건너뜁니다"
 
 #: src/commands/info.md:28 src/commands/status.md:27
 msgid "Human Output"
-msgstr ""
+msgstr "사람이 읽는 출력"
 
 #: src/commands/info.md:43
 msgid ""
 "The `Last used:` row reads `never` for envs whose metadata exists but have "
-"never been activated (`scoop activate` / `scoop run` / `scoop shell` is what "
-"touches it), and is omitted entirely when there is no on-disk metadata at "
+"never been activated (`scoop activate` / `scoop run` / `scoop shell` is what"
+" touches it), and is omitted entirely when there is no on-disk metadata at "
 "all."
 msgstr ""
+"`Last used:` 행은 메타데이터가 있지만 한 번도 활성화되지 않은 환경(`scoop activate` / `scoop run` /"
+" `scoop shell`이 이 값을 갱신합니다)에 대해 `never`로 표시되며, 디스크에 메타데이터가 전혀 없는 경우에는 행 자체가 "
+"생략됩니다."
 
 #: src/commands/info.md:48 src/commands/status.md:50 src/commands/import.md:55
-#: src/commands/clone.md:52 src/commands/migrate.md:160 src/commands/lang.md:85
+#: src/commands/clone.md:52 src/commands/migrate.md:160
+#: src/commands/lang.md:85 src/commands/self.md:44
 msgid "JSON Output"
-msgstr ""
+msgstr "JSON 출력"
 
 #: src/commands/info.md:57 src/commands/status.md:55 src/commands/sync.md:98
 #: src/commands/import.md:60 src/commands/clone.md:57
 #: src/commands/migrate.md:176 src/commands/migrate.md:221
-#: src/commands/migrate.md:259 src/commands/gc.md:110 src/commands/verify.md:68
-#: src/commands/diff.md:109 src/commands/diff.md:143
+#: src/commands/migrate.md:259 src/commands/gc.md:110
+#: src/commands/verify.md:68 src/commands/diff.md:109 src/commands/diff.md:143
+#: src/commands/lang.md:91 src/commands/self.md:49
 msgid "\"command\""
-msgstr ""
+msgstr "\"command\""
 
 #: src/commands/info.md:57
 msgid "\"info\""
-msgstr ""
+msgstr "\"info\""
 
 #: src/commands/info.md:59 src/commands/info.md:67 src/commands/status.md:58
 #: src/commands/export.md:41 src/commands/export.md:46
@@ -3929,111 +4080,113 @@ msgstr ""
 #: src/commands/verify.md:77 src/commands/verify.md:78
 #: src/commands/verify.md:79 src/commands/verify.md:80
 #: src/commands/verify.md:81 src/commands/diff.md:116 src/commands/diff.md:117
-#: src/commands/diff.md:118 src/commands/lang.md:93 src/api.md:155
+#: src/commands/diff.md:118 src/commands/lang.md:94 src/api.md:155
 msgid "\"name\""
-msgstr ""
+msgstr "\"name\""
 
 #: src/commands/info.md:60 src/commands/status.md:61 src/commands/sync.md:102
-#: src/commands/export.md:42 src/commands/import.md:63 src/commands/clone.md:61
-#: src/commands/verify.md:74 src/commands/diff.md:114
+#: src/commands/export.md:42 src/commands/import.md:63
+#: src/commands/clone.md:61 src/commands/verify.md:74 src/commands/diff.md:114
 msgid "\"python\""
-msgstr ""
+msgstr "\"python\""
 
 #: src/commands/info.md:60 src/commands/status.md:61 src/api.md:156
 msgid "\"3.12.1\""
-msgstr ""
+msgstr "\"3.12.1\""
 
 #: src/commands/info.md:61 src/commands/status.md:60 src/commands/clone.md:62
 #: src/commands/migrate.md:183 src/commands/migrate.md:191
 #: src/commands/migrate.md:230 src/commands/gc.md:114 src/commands/gc.md:115
 #: src/commands/gc.md:116
 msgid "\"path\""
-msgstr ""
+msgstr "\"path\""
 
 #: src/commands/info.md:61
 msgid "\"/Users/me/.scoop/virtualenvs/myproject\""
-msgstr ""
+msgstr "\"/Users/me/.scoop/virtualenvs/myproject\""
 
 #: src/commands/info.md:62 src/commands/status.md:57
 msgid "\"active\""
-msgstr ""
+msgstr "\"active\""
 
 #: src/commands/info.md:63 src/commands/status.md:62 src/commands/export.md:43
 #: src/commands/diff.md:122 src/api.md:157
 msgid "\"created_at\""
-msgstr ""
+msgstr "\"created_at\""
 
 #: src/commands/info.md:63 src/commands/status.md:62 src/commands/export.md:43
 msgid "\"2026-05-29T12:34:56+00:00\""
-msgstr ""
+msgstr "\"2026-05-29T12:34:56+00:00\""
 
 #: src/commands/info.md:64 src/commands/status.md:63 src/commands/diff.md:123
 msgid "\"last_used\""
-msgstr ""
+msgstr "\"last_used\""
 
 #: src/commands/info.md:64 src/commands/status.md:63
 msgid "\"2026-06-02T09:00:00+00:00\""
-msgstr ""
+msgstr "\"2026-06-02T09:00:00+00:00\""
 
 #: src/commands/info.md:65 src/commands/migrate.md:185
 #: src/commands/migrate.md:193
 msgid "\"size_bytes\""
-msgstr ""
+msgstr "\"size_bytes\""
 
 #: src/commands/info.md:66
 msgid "\"size_display\""
-msgstr ""
+msgstr "\"size_display\""
 
 #: src/commands/info.md:66
 msgid "\"45 MB\""
-msgstr ""
+msgstr "\"45 MB\""
 
 #: src/commands/info.md:67 src/commands/sync.md:104 src/commands/export.md:45
 #: src/commands/diff.md:115
 msgid "\"packages\""
-msgstr ""
+msgstr "\"packages\""
 
 #: src/commands/info.md:67 src/commands/migrate.md:198
 #: src/commands/migrate.md:238 src/commands/migrate.md:286
 #: src/commands/verify.md:85
 msgid "\"total\""
-msgstr ""
+msgstr "\"total\""
 
 #: src/commands/info.md:67
 msgid "\"items\""
-msgstr ""
+msgstr "\"items\""
 
 #: src/commands/info.md:67 src/commands/diff.md:118
 msgid "\"requests\""
-msgstr ""
+msgstr "\"requests\""
 
 #: src/commands/info.md:67 src/commands/export.md:46 src/commands/export.md:47
 #: src/commands/migrate.md:195 src/commands/diff.md:116
 #: src/commands/diff.md:117
 msgid "\"version\""
-msgstr ""
+msgstr "\"version\""
 
 #: src/commands/info.md:67 src/commands/diff.md:118
 msgid "\"2.31.0\""
-msgstr ""
+msgstr "\"2.31.0\""
 
 #: src/commands/info.md:67
 msgid "\"truncated\""
-msgstr ""
+msgstr "\"truncated\""
 
 #: src/commands/info.md:72
 msgid ""
 "`last_used` (RFC 3339) is omitted when the env has never been activated. "
 "`size_bytes` / `size_display` are omitted under `--no-size`."
 msgstr ""
+"환경이 한 번도 활성화되지 않은 경우 `last_used` (RFC 3339)는 생략됩니다. `--no-size` 옵션 사용 시 "
+"`size_bytes` / `size_display`는 생략됩니다."
 
 #: src/commands/info.md:78
 msgid "# Default top-5 packages\n"
-msgstr ""
+msgstr "# 기본 상위 5개 패키지\n"
 
 #: src/commands/info.md:80
 msgid "# Skip directory-size walk\n"
-msgstr ""
+msgstr "# 디렉터리 크기 탐색 건너뛰기\n"
 
 #: src/commands/status.md:3
 msgid ""
@@ -4041,331 +4194,358 @@ msgid ""
 "package listing, no directory size walk). Use [`scoop info`](info.md) for "
 "the heavier per-env view."
 msgstr ""
+"현재 환경을 한 번에 요약합니다 — 빠른 실행을 위해 설계되었습니다(패키지 목록, 디렉터리 크기 탐색 없음). 더 상세한 환경별 보기는 "
+"[`scoop info`](info.md)를 사용하세요."
 
 #: src/commands/status.md:13
 msgid "States"
-msgstr ""
+msgstr "상태"
 
 #: src/commands/status.md:15
 msgid "`status` resolves to one of four states:"
-msgstr ""
+msgstr "`status`는 다음 네 가지 상태 중 하나로 결정됩니다:"
 
 #: src/commands/status.md:17 src/commands/sync.md:54
 msgid "State"
-msgstr ""
+msgstr "상태"
 
 #: src/commands/status.md:17 src/commands/migrate.md:306
 msgid "Trigger"
-msgstr ""
+msgstr "트리거"
 
 #: src/commands/status.md:19
 msgid "`active`"
-msgstr ""
+msgstr "`active`"
 
 #: src/commands/status.md:19
 msgid "`$SCOOP_ACTIVE` is set (shell-activated)"
-msgstr ""
+msgstr "`$SCOOP_ACTIVE`가 설정됨 (shell 활성화됨)"
 
 #: src/commands/status.md:20
 msgid "`configured`"
-msgstr ""
+msgstr "`configured`"
 
 #: src/commands/status.md:20
 msgid "A `.scoop-version` file or `~/.scoop/version` selects an env"
-msgstr ""
+msgstr "`.scoop-version` 파일 또는 `~/.scoop/version`으로 환경이 선택됨"
 
 #: src/commands/status.md:21
 msgid "`system`"
-msgstr ""
+msgstr "`system`"
 
 #: src/commands/status.md:21
 msgid "The configured env is the literal name `system`"
-msgstr ""
+msgstr "설정된 환경의 이름이 `system`인 경우"
 
 #: src/commands/status.md:22
 msgid "`none`"
-msgstr ""
+msgstr "`none`"
 
 #: src/commands/status.md:22
 msgid "Nothing resolved"
-msgstr ""
+msgstr "아무것도 결정되지 않음"
 
 #: src/commands/status.md:24
 msgid ""
 "`$SCOOP_ACTIVE` wins over version files because it reflects what the shell "
 "actually activated."
-msgstr ""
+msgstr "`$SCOOP_ACTIVE`는 shell이 실제로 활성화한 내용을 반영하므로 버전 파일보다 우선합니다."
 
 #: src/commands/status.md:29
 msgid "For a real env (`active` / `configured`):"
-msgstr ""
+msgstr "실제 환경(`active` / `configured`)의 경우:"
 
 #: src/commands/status.md:40
 msgid ""
 "The `Last used:` row reads `never` for envs that have metadata but have not "
 "yet been activated (fresh `scoop create`, or envs whose metadata predates "
-"the field). It's omitted entirely when there's no metadata at all — that way "
-"\"we don't know\" doesn't get conflated with \"definitely never used\"."
+"the field). It's omitted entirely when there's no metadata at all — that way"
+" \"we don't know\" doesn't get conflated with \"definitely never used\"."
 msgstr ""
+"`Last used:` 행은 메타데이터가 있지만 아직 활성화되지 않은 환경(`scoop create`로 방금 생성되었거나 해당 필드가 "
+"도입되기 전에 메타데이터가 생성된 환경)에 대해 `never`로 표시됩니다. 메타데이터가 전혀 없을 경우에는 행 자체가 생략됩니다 — "
+"이렇게 하면 \"알 수 없음\"이 \"사용한 적 없음\"으로 잘못 해석되는 것을 방지할 수 있습니다."
 
 #: src/commands/status.md:46
 msgid "For `system`: a single line indicating system Python is in use."
-msgstr ""
+msgstr "`system`의 경우: 시스템 Python이 사용 중임을 나타내는 한 줄이 표시됩니다."
 
 #: src/commands/status.md:48
 msgid "For `none`: a hint pointing to `scoop use <name>`."
-msgstr ""
+msgstr "`none`의 경우: `scoop use <name>`을 안내하는 힌트가 표시됩니다."
 
 #: src/commands/status.md:57
 msgid "\"state\""
-msgstr ""
+msgstr "\"state\""
 
-#: src/commands/status.md:58 src/commands/import.md:62 src/commands/clone.md:59
-#: src/commands/verify.md:72 src/development/architecture.md:126 src/api.md:111
-#: src/api.md:113 src/api.md:117 src/development/testing.md:197
+#: src/commands/status.md:58 src/commands/import.md:62
+#: src/commands/clone.md:59 src/commands/verify.md:72
+#: src/development/architecture.md:130 src/api.md:111 src/api.md:113
+#: src/api.md:117 src/development/testing.md:197
 #: src/development/testing.md:330
 msgid "\"myenv\""
-msgstr ""
+msgstr "\"myenv\""
 
 #: src/commands/status.md:59 src/commands/import.md:65
-#: src/commands/migrate.md:178 src/commands/lang.md:94
+#: src/commands/migrate.md:178 src/commands/lang.md:95
 msgid "\"source\""
-msgstr ""
+msgstr "\"source\""
 
 #: src/commands/status.md:59
 msgid "\"scoop_active_env\""
-msgstr ""
+msgstr "\"scoop_active_env\""
 
 #: src/commands/status.md:60
 msgid "\"/Users/me/.scoop/virtualenvs/myenv\""
-msgstr ""
+msgstr "\"/Users/me/.scoop/virtualenvs/myenv\""
 
 #: src/commands/status.md:68
 msgid ""
-"Fields are omitted (`skip_serializing_if`) when not applicable to the state. "
-"`last_used` is RFC 3339 and absent in two distinct cases:"
+"Fields are omitted (`skip_serializing_if`) when not applicable to the state."
+" `last_used` is RFC 3339 and absent in two distinct cases:"
 msgstr ""
+"해당 상태에 적용되지 않는 필드는 (`skip_serializing_if`) 생략됩니다. `last_used`는 RFC 3339 형식이며"
+" 다음 두 가지 경우에 생략됩니다:"
 
 #: src/commands/status.md:71
 msgid ""
 "**No metadata at all** (legacy env / metadata file removed) — the timestamp "
 "is _unknown_. Human output omits the `Last used:` row entirely."
 msgstr ""
+"**메타데이터가 전혀 없음** (레거시 환경 / 메타데이터 파일 삭제됨) — 타임스탬프를 _알 수 없습니다_. 사람이 읽는 출력에서는 "
+"`Last used:` 행이 완전히 생략됩니다."
 
 #: src/commands/status.md:74
 msgid ""
 "**Metadata present but never activated** since the field landed — the "
 "timestamp is _known to be never_. Human output renders `Last used: never`."
 msgstr ""
+"**메타데이터는 있지만 해당 필드 도입 이후 한 번도 활성화되지 않음** — 타임스탬프가 _한 번도 없었음을 알 수 있습니다_. 사람이 "
+"읽는 출력에서는 `Last used: never`로 표시됩니다."
 
 #: src/commands/status.md:78
 msgid ""
 "JSON consumers therefore should NOT collapse \"missing\" to \"never\"; "
-"combine the absence of `last_used` with the presence of `created_at` to tell "
-"the two cases apart."
+"combine the absence of `last_used` with the presence of `created_at` to tell"
+" the two cases apart."
 msgstr ""
+"따라서 JSON 소비자는 \"없음\"을 \"한 번도 없음\"으로 단순화해서는 안 됩니다. 두 경우를 구분하려면 `last_used`의 "
+"부재와 `created_at`의 존재를 조합하여 판단하세요."
 
 #: src/commands/status.md:85
 msgid "# human-readable\n"
-msgstr ""
+msgstr "# 사람이 읽는 형식\n"
 
 #: src/commands/status.md:86 src/commands/diff.md:12
 msgid "# machine-readable\n"
-msgstr ""
+msgstr "# 기계가 읽는 형식\n"
 
 #: src/commands/which.md:3
 msgid ""
 "Print the full path to an executable inside a scoop environment, the same "
 "way `pyenv which` resolves binaries."
-msgstr ""
+msgstr "scoop 환경 내 실행 파일의 전체 경로를 출력합니다. `pyenv which`가 바이너리를 찾는 방식과 동일합니다."
 
 #: src/commands/which.md:16
 msgid "`exe`"
-msgstr ""
+msgstr "`exe`"
 
 #: src/commands/which.md:16
 msgid "Executable name to locate (e.g. `python`, `pip`, `pytest`)"
-msgstr ""
+msgstr "찾을 실행 파일 이름 (예: `python`, `pip`, `pytest`)"
 
 #: src/commands/which.md:22
 msgid "`--env <name>`"
-msgstr ""
+msgstr "`--env <name>`"
 
 #: src/commands/which.md:22
 msgid "Look in this environment instead of the active one"
-msgstr ""
+msgstr "활성 환경 대신 이 환경에서 검색합니다"
 
 #: src/commands/which.md:25
 msgid "Resolution Order"
-msgstr ""
+msgstr "결정 순서"
 
 #: src/commands/which.md:27
 msgid "`--env <name>` if provided"
-msgstr ""
+msgstr "제공된 경우 `--env <name>`"
 
 #: src/commands/which.md:28
 msgid "`$SCOOP_ACTIVE` (set by `scoop activate` / `scoop shell`)"
-msgstr ""
+msgstr "`$SCOOP_ACTIVE` (`scoop activate` / `scoop shell`로 설정됨)"
 
 #: src/commands/which.md:29
 msgid "`.scoop-version` (local → parents → global)"
-msgstr ""
+msgstr "`.scoop-version` (local → parents → global)"
 
 #: src/commands/which.md:31
 msgid ""
 "If none of those resolve to a real virtualenv (e.g. system Python or no "
 "configuration), the command fails with `No active environment`."
 msgstr ""
+"위 항목 중 어느 것도 실제 virtualenv로 결정되지 않으면 (예: 시스템 Python이거나 설정이 없는 경우) 명령이 `No "
+"active environment` 오류와 함께 실패합니다."
 
 #: src/commands/which.md:34
 msgid ""
 "On Windows, the lookup also probes `.exe`, `.bat`, and `.cmd` extensions."
-msgstr ""
+msgstr "Windows에서는 `.exe`, `.bat`, `.cmd` 확장자도 함께 탐색합니다."
 
 #: src/commands/which.md:39
 msgid "# active env's python\n"
-msgstr ""
+msgstr "# 활성 환경의 python\n"
 
 #: src/commands/which.md:40
 msgid "# explicit env\n"
-msgstr ""
+msgstr "# 명시적 환경 지정\n"
 
 #: src/commands/which.md:41
 msgid "# JSON: { exe, env, path }\n"
-msgstr ""
+msgstr "# JSON: { exe, env, path }\n"
 
 #: src/commands/which.md:44 src/commands/run.md:37 src/commands/sync.md:111
-#: src/commands/export.md:67 src/commands/import.md:70 src/commands/clone.md:69
+#: src/commands/export.md:67 src/commands/import.md:70
+#: src/commands/clone.md:69
 msgid "Exit Codes"
-msgstr ""
+msgstr "종료 코드"
 
 #: src/commands/which.md:46 src/commands/sync.md:113 src/commands/export.md:69
 #: src/commands/import.md:72 src/commands/clone.md:71
 #: src/commands/migrate.md:56 src/commands/migrate.md:64
 #: src/commands/diff.md:51 src/commands/lang.md:37 src/api.md:700
 msgid "Code"
-msgstr ""
+msgstr "코드"
 
 #: src/commands/which.md:46 src/commands/sync.md:113 src/commands/export.md:69
 #: src/commands/import.md:72 src/commands/clone.md:71
-#: src/development/translation.md:207 src/api.md:700
+#: src/development/translation.md:208 src/api.md:700
 msgid "Meaning"
-msgstr ""
+msgstr "의미"
 
 #: src/commands/which.md:48
 msgid "Path printed to stdout"
-msgstr ""
+msgstr "경로가 stdout에 출력됨"
 
 #: src/commands/which.md:49
 msgid "No active env / env missing / executable not in env's bin/"
-msgstr ""
+msgstr "활성 환경 없음 / 환경 없음 / 실행 파일이 환경의 bin/에 없음"
 
 #: src/commands/run.md:3
 msgid ""
 "Run a command inside a virtualenv without activating it in the parent shell "
 "— useful for CI, one-shot scripts, and editor integrations."
 msgstr ""
+"부모 shell을 활성화하지 않고 virtualenv 내에서 명령을 실행합니다 — CI, 일회성 스크립트, 에디터 통합에 유용합니다."
 
 #: src/commands/run.md:12
 msgid ""
 "The `--` separator is optional but recommended when `<command>` accepts "
 "flags that might collide with `scoop`'s own flags."
 msgstr ""
+"`--` 구분자는 선택 사항이지만, `<command>`가 `scoop`의 자체 플래그와 충돌할 수 있는 플래그를 받을 때 사용하는 것을"
+" 권장합니다."
 
 #: src/commands/run.md:19
 msgid "`env`"
-msgstr ""
+msgstr "`env`"
 
 #: src/commands/run.md:20
 msgid "`command`"
-msgstr ""
+msgstr "`command`"
 
 #: src/commands/run.md:20
 msgid "Program (and arguments) to execute"
-msgstr ""
+msgstr "실행할 프로그램 (및 인수)"
 
 #: src/commands/run.md:22
 msgid "Environment Wiring"
-msgstr ""
+msgstr "환경 변수 연결"
 
 #: src/commands/run.md:24
 msgid "The spawned child sees the same vars that `scoop activate` would set:"
-msgstr ""
+msgstr "생성된 자식 프로세스는 `scoop activate`가 설정하는 것과 동일한 환경 변수를 사용합니다:"
 
 #: src/commands/run.md:26
 msgid "Value"
-msgstr ""
+msgstr "값"
 
 #: src/commands/run.md:28
 msgid "`VIRTUAL_ENV`"
-msgstr ""
+msgstr "`VIRTUAL_ENV`"
 
 #: src/commands/run.md:28
 msgid "Absolute path of the env"
-msgstr ""
+msgstr "환경의 절대 경로"
 
 #: src/commands/run.md:29
 msgid "`<env>`"
-msgstr ""
+msgstr "`<env>`"
 
-#: src/commands/run.md:30 src/development/translation.md:167
+#: src/commands/run.md:30 src/development/translation.md:168
 msgid "`PATH`"
-msgstr ""
+msgstr "`PATH`"
 
 #: src/commands/run.md:30
 msgid "Env's `bin/` prepended to inherited `PATH`"
-msgstr ""
+msgstr "환경의 `bin/`이 상속된 `PATH` 앞에 추가됨"
 
 #: src/commands/run.md:31
 msgid "`PYTHONHOME`"
-msgstr ""
+msgstr "`PYTHONHOME`"
 
 #: src/commands/run.md:31
 msgid "Removed"
-msgstr ""
+msgstr "제거됨"
 
 #: src/commands/run.md:33
 msgid ""
 "A bare program name (no `/` or `\\`) is looked up inside the env's `bin/` "
-"first — so `scoop run env -- python` always picks the env's interpreter, not "
-"a system one. An explicit path (`/usr/bin/python3`) is used verbatim."
+"first — so `scoop run env -- python` always picks the env's interpreter, not"
+" a system one. An explicit path (`/usr/bin/python3`) is used verbatim."
 msgstr ""
+"슬래시 없는 단순 프로그램 이름(`/` 또는 `\\` 없음)은 먼저 환경의 `bin/`에서 검색됩니다 — 따라서 `scoop run "
+"env -- python`은 항상 환경의 인터프리터를 선택하며, 시스템 인터프리터를 선택하지 않습니다. 명시적 "
+"경로(`/usr/bin/python3`)는 그대로 사용됩니다."
 
 #: src/commands/run.md:39
 msgid ""
 "`scoop run` exits with the child's exit code. On Unix, a child killed by a "
 "signal exits as `128 + signum` (matching what bash exposes via `$?`)."
 msgstr ""
+"`scoop run`은 자식 프로세스의 종료 코드로 종료됩니다. Unix에서는 시그널로 종료된 자식 프로세스가 `128 + "
+"signum`으로 종료됩니다 (bash가 `$?`로 노출하는 방식과 동일합니다)."
 
 #: src/commands/run.md:48
 msgid "# absolute path inside myenv\n"
-msgstr ""
+msgstr "# myenv 내부의 절대 경로\n"
 
 #: src/commands/sync.md:3
 msgid ""
 "Apply a project's declarative `.scoop.toml` — create the env if needed "
 "(auto- installing Python if missing) and reconcile its packages via uv pip."
 msgstr ""
+"프로젝트의 선언적 `.scoop.toml`을 적용합니다 — 필요한 경우 환경을 생성하고 (Python이 없으면 자동 설치), uv "
+"pip를 통해 패키지를 동기화합니다."
 
 #: src/commands/sync.md:16
 msgid "`--with <GROUP>`"
-msgstr ""
+msgstr "`--with <GROUP>`"
 
 #: src/commands/sync.md:16
 msgid "Install an extra package group on top of `default` (repeatable)"
-msgstr ""
+msgstr "`default` 위에 추가 패키지 그룹을 설치합니다 (반복 가능)"
 
 #: src/commands/sync.md:17 src/commands/migrate.md:40
 msgid "`--dry-run`"
-msgstr ""
+msgstr "`--dry-run`"
 
 #: src/commands/sync.md:17
 msgid "Print the resolved plan without creating env or installing packages"
-msgstr ""
+msgstr "환경을 생성하거나 패키지를 설치하지 않고 결정된 계획을 출력합니다"
 
 #: src/commands/sync.md:20
 msgid "Manifest Resolution"
-msgstr ""
+msgstr "매니페스트 결정"
 
 #: src/commands/sync.md:22
 msgid ""
@@ -4374,18 +4554,20 @@ msgid ""
 "manifest it finds wins. If none is found, the command fails with "
 "`MANIFEST_NOT_FOUND` and points you at this doc."
 msgstr ""
+"`scoop sync`는 현재 디렉터리에서 파일시스템 루트까지 `.scoop.toml`을 검색합니다 — `.scoop-version`과 "
+"동일한 방식입니다. 처음 찾은 매니페스트가 사용됩니다. 찾지 못하면 명령이 `MANIFEST_NOT_FOUND`와 함께 실패하며 이 "
+"문서를 안내합니다."
 
 #: src/commands/sync.md:27
 msgid "`.scoop.toml` Format"
-msgstr ""
+msgstr "`.scoop.toml` 형식"
 
 #: src/commands/sync.md:29
 msgid ""
 "```toml\n"
 "[environment]\n"
 "name = \"myproject\"        # required — must pass `is_valid_env_name`\n"
-"python = \"3.12\"           # required — same specifier syntax as `scoop "
-"create`\n"
+"python = \"3.12\"           # required — same specifier syntax as `scoop create`\n"
 "\n"
 "[packages]\n"
 "default = [\"pytest\", \"black\", \"mypy\"]   # always installed\n"
@@ -4393,32 +4575,46 @@ msgid ""
 "docs = [\"mkdocs\"]                       # opt-in via `--with docs`\n"
 "```"
 msgstr ""
+"```toml\n"
+"[environment]\n"
+"name = \"myproject\"        # required — must pass `is_valid_env_name`\n"
+"python = \"3.12\"           # required — same specifier syntax as `scoop create`\n"
+"\n"
+"[packages]\n"
+"default = [\"pytest\", \"black\", \"mypy\"]   # always installed\n"
+"dev = [\"ipython\", \"debugpy\"]            # opt-in via `--with dev`\n"
+"docs = [\"mkdocs\"]                       # opt-in via `--with docs`\n"
+"```"
 
 #: src/commands/sync.md:40
 msgid "Field rules:"
-msgstr ""
+msgstr "필드 규칙:"
 
 #: src/commands/sync.md:41
 msgid ""
 "`[environment].name` follows the same validation as `scoop create <NAME>` "
 "(letter-leading, `[a-zA-Z][a-zA-Z0-9_-]*`, not a reserved subcommand name)."
 msgstr ""
+"`[environment].name`은 `scoop create <NAME>`과 동일한 유효성 검사를 따릅니다 (문자로 시작, "
+"`[a-zA-Z][a-zA-Z0-9_-]*`, 예약된 서브커맨드 이름 불가)."
 
 #: src/commands/sync.md:43
 msgid ""
 "`[environment].python` is forwarded to `uv venv --python` as-is, so any "
 "specifier uv accepts works (`3.12`, `3.12.7`, `cpython@3.12`, `pypy@3.10`)."
 msgstr ""
+"`[environment].python`은 `uv venv --python`에 그대로 전달되므로, uv가 허용하는 모든 지정자를 사용할 "
+"수 있습니다 (`3.12`, `3.12.7`, `cpython@3.12`, `pypy@3.10`)."
 
 #: src/commands/sync.md:45
 msgid "`[packages]` is optional; `default = []` is valid."
-msgstr ""
+msgstr "`[packages]`는 선택 사항이며, `default = []`도 유효합니다."
 
 #: src/commands/sync.md:46
 msgid ""
-"Any other key inside `[packages]` becomes a named group selectable with `--"
-"with <name>`."
-msgstr ""
+"Any other key inside `[packages]` becomes a named group selectable with "
+"`--with <name>`."
+msgstr "`[packages]` 내의 다른 키는 `--with <name>`으로 선택 가능한 명명된 그룹이 됩니다."
 
 #: src/commands/sync.md:48
 msgid ""
@@ -4426,52 +4622,56 @@ msgid ""
 "(`deny_unknown_fields`) so typo'd sections fail loudly instead of silently "
 "doing nothing."
 msgstr ""
+"`[environment]`와 `[packages]` 외의 최상위 키는 거부됩니다(`deny_unknown_fields`). 오타가 있는"
+" 섹션은 조용히 무시되는 대신 명확한 오류로 실패합니다."
 
 #: src/commands/sync.md:52 src/commands/import.md:26 src/commands/clone.md:27
 msgid "Behaviour"
-msgstr ""
+msgstr "동작 방식"
 
 #: src/commands/sync.md:54
 msgid "What `scoop sync` does"
-msgstr ""
+msgstr "`scoop sync`의 동작"
 
 #: src/commands/sync.md:56
 msgid "Env missing"
-msgstr ""
+msgstr "환경 없음"
 
 #: src/commands/sync.md:56
 msgid ""
-"Auto-installs the requested Python (if uv doesn't have it), creates the env, "
-"then installs packages"
-msgstr ""
+"Auto-installs the requested Python (if uv doesn't have it), creates the env,"
+" then installs packages"
+msgstr "요청한 Python을 자동으로 설치하고(uv에 없는 경우), 환경을 생성한 뒤 패키지를 설치합니다."
 
 #: src/commands/sync.md:57
 msgid "Env exists, Python matches"
-msgstr ""
+msgstr "환경 존재, Python 버전 일치"
 
 #: src/commands/sync.md:57
 msgid ""
 "Just installs packages (idempotent — pip resolves and skips already-"
 "satisfied entries)"
-msgstr ""
+msgstr "패키지만 설치합니다(멱등 — pip이 이미 충족된 항목은 건너뜁니다)."
 
 #: src/commands/sync.md:58
 msgid "Env exists, Python mismatch"
-msgstr ""
+msgstr "환경 존재, Python 버전 불일치"
 
 #: src/commands/sync.md:58
 msgid ""
 "**Warns and proceeds.** Recreating an env on a version change is "
 "destructive, so it stays explicit: `scoop remove <name>` then `scoop sync`"
 msgstr ""
+"**경고 후 진행합니다.** 버전 변경 시 환경을 재생성하는 것은 파괴적인 작업이므로, 명시적으로 처리해야 합니다: `scoop "
+"remove <name>` 후 `scoop sync` 실행"
 
 #: src/commands/sync.md:59
 msgid "Unknown `--with <group>`"
-msgstr ""
+msgstr "알 수 없는 `--with <group>`"
 
 #: src/commands/sync.md:59
 msgid "Fails fast before any env work, lists available groups"
-msgstr ""
+msgstr "환경 작업을 시작하기 전에 즉시 실패하며, 사용 가능한 그룹 목록을 표시합니다."
 
 #: src/commands/sync.md:61
 msgid ""
@@ -4479,130 +4679,136 @@ msgid ""
 "missing from the manifest. That's a deliberate scoping decision for v1 — "
 "full lockstep reconciliation is left to a future `--prune` flag."
 msgstr ""
+"`scoop sync`는 환경에 존재하지만 매니페스트에 없는 패키지를 _제거하지 않습니다_. 이는 v1에서 의도적으로 내린 범위 "
+"결정입니다 — 완전한 동기화 조정은 향후 `--prune` 플래그에서 지원할 예정입니다."
 
 #: src/commands/sync.md:68
 msgid "# In a project directory with .scoop.toml\n"
-msgstr ""
+msgstr "# .scoop.toml이 있는 프로젝트 디렉터리에서\n"
 
 #: src/commands/sync.md:69
 msgid "# default group only\n"
-msgstr ""
+msgstr "# default 그룹만\n"
 
 #: src/commands/sync.md:70
 msgid "# default + dev\n"
-msgstr ""
+msgstr "# default + dev\n"
 
 #: src/commands/sync.md:71
 msgid "# multiple groups\n"
-msgstr ""
+msgstr "# 여러 그룹\n"
 
 #: src/commands/sync.md:73
 msgid "# preview, no side effects\n"
-msgstr ""
+msgstr "# 미리 보기, 부작용 없음\n"
 
 #: src/commands/sync.md:74
 msgid "# machine-readable plan\n"
-msgstr ""
+msgstr "# 기계 가독 형식 계획\n"
 
 #: src/commands/sync.md:77
 msgid "Sample dry-run output"
-msgstr ""
+msgstr "dry-run 출력 예시"
 
 #: src/commands/sync.md:93
 msgid "Sample JSON output"
-msgstr ""
+msgstr "JSON 출력 예시"
 
 #: src/commands/sync.md:98
 msgid "\"sync\""
-msgstr ""
+msgstr "\"sync\""
 
 #: src/commands/sync.md:100
 msgid "\"manifest_path\""
-msgstr ""
+msgstr "\"manifest_path\""
 
 #: src/commands/sync.md:100
 msgid "\"/path/to/.scoop.toml\""
-msgstr ""
+msgstr "\"/path/to/.scoop.toml\""
 
 #: src/commands/sync.md:101 src/commands/export.md:40
 msgid "\"environment\""
-msgstr ""
+msgstr "\"environment\""
 
 #: src/commands/sync.md:102 src/api.md:113 src/development/testing.md:330
 msgid "\"3.12\""
-msgstr ""
+msgstr "\"3.12\""
 
 #: src/commands/sync.md:103
 msgid "\"groups\""
-msgstr ""
+msgstr "\"groups\""
 
 #: src/commands/sync.md:103
 msgid "\"default\""
-msgstr ""
+msgstr "\"default\""
 
 #: src/commands/sync.md:103
 msgid "\"dev\""
-msgstr ""
+msgstr "\"dev\""
 
 #: src/commands/sync.md:104 src/commands/export.md:46
 msgid "\"pytest\""
-msgstr ""
+msgstr "\"pytest\""
 
 #: src/commands/sync.md:104 src/commands/export.md:47
 msgid "\"black\""
-msgstr ""
+msgstr "\"black\""
 
 #: src/commands/sync.md:104
 msgid "\"mypy\""
-msgstr ""
+msgstr "\"mypy\""
 
 #: src/commands/sync.md:104
 msgid "\"ipython\""
-msgstr ""
+msgstr "\"ipython\""
 
 #: src/commands/sync.md:104
 msgid "\"debugpy\""
-msgstr ""
+msgstr "\"debugpy\""
 
 #: src/commands/sync.md:105
 msgid "\"env_created\""
-msgstr ""
+msgstr "\"env_created\""
 
 #: src/commands/sync.md:106 src/commands/migrate.md:229 src/commands/gc.md:112
 msgid "\"dry_run\""
-msgstr ""
+msgstr "\"dry_run\""
 
 #: src/commands/sync.md:115
 msgid "Sync succeeded (or dry-run produced a plan)"
-msgstr ""
+msgstr "동기화 성공 (또는 dry-run으로 계획 생성)"
 
 #: src/commands/sync.md:116
 msgid "Manifest not found, unknown group, parse error, or pip install failed"
-msgstr ""
+msgstr "매니페스트를 찾을 수 없음, 알 수 없는 그룹, 파싱 오류, 또는 pip 설치 실패"
 
 #: src/commands/sync.md:118
 msgid "Not Yet Supported (v1)"
-msgstr ""
+msgstr "아직 미지원 (v1)"
 
 #: src/commands/sync.md:120
 msgid "These fields are intentionally not parsed in this version:"
-msgstr ""
+msgstr "이 필드들은 이 버전에서 의도적으로 파싱되지 않습니다:"
 
 #: src/commands/sync.md:122
 msgid ""
 "`[hooks]` (`post-create`, `post-activate`, ...) — needs a separate threat "
 "model before scoop will execute arbitrary shell from a checked-in file."
 msgstr ""
+"`[hooks]` (`post-create`, `post-activate`, ...) — scoop이 체크인된 파일에서 임의 shell "
+"코드를 실행하기 전에 별도의 위협 모델 검토가 필요합니다."
 
 #: src/commands/sync.md:124
 msgid ""
 "`python_path` — per-env custom interpreter overrides (parallel to the "
 "existing `--python-path` flag on `scoop create`)."
 msgstr ""
+"`python_path` — 환경별 커스텀 인터프리터 재정의(`scoop create`의 기존 `--python-path` 플래그에 "
+"상응합니다)."
 
 #: src/commands/sync.md:126
 msgid "Lock file format."
-msgstr ""
+msgstr "Lock 파일 형식."
 
 #: src/commands/sync.md:128
 msgid ""
@@ -4610,148 +4816,165 @@ msgid ""
 "fail cleanly today and stop working when they ship in a future release "
 "without a silent behaviour change."
 msgstr ""
+"파서는 알 수 없는 최상위 키를 거부합니다. 따라서 이러한 키를 사용하는 매니페스트는 현재 명확하게 실패하며, 향후 릴리스에서 이 "
+"기능들이 출시되면 조용한 동작 변경 없이 정상적으로 작동하게 됩니다."
 
 #: src/commands/export.md:3
 msgid ""
 "Write a portable JSON snapshot of an environment so another machine (or "
 "another teammate) can recreate it with [`scoop import`](import.md)."
 msgstr ""
+"[`scoop import`](import.md)로 다른 머신(또는 다른 팀원)이 재생성할 수 있도록 환경의 이식 가능한 JSON "
+"스냅샷을 작성합니다."
 
 #: src/commands/export.md:16
 msgid "Name of the environment to export"
-msgstr ""
+msgstr "내보낼 환경 이름"
 
 #: src/commands/export.md:22
 msgid "`-o`, `--output <PATH>`"
-msgstr ""
+msgstr "`-o`, `--output <PATH>`"
 
 #: src/commands/export.md:22
 msgid "Write to this file instead of stdout"
-msgstr ""
+msgstr "stdout 대신 이 파일에 씁니다"
 
 #: src/commands/export.md:24
 msgid ""
 "When `-o` is omitted, the JSON document is written to **stdout** and status "
 "messages stay on stderr. That keeps the command pipe-friendly:"
 msgstr ""
+"`-o`를 생략하면 JSON 문서는 **stdout**으로 출력되고 상태 메시지는 stderr에 남습니다. 이렇게 하면 명령을 파이프 "
+"친화적으로 유지할 수 있습니다:"
 
 #: src/commands/export.md:29
 msgid "'.packages | length'"
-msgstr ""
+msgstr "'.packages | length'"
 
 #: src/commands/export.md:32
 msgid "Schema"
-msgstr ""
+msgstr "스키마"
 
 #: src/commands/export.md:34
 msgid ""
 "The exported file is versioned (`scoop_export_version`) so a future format "
 "change is detected cleanly rather than silently mis-parsed."
 msgstr ""
+"내보낸 파일은 버전이 지정됩니다(`scoop_export_version`). 덕분에 향후 형식 변경 시 조용히 잘못 파싱되는 대신 "
+"명확하게 감지됩니다."
 
 #: src/commands/export.md:39
 msgid "\"scoop_export_version\""
-msgstr ""
+msgstr "\"scoop_export_version\""
 
 #: src/commands/export.md:39
 msgid "\"1\""
-msgstr ""
+msgstr "\"1\""
 
-#: src/commands/export.md:42 src/commands/import.md:63 src/commands/clone.md:61
+#: src/commands/export.md:42 src/commands/import.md:63
+#: src/commands/clone.md:61
 msgid "\"3.12.7\""
-msgstr ""
+msgstr "\"3.12.7\""
 
 #: src/commands/export.md:46
 msgid "\"8.0.0\""
-msgstr ""
+msgstr "\"8.0.0\""
 
 #: src/commands/export.md:47
 msgid "\"24.1.0\""
-msgstr ""
+msgstr "\"24.1.0\""
 
 #: src/commands/export.md:52
 msgid "Field notes:"
-msgstr ""
+msgstr "필드 설명:"
 
 #: src/commands/export.md:53
 msgid ""
 "`environment.python` is the resolved version recorded in the env's metadata "
 "(e.g. `3.12.7`), not the original specifier you typed."
 msgstr ""
+"`environment.python`은 환경 메타데이터에 기록된 해석된 버전(예: `3.12.7`)이며, 입력한 원래 버전 지정자가 "
+"아닙니다."
 
 #: src/commands/export.md:55
 msgid ""
 "`environment.created_at` is RFC 3339 and may be absent for hand-authored or "
 "pre-metadata exports."
 msgstr ""
+"`environment.created_at`은 RFC 3339 형식이며, 직접 작성했거나 메타데이터 이전에 내보낸 파일에는 없을 수 "
+"있습니다."
 
 #: src/commands/export.md:57
 msgid ""
 "`packages` is what the venv's own pip reports — versions are pinned exactly "
 "so imports are reproducible."
 msgstr ""
+"`packages`는 virtualenv 자체 pip이 보고하는 내용입니다 — 버전이 정확히 고정되어 import가 재현 가능합니다."
 
 #: src/commands/export.md:60
 msgid ""
-"**Note (Unreleased / post-0.12.0):** The export schema is still v1 and "
-"intentionally does **not** include the new `last_used` timestamp. "
-"`last_used` is local usage telemetry — it describes how you've been using "
-"_this_ env, not what an importer needs to recreate it elsewhere. Imported "
-"envs start fresh with no `last_used` and the field populates the first time "
-"the new env is activated locally."
+"**Note:** The export schema is still v1 and intentionally does **not** "
+"include the new `last_used` timestamp. `last_used` is local usage telemetry "
+"— it describes how you've been using _this_ env, not what an importer needs "
+"to recreate it elsewhere. Imported envs start fresh with no `last_used` and "
+"the field populates the first time the new env is activated locally."
 msgstr ""
+"**참고:** export 스키마는 여전히 v1이며 의도적으로 새 `last_used` 타임스탬프를 **포함하지 않습니다**. "
+"`last_used`는 로컬 사용 통계로, _이_ 환경을 어떻게 사용해왔는지를 나타내며 다른 곳에서 재생성하는 데 필요한 정보가 "
+"아닙니다. 가져온 환경은 `last_used` 없이 새로 시작하며, 해당 필드는 새 환경이 로컬에서 처음 활성화될 때 채워집니다."
 
 #: src/commands/export.md:71
 msgid "Export written successfully (or printed to stdout)"
-msgstr ""
+msgstr "내보내기 완료 (또는 stdout에 출력됨)"
 
 #: src/commands/export.md:72
 msgid "Env not found, or writing the destination file failed"
-msgstr ""
+msgstr "환경을 찾을 수 없거나 대상 파일 쓰기에 실패했습니다"
 
-#: src/commands/export.md:74 src/commands/import.md:77 src/commands/clone.md:76
+#: src/commands/export.md:74 src/commands/import.md:77
+#: src/commands/clone.md:76
 msgid "See Also"
-msgstr ""
+msgstr "참고 항목"
 
 #: src/commands/export.md:76
 msgid "[`scoop import`](import.md) — reverse operation"
-msgstr ""
+msgstr "[`scoop import`](import.md) — 역방향 작업"
 
 #: src/commands/export.md:77
 msgid "[`scoop sync`](sync.md) — declarative manifest with looser pinning"
-msgstr ""
+msgstr "[`scoop sync`](sync.md) — 느슨한 고정이 가능한 선언적 매니페스트"
 
 #: src/commands/import.md:3
 msgid "Recreate an environment from a [`scoop export`](export.md) JSON file."
-msgstr ""
+msgstr "[`scoop export`](export.md) JSON 파일로부터 환경을 재생성합니다."
 
 #: src/commands/import.md:9
 msgid "# read from stdin\n"
-msgstr ""
+msgstr "# stdin에서 읽기\n"
 
 #: src/commands/import.md:16
 msgid "`path`"
-msgstr ""
+msgstr "`path`"
 
 #: src/commands/import.md:16
 msgid "Path to the export JSON, or `-` to read from stdin"
-msgstr ""
+msgstr "export JSON 파일 경로, 또는 stdin에서 읽으려면 `-`를 입력하세요"
 
 #: src/commands/import.md:22
 msgid "`--name <NAME>`"
-msgstr ""
+msgstr "`--name <NAME>`"
 
 #: src/commands/import.md:22
 msgid "Override the env name from the file (validated like `scoop create`)"
-msgstr ""
+msgstr "파일의 환경 이름을 재정의합니다(`scoop create`와 동일하게 검증됩니다)"
 
 #: src/commands/import.md:23 src/commands/clone.md:24
 msgid "`-f`, `--force`"
-msgstr ""
+msgstr "`-f`, `--force`"
 
 #: src/commands/import.md:23
 msgid "Overwrite an existing environment with the same name"
-msgstr ""
+msgstr "동일한 이름의 기존 환경을 덮어씁니다"
 
 #: src/commands/import.md:28
 msgid ""
@@ -4759,121 +4982,127 @@ msgid ""
 "produces a clear `EXPORT_UNSUPPORTED_VERSION` error pointing at upgrade "
 "guidance instead of trying to limp on."
 msgstr ""
+"export 스키마를 읽고 유효성을 검사합니다. `scoop_export_version`이 일치하지 않으면 억지로 진행하는 대신, "
+"업그레이드 안내를 가리키는 명확한 `EXPORT_UNSUPPORTED_VERSION` 오류가 발생합니다."
 
 #: src/commands/import.md:31
 msgid "Applies `--name` override (if any) and validates the resulting name."
-msgstr ""
+msgstr "`--name` 재정의를 적용하고(있는 경우) 결과 이름의 유효성을 검사합니다."
 
 #: src/commands/import.md:32
 msgid ""
 "If the target env already exists: errors out unless `--force` is set, in "
 "which case the existing env is removed first."
 msgstr ""
+"대상 환경이 이미 존재하는 경우: `--force`가 설정되어 있지 않으면 오류가 발생하며, 설정된 경우에는 기존 환경을 먼저 "
+"제거합니다."
 
 #: src/commands/import.md:34
 msgid ""
 "Auto-installs the requested Python if it isn't already available via uv "
 "(matches the ergonomics of [`scoop sync`](sync.md))."
 msgstr ""
+"uv를 통해 요청한 Python을 아직 사용할 수 없는 경우 자동으로 설치합니다([`scoop sync`](sync.md)와 동일한 "
+"사용성)."
 
 #: src/commands/import.md:36
 msgid ""
 "Creates the env, then `uv pip install`s every pinned package "
 "(`name==version`) in one shot."
-msgstr ""
+msgstr "환경을 생성한 후, 고정된 모든 패키지(`name==version`)를 `uv pip install`로 한 번에 설치합니다."
 
 #: src/commands/import.md:42
 msgid "# Plain file -> recreates with the schema's original name\n"
-msgstr ""
+msgstr "# 일반 파일 -> 스키마의 원래 이름으로 재생성\n"
 
 #: src/commands/import.md:44
 msgid "# Pipe from a sibling machine\n"
-msgstr ""
+msgstr "# 다른 머신에서 파이프로 전달\n"
 
 #: src/commands/import.md:46
 msgid "'scoop export myenv'"
-msgstr ""
+msgstr "'scoop export myenv'"
 
 #: src/commands/import.md:47
 msgid "# Rename on the fly + overwrite if it already exists\n"
-msgstr ""
+msgstr "# 즉석 이름 변경 + 이미 존재하면 덮어쓰기\n"
 
 #: src/commands/import.md:50
 msgid "# Machine-readable summary for CI\n"
-msgstr ""
+msgstr "# CI용 기계 가독 요약\n"
 
 #: src/commands/import.md:60
 msgid "\"import\""
-msgstr ""
+msgstr "\"import\""
 
 #: src/commands/import.md:64
 msgid "\"packages_installed\""
-msgstr ""
+msgstr "\"packages_installed\""
 
 #: src/commands/import.md:65
 msgid "\"/path/to/myenv.json\""
-msgstr ""
+msgstr "\"/path/to/myenv.json\""
 
 #: src/commands/import.md:74
 msgid "Imported successfully"
-msgstr ""
+msgstr "가져오기 완료"
 
 #: src/commands/import.md:75
 msgid ""
 "Invalid file, unsupported schema version, invalid name, or env existed "
 "without `--force`"
-msgstr ""
+msgstr "잘못된 파일, 지원되지 않는 스키마 버전, 잘못된 이름, 또는 `--force` 없이 환경이 이미 존재함"
 
 #: src/commands/import.md:79
 msgid "[`scoop export`](export.md) — produce the input file"
-msgstr ""
+msgstr "[`scoop export`](export.md) — 입력 파일 생성"
 
 #: src/commands/import.md:80
 msgid ""
 "[`scoop sync`](sync.md) — for declarative `.scoop.toml`\\-driven workflows"
-msgstr ""
+msgstr "[`scoop sync`](sync.md) — 선언적 `.scoop.toml`\\-기반 워크플로를 위한 명령"
 
 #: src/commands/clone.md:3
 msgid ""
 "Duplicate an environment — same Python version, same packages by default — "
 "without going through an export/import roundtrip."
-msgstr ""
+msgstr "export/import 왕복 과정 없이 환경을 복제합니다 — 기본적으로 동일한 Python 버전과 패키지를 사용합니다."
 
 #: src/commands/clone.md:16
 msgid "`src`"
-msgstr ""
+msgstr "`src`"
 
 #: src/commands/clone.md:16
 msgid "Name of the source environment"
-msgstr ""
+msgstr "원본 환경 이름"
 
 #: src/commands/clone.md:17
 msgid "`dst`"
-msgstr ""
+msgstr "`dst`"
 
 #: src/commands/clone.md:17
 msgid "Name for the new environment"
-msgstr ""
+msgstr "새 환경 이름"
 
 #: src/commands/clone.md:23
 msgid "`--no-packages`"
-msgstr ""
+msgstr "`--no-packages`"
 
 #: src/commands/clone.md:23
 msgid "Skip package copy — create an empty env at the same Python version"
-msgstr ""
+msgstr "패키지 복사를 건너뜁니다 — 동일한 Python 버전의 빈 환경을 생성합니다"
 
 #: src/commands/clone.md:24
 msgid "Overwrite the destination if it already exists"
-msgstr ""
+msgstr "대상이 이미 존재하면 덮어씁니다"
 
 #: src/commands/clone.md:29
 msgid "Validates `<DST>` (rejects reserved names like `list`, `clone`, …)."
-msgstr ""
+msgstr "`<DST>`의 유효성을 검사합니다(`list`, `clone` 등 예약된 이름을 거부합니다)."
 
 #: src/commands/clone.md:30
 msgid "Refuses a self-clone (`src == dst`)."
-msgstr ""
+msgstr "자기 자신 복제를 거부합니다(`src == dst`)."
 
 #: src/commands/clone.md:31
 msgid ""
@@ -4881,246 +5110,253 @@ msgid ""
 "clear `CorruptedEnvironment` error when metadata is missing so you know "
 "recreate-from-scratch is the right next step."
 msgstr ""
+"메타데이터에서 `<SRC>`에 기록된 Python 버전을 확인합니다. 메타데이터가 없으면 명확한 `CorruptedEnvironment`"
+" 오류가 표시되어 처음부터 재생성해야 한다는 것을 알 수 있습니다."
 
 #: src/commands/clone.md:34
 msgid "Creates `<DST>` at the same Python version."
-msgstr ""
+msgstr "동일한 Python 버전으로 `<DST>`를 생성합니다."
 
 #: src/commands/clone.md:35
 msgid ""
-"Unless `--no-packages`, lists the source's installed packages via the venv's "
-"own pip and re-installs them pinned (`name==version`) into the destination."
+"Unless `--no-packages`, lists the source's installed packages via the venv's"
+" own pip and re-installs them pinned (`name==version`) into the destination."
 msgstr ""
+"`--no-packages`가 지정되지 않은 경우, virtualenv 자체 pip을 통해 원본의 설치된 패키지 목록을 가져와 고정된 "
+"버전(`name==version`)으로 대상에 재설치합니다."
 
 #: src/commands/clone.md:42
 msgid "# Full copy\n"
-msgstr ""
+msgstr "# 전체 복사\n"
 
 #: src/commands/clone.md:44
 msgid "# Just the shell, no packages\n"
-msgstr ""
+msgstr "# shell만, 패키지 없음\n"
 
 #: src/commands/clone.md:47
 msgid "# Replace an existing clone\n"
-msgstr ""
+msgstr "# 기존 복제본 교체\n"
 
 #: src/commands/clone.md:57
 msgid "\"clone\""
-msgstr ""
+msgstr "\"clone\""
 
 #: src/commands/clone.md:59
 msgid "\"src\""
-msgstr ""
+msgstr "\"src\""
 
 #: src/commands/clone.md:60
 msgid "\"dst\""
-msgstr ""
+msgstr "\"dst\""
 
 #: src/commands/clone.md:60
 msgid "\"myenv-experiment\""
-msgstr ""
+msgstr "\"myenv-experiment\""
 
 #: src/commands/clone.md:62
 msgid "\"/Users/me/.scoop/virtualenvs/myenv-experiment\""
-msgstr ""
+msgstr "\"/Users/me/.scoop/virtualenvs/myenv-experiment\""
 
 #: src/commands/clone.md:63
 msgid "\"packages_copied\""
-msgstr ""
+msgstr "\"packages_copied\""
 
 #: src/commands/clone.md:64
 msgid "\"packages_skipped\""
-msgstr ""
+msgstr "\"packages_skipped\""
 
 #: src/commands/clone.md:73
 msgid "Cloned successfully"
-msgstr ""
+msgstr "복제 완료"
 
 #: src/commands/clone.md:74
 msgid ""
 "Invalid dst name, self-clone, src missing, dst exists without `--force`, or "
 "src corrupted"
-msgstr ""
+msgstr "잘못된 dst 이름, 자기 자신 복제, src 없음, `--force` 없이 dst 존재, 또는 src 손상됨"
 
 #: src/commands/clone.md:78
 msgid ""
 "[`scoop export`](export.md) / [`scoop import`](import.md) — portable JSON "
 "for cross-machine duplication"
 msgstr ""
+"[`scoop export`](export.md) / [`scoop import`](import.md) — 머신 간 복제를 위한 이식 "
+"가능한 JSON"
 
 #: src/commands/clone.md:80
 msgid ""
 "[`scoop create --force`](create.md) — recreate from scratch with a specific "
 "Python version"
-msgstr ""
+msgstr "[`scoop create --force`](create.md) — 특정 Python 버전으로 처음부터 재생성"
 
 #: src/commands/migrate.md:3
 msgid ""
 "Migrate virtual environments from other tools (pyenv-virtualenv, "
 "virtualenvwrapper, conda)."
-msgstr ""
+msgstr "다른 도구(pyenv-virtualenv, virtualenvwrapper, conda)의 가상 환경을 마이그레이션합니다."
 
 #: src/commands/migrate.md:8
 msgid "# List migratable environments\n"
-msgstr ""
+msgstr "# 마이그레이션 가능한 환경 목록\n"
 
 #: src/commands/migrate.md:10
 msgid "# Migrate a single environment\n"
-msgstr ""
+msgstr "# 단일 환경 마이그레이션\n"
 
 #: src/commands/migrate.md:18
 msgid "Subcommands"
-msgstr ""
+msgstr "서브커맨드"
 
 #: src/commands/migrate.md:20 src/commands/migrate.md:36
 msgid "Subcommand"
-msgstr ""
+msgstr "서브커맨드"
 
 #: src/commands/migrate.md:22
 msgid "`list`"
-msgstr ""
+msgstr "`list`"
 
 #: src/commands/migrate.md:22
 msgid "List environments available for migration"
-msgstr ""
+msgstr "마이그레이션 가능한 환경 목록 표시"
 
 #: src/commands/migrate.md:23
 msgid "`@env <name>`"
-msgstr ""
+msgstr "`@env <name>`"
 
 #: src/commands/migrate.md:23
 msgid "Migrate a single environment by name"
-msgstr ""
+msgstr "이름으로 단일 환경을 마이그레이션합니다"
 
 #: src/commands/migrate.md:24
 msgid "`all`"
-msgstr ""
+msgstr "`all`"
 
 #: src/commands/migrate.md:24
 msgid "Migrate all discovered environments"
-msgstr ""
+msgstr "발견된 모든 환경을 마이그레이션합니다"
 
 #: src/commands/migrate.md:26
 msgid "Supported Sources"
-msgstr ""
+msgstr "지원되는 소스"
 
 #: src/commands/migrate.md:28
 msgid "Detection"
-msgstr ""
+msgstr "감지 방법"
 
 #: src/commands/migrate.md:30
 msgid "**pyenv-virtualenv**"
-msgstr ""
+msgstr "**pyenv-virtualenv**"
 
 #: src/commands/migrate.md:30
 msgid "`~/.pyenv/versions/` (non-system virtualenvs)"
-msgstr ""
+msgstr "`~/.pyenv/versions/` (시스템 virtualenv 제외)"
 
 #: src/commands/migrate.md:31
 msgid "**virtualenvwrapper**"
-msgstr ""
+msgstr "**virtualenvwrapper**"
 
 #: src/commands/migrate.md:31
 msgid "`$WORKON_HOME` or `~/.virtualenvs/`"
-msgstr ""
+msgstr "`$WORKON_HOME` or `~/.virtualenvs/`"
 
 #: src/commands/migrate.md:32
 msgid "**conda**"
-msgstr ""
+msgstr "**conda**"
 
 #: src/commands/migrate.md:32
 msgid "`conda info --envs`"
-msgstr ""
+msgstr "`conda info --envs`"
 
 #: src/commands/migrate.md:38
 msgid "`--source <pyenv\\|virtualenvwrapper\\|conda>`"
-msgstr ""
+msgstr "`--source <pyenv\\|virtualenvwrapper\\|conda>`"
 
 #: src/commands/migrate.md:38 src/commands/migrate.md:39
 msgid "all subcommands"
-msgstr ""
+msgstr "모든 서브커맨드"
 
 #: src/commands/migrate.md:38
 msgid "Restrict to a single source tool"
-msgstr ""
+msgstr "단일 소스 도구로 제한합니다"
 
 #: src/commands/migrate.md:39
 msgid "Machine-readable output (see [JSON Output](#json-output))"
-msgstr ""
+msgstr "기계 가독 출력 (참고: [JSON 출력](#json-output))"
 
 #: src/commands/migrate.md:40 src/commands/migrate.md:41
 #: src/commands/migrate.md:42 src/commands/migrate.md:43
 #: src/commands/migrate.md:44
 msgid "`@env`, `all`"
-msgstr ""
+msgstr "`@env`, `all`"
 
 #: src/commands/migrate.md:40
 msgid "Preview without making changes"
-msgstr ""
+msgstr "변경 없이 미리 보기"
 
-#: src/commands/migrate.md:41
+#: src/commands/migrate.md:41 src/commands/self.md:15
 msgid "`--force`"
-msgstr ""
+msgstr "`--force`"
 
 #: src/commands/migrate.md:41
 msgid ""
 "Overwrite existing scoop env with the same name; bypass EOL Python guard"
-msgstr ""
+msgstr "동일한 이름의 기존 scoop 환경을 덮어씁니다; EOL Python 가드를 우회합니다"
 
 #: src/commands/migrate.md:42
 msgid "`--yes`"
-msgstr ""
+msgstr "`--yes`"
 
 #: src/commands/migrate.md:42
 msgid "Skip the interactive confirmation prompt"
-msgstr ""
+msgstr "대화형 확인 프롬프트를 건너뜁니다"
 
 #: src/commands/migrate.md:43 src/commands/diff.md:38
 msgid "`--strict`"
-msgstr ""
+msgstr "`--strict`"
 
 #: src/commands/migrate.md:43
 msgid ""
 "Fail on the first package install error inside an env (default: keep going)"
-msgstr ""
+msgstr "환경 내 첫 번째 패키지 설치 오류에서 실패합니다(기본값: 계속 진행)"
 
 #: src/commands/migrate.md:44
 msgid "`--delete-source`"
-msgstr ""
+msgstr "`--delete-source`"
 
 #: src/commands/migrate.md:44
 msgid "Remove the source env after successful migration"
-msgstr ""
+msgstr "마이그레이션 성공 후 소스 환경을 제거합니다"
 
 #: src/commands/migrate.md:45
 msgid "`--rename <new-name>`"
-msgstr ""
+msgstr "`--rename <new-name>`"
 
 #: src/commands/migrate.md:45 src/commands/migrate.md:46
 msgid "`@env`"
-msgstr ""
+msgstr "`@env`"
 
 #: src/commands/migrate.md:45
 msgid "Migrate under a different name"
-msgstr ""
+msgstr "다른 이름으로 마이그레이션합니다"
 
 #: src/commands/migrate.md:46
 msgid "`--auto-rename`"
-msgstr ""
+msgstr "`--auto-rename`"
 
 #: src/commands/migrate.md:46
 msgid ""
-"On name conflict, append `-<source>` suffix automatically (conflicts with `--"
-"force`)"
-msgstr ""
+"On name conflict, append `-<source>` suffix automatically (conflicts with "
+"`--force`)"
+msgstr "이름 충돌 시 `-<source>` 접미사를 자동으로 추가합니다(`--force`와 충돌)"
 
 #: src/commands/migrate.md:48
 msgid "Global flags (`--quiet`, `--no-color`) apply to all subcommands."
-msgstr ""
+msgstr "전역 플래그(`--quiet`, `--no-color`)는 모든 서브커맨드에 적용됩니다."
 
-#: src/commands/migrate.md:50 src/commands/verify.md:36 src/commands/diff.md:47
+#: src/commands/migrate.md:50 src/commands/verify.md:36
+#: src/commands/diff.md:47
 msgid "Exit codes"
-msgstr ""
+msgstr "종료 코드"
 
 #: src/commands/migrate.md:52
 msgid ""
@@ -5129,20 +5365,22 @@ msgid ""
 "partitions envs into buckets before iterating) and the single-env paths "
 "(`@env`, `list`)."
 msgstr ""
+"`scoop migrate`는 [계층화된 종료 코드 계약](../api.md#process-exit-codes)을 따릅니다. 환경을 "
+"반복하기 전에 버킷으로 분류하는 `migrate all`과 단일 환경 경로(`@env`, `list`) 사이에 매핑이 약간 다릅니다."
 
 #: src/commands/migrate.md:54 src/commands/migrate.md:308
 msgid "`migrate all`"
-msgstr ""
+msgstr "`migrate all`"
 
 #: src/commands/migrate.md:56 src/commands/migrate.md:64
 #: src/commands/diff.md:51
 msgid "Returned when"
-msgstr ""
+msgstr "반환 조건"
 
 #: src/commands/migrate.md:58 src/commands/migrate.md:66
 #: src/commands/diff.md:53 src/api.md:702
 msgid "`0`"
-msgstr ""
+msgstr "`0`"
 
 #: src/commands/migrate.md:58
 msgid ""
@@ -5150,37 +5388,43 @@ msgid ""
 "(c) only non-conflict skips occurred (EOL / corrupted envs in the skipped "
 "bucket, no preflight name conflicts, no per-env failures)"
 msgstr ""
+"(a) 모든 환경 마이그레이션 완료, (b) 환경을 찾지 못했지만 소스 도구가 설치되어 있음, 또는 (c) 충돌 없는 건너뜀만 "
+"발생(건너뛴 버킷의 EOL / 손상된 환경, 사전 점검 이름 충돌 없음, 환경별 실패 없음)"
 
 #: src/commands/migrate.md:59 src/commands/migrate.md:67 src/api.md:704
 msgid "`2`"
-msgstr ""
+msgstr "`2`"
 
 #: src/commands/migrate.md:59
 msgid ""
 "At least one per-env failure **or** at least one preflight name conflict "
 "without `--force`. Returned via `MigrationBatchFailed`"
 msgstr ""
+"하나 이상의 환경별 실패 **또는** `--force` 없이 하나 이상의 사전 점검 이름 충돌. "
+"`MigrationBatchFailed`를 통해 반환됩니다"
 
 #: src/commands/migrate.md:60 src/commands/migrate.md:68 src/api.md:705
 msgid "`3`"
-msgstr ""
+msgstr "`3`"
 
 #: src/commands/migrate.md:60
 msgid ""
 "No source tool (pyenv / virtualenvwrapper / conda) is detected on the "
 "system. Returned via `MigrationSourcesNotFound`"
 msgstr ""
+"시스템에서 소스 도구(pyenv / virtualenvwrapper / conda)가 감지되지 않았습니다. "
+"`MigrationSourcesNotFound`를 통해 반환됩니다"
 
 #: src/commands/migrate.md:62 src/commands/migrate.md:309
 #: src/commands/migrate.md:310
 msgid "`migrate @env <name>`"
-msgstr ""
+msgstr "`migrate @env <name>`"
 
 #: src/commands/migrate.md:66
 msgid ""
 "The env migrated successfully (or the user chose `Skip` at the interactive "
 "conflict prompt)"
-msgstr ""
+msgstr "환경이 성공적으로 마이그레이션되었습니다(또는 사용자가 대화형 충돌 프롬프트에서 `Skip`을 선택했습니다)"
 
 #: src/commands/migrate.md:67
 msgid ""
@@ -5188,6 +5432,8 @@ msgid ""
 "interactive context) **or** `MigrationFailed` (e.g. requested env's Python "
 "is EOL and `--force` not set)"
 msgstr ""
+"`MigrationNameConflict`(scoop home에 환경 존재, `--force` 미설정, 비대화형 컨텍스트) **또는** "
+"`MigrationFailed`(예: 요청된 환경의 Python이 EOL이고 `--force` 미설정)"
 
 #: src/commands/migrate.md:68
 msgid ""
@@ -5195,23 +5441,28 @@ msgid ""
 "(`PyenvEnvNotFound`, `VenvWrapperEnvNotFound`, `CondaEnvNotFound`) **or** "
 "the source env is `CorruptedEnvironment`"
 msgstr ""
+"요청한 소스에서 지정된 소스 환경을 찾을 수 없습니다(`PyenvEnvNotFound`, `VenvWrapperEnvNotFound`, "
+"`CondaEnvNotFound`) **또는** 소스 환경이 `CorruptedEnvironment`입니다"
 
 #: src/commands/migrate.md:70
 msgid "`migrate list`"
-msgstr ""
+msgstr "`migrate list`"
 
 #: src/commands/migrate.md:72
 msgid ""
 "Exit `0` is informational. `list` only fails when a discovery I/O error "
 "occurs (exit `1`, via the catchall)."
 msgstr ""
+"종료 코드 `0`은 정보 제공용입니다. `list`는 탐색 I/O 오류가 발생할 때만 실패합니다(캐치올을 통해 종료 코드 `1`)."
 
 #: src/commands/migrate.md:76
 msgid ""
-"Before v0.14, `migrate all` always exited `0` regardless of per-env outcome. "
-"CI gates need `0.14+` to distinguish success from a batch where some envs "
+"Before v0.14, `migrate all` always exited `0` regardless of per-env outcome."
+" CI gates need `0.14+` to distinguish success from a batch where some envs "
 "failed."
 msgstr ""
+"v0.14 이전에는 `migrate all`이 환경별 결과와 무관하게 항상 `0`으로 종료되었습니다. 일부 환경이 실패한 배치와 성공을 "
+"구별하려면 CI 게이트에서 `0.14+` 이상이 필요합니다."
 
 #: src/commands/migrate.md:77
 msgid ""
@@ -5219,10 +5470,12 @@ msgid ""
 "JSON envelope are already on stdout/stderr; `main.rs` suppresses the global "
 "`error:` prefix to avoid duplicate noise."
 msgstr ""
+"`migrate all`이 `MigrationBatchFailed`를 반환할 때, 사람이 읽을 수 있는 요약과 JSON 봉투는 이미 "
+"stdout/stderr에 출력됩니다. `main.rs`는 중복 노이즈를 방지하기 위해 전역 `error:` 접두사를 억제합니다."
 
 #: src/commands/migrate.md:79
 msgid "\\--force vs --auto-rename (single env, `@env`)"
-msgstr ""
+msgstr "\\--force vs --auto-rename (단일 환경, `@env`)"
 
 #: src/commands/migrate.md:81
 msgid ""
@@ -5230,202 +5483,220 @@ msgid ""
 "= \"force\"`). For `migrate all` only `--force` is available; conflicts "
 "without `--force` count toward the exit-2 contract."
 msgstr ""
+"두 플래그는 상호 배타적입니다(`clap`\\-`conflicts_with = \"force\"`를 통해 강제됩니다). `migrate "
+"all`에서는 `--force`만 사용 가능하며, `--force` 없는 충돌은 exit-2 계약에 포함됩니다."
 
 #: src/commands/migrate.md:86
 msgid "`--force` (recommended for guaranteed resolution)"
-msgstr ""
+msgstr "`--force` (확실한 해결을 위해 권장)"
 
 #: src/commands/migrate.md:88
 msgid "Status of source env"
-msgstr ""
+msgstr "소스 환경 상태"
 
 #: src/commands/migrate.md:88
 msgid "With `--force`"
-msgstr ""
+msgstr "`--force` 사용 시"
 
 #: src/commands/migrate.md:90
 msgid "Ready"
-msgstr ""
+msgstr "준비됨"
 
 #: src/commands/migrate.md:90
 msgid "Migrated normally"
-msgstr ""
+msgstr "정상적으로 마이그레이션됨"
 
 #: src/commands/migrate.md:91
 msgid "Name conflict with an existing scoop env"
-msgstr ""
+msgstr "기존 scoop 환경과 이름 충돌"
 
 #: src/commands/migrate.md:91
 msgid "The existing scoop env is overwritten in place"
-msgstr ""
+msgstr "기존 scoop 환경이 제자리에서 덮어씌워집니다"
 
 #: src/commands/migrate.md:92
 msgid "EOL Python version (e.g. 2.7)"
-msgstr ""
+msgstr "EOL Python 버전 (예: 2.7)"
 
 #: src/commands/migrate.md:92
 msgid "Migrated anyway (the EOL guard is intentionally bypassed)"
-msgstr ""
+msgstr "어쨌든 마이그레이션됩니다(EOL 가드가 의도적으로 우회됨)"
 
 #: src/commands/migrate.md:93
 msgid "Corrupted source env"
-msgstr ""
+msgstr "손상된 소스 환경"
 
 #: src/commands/migrate.md:93
 msgid "**Not bypassed** — still returns `CorruptedEnvironment` (exit 3)"
-msgstr ""
+msgstr "**우회되지 않음** — 여전히 `CorruptedEnvironment`를 반환합니다(종료 코드 3)"
 
 #: src/commands/migrate.md:95
 msgid "`--auto-rename` (name-conflict only)"
-msgstr ""
+msgstr "`--auto-rename` (이름 충돌 시에만)"
 
 #: src/commands/migrate.md:97
 msgid ""
 "`--auto-rename` is a convenience for the pure name-conflict case: when a "
-"scoop env with the same name already exists, the migration proceeds under an "
-"auto-generated name. It does **not** override any other status (EOL / "
+"scoop env with the same name already exists, the migration proceeds under an"
+" auto-generated name. It does **not** override any other status (EOL / "
 "corrupted), and it does **not** delete or overwrite the existing scoop env."
 msgstr ""
+"`--auto-rename`은 순수한 이름 충돌 케이스를 위한 편의 기능입니다. 동일한 이름의 scoop 환경이 이미 존재할 때 자동 "
+"생성된 이름으로 마이그레이션을 진행합니다. EOL / 손상 등 **다른 상태는 재정의하지 않으며**, 기존 scoop 환경을 삭제하거나 "
+"덮어쓰지도 **않습니다**."
 
 #: src/commands/migrate.md:103
 msgid "Known limitations (tracked separately from this docs PR):"
-msgstr ""
+msgstr "알려진 제한 사항(이 문서 PR과는 별도로 추적됩니다):"
 
 #: src/commands/migrate.md:105
 msgid ""
 "The generated name is currently hard-coded as `<name>-pyenv` even for "
-"`virtualenvwrapper` / `conda` sources; the doc-comment promise of `<name>-"
-"<source>` doesn't yet match the code."
+"`virtualenvwrapper` / `conda` sources; the doc-comment promise of "
+"`<name>-<source>` doesn't yet match the code."
 msgstr ""
+"생성되는 이름은 `virtualenvwrapper` / `conda` 소스의 경우에도 현재 `<name>-pyenv`로 하드코딩되어 "
+"있습니다. doc-comment에서 약속한 `<name>-<source>` 형식은 아직 코드와 일치하지 않습니다."
 
 #: src/commands/migrate.md:108
 msgid ""
 "For envs whose status would be both \"name conflict\" and \"EOL\", conflict "
-"detection runs before EOL detection in `determine_status`, so the EOL branch "
-"is never reached and `--auto-rename` proceeds with the EOL Python silently. "
-"Prefer `--force` if you need explicit control over EOL semantics in mixed-"
+"detection runs before EOL detection in `determine_status`, so the EOL branch"
+" is never reached and `--auto-rename` proceeds with the EOL Python silently."
+" Prefer `--force` if you need explicit control over EOL semantics in mixed-"
 "status envs."
 msgstr ""
+"상태가 \"name conflict\"이면서 동시에 \"EOL\"인 환경의 경우, `determine_status`에서 충돌 감지가 "
+"EOL 감지보다 먼저 실행되므로 EOL 분기에 도달하지 못하며, `--auto-rename`이 EOL Python을 조용히 사용해 "
+"진행됩니다. 혼합 상태 환경에서 EOL 시맨틱을 명시적으로 제어해야 한다면 `--force`를 사용하는 것이 좋습니다."
 
 #: src/commands/migrate.md:114
 msgid ""
-"For deterministic conflict handling in scripts, prefer `--force` over `--"
-"auto-rename` until these limitations are addressed."
+"For deterministic conflict handling in scripts, prefer `--force` over "
+"`--auto-rename` until these limitations are addressed."
 msgstr ""
+"스크립트에서 충돌을 결정론적으로 처리하려면, 이러한 제한 사항이 해결될 때까지 `--auto-rename` 대신 `--force`를 "
+"사용하는 것이 좋습니다."
 
 #: src/commands/migrate.md:119
 msgid "List Migratable Environments"
-msgstr ""
+msgstr "마이그레이션 가능한 환경 목록"
 
 #: src/commands/migrate.md:133
 msgid "Migrate Single Environment"
-msgstr ""
+msgstr "단일 환경 마이그레이션"
 
 #: src/commands/migrate.md:142
 msgid "Migrate All"
-msgstr ""
+msgstr "전체 마이그레이션"
 
 #: src/commands/migrate.md:152
 msgid "CI gate (fail the build on batch failure)"
-msgstr ""
+msgstr "CI 게이트 (배치 실패 시 빌드 실패)"
 
 #: src/commands/migrate.md:155
 msgid "# Exits 2 if any env failed or a name conflict was skipped.\n"
-msgstr ""
+msgstr "# Exits 2 if any env failed or a name conflict was skipped.\n"
 
 #: src/commands/migrate.md:162
 msgid ""
-"All three subcommands accept `--json`. The envelope follows scoop's standard "
-"shape: `{status, command, data}` on success; `{status: \"error\", command, "
-"error: { code, message, ... }, data}` on failure paths that already rendered "
-"structured data."
+"All three subcommands accept `--json`. The envelope follows scoop's standard"
+" shape: `{status, command, data}` on success; `{status: \"error\", command, "
+"error: { code, message, ... }, data}` on failure paths that already rendered"
+" structured data."
 msgstr ""
+"세 가지 서브커맨드 모두 `--json`을 지원합니다. 성공 시 envelope는 scoop의 표준 형태인 `{status, "
+"command, data}`를 따르며, 구조화된 데이터를 이미 렌더링한 실패 경로의 경우 `{status: \"error\", "
+"command, error: { code, message, ... }, data}` 형태를 사용합니다."
 
 #: src/commands/migrate.md:167
 msgid "`migrate list --json`"
-msgstr ""
+msgstr "`migrate list --json`"
 
 #: src/commands/migrate.md:169
 msgid ""
 "`data` carries the requested `source` filter string (`\"pyenv\"`, "
-"`\"virtualenvwrapper\"`, `\"conda\"`, or `\"all\"`), the full `environments` "
-"array, and a `summary` bucketed by status."
+"`\"virtualenvwrapper\"`, `\"conda\"`, or `\"all\"`), the full `environments`"
+" array, and a `summary` bucketed by status."
 msgstr ""
+"`data`에는 요청한 `source` 필터 문자열(`\"pyenv\"`, `\"virtualenvwrapper\"`, "
+"`\"conda\"`, 또는 `\"all\"`), 전체 `environments` 배열, 그리고 상태별로 분류된 `summary`가 "
+"포함됩니다."
 
 #: src/commands/migrate.md:176
 msgid "\"migrate list\""
-msgstr ""
+msgstr "\"migrate list\""
 
 #: src/commands/migrate.md:178
 msgid "\"all\""
-msgstr ""
+msgstr "\"all\""
 
 #: src/commands/migrate.md:179
 msgid "\"environments\""
-msgstr ""
+msgstr "\"environments\""
 
 #: src/commands/migrate.md:182 src/commands/migrate.md:190
 #: src/commands/migrate.md:226 src/commands/diff.md:121 src/api.md:156
 msgid "\"python_version\""
-msgstr ""
+msgstr "\"python_version\""
 
 #: src/commands/migrate.md:182 src/commands/migrate.md:226
 #: src/commands/migrate.md:232 src/commands/verify.md:74
 #: src/commands/diff.md:114 src/commands/diff.md:121
 msgid "\"3.12.0\""
-msgstr ""
+msgstr "\"3.12.0\""
 
 #: src/commands/migrate.md:183
 msgid "\"/home/u/.pyenv/versions/myproject\""
-msgstr ""
+msgstr "\"/home/u/.pyenv/versions/myproject\""
 
 #: src/commands/migrate.md:184 src/commands/migrate.md:192
 #: src/commands/migrate.md:271 src/commands/migrate.md:282
 msgid "\"source_type\""
-msgstr ""
+msgstr "\"source_type\""
 
 #: src/commands/migrate.md:184 src/commands/migrate.md:192
 #: src/commands/migrate.md:271 src/commands/migrate.md:282
 msgid "\"pyenv\""
-msgstr ""
+msgstr "\"pyenv\""
 
 #: src/commands/migrate.md:186 src/commands/migrate.md:198
 msgid "\"ready\""
-msgstr ""
+msgstr "\"ready\""
 
 #: src/commands/migrate.md:189
 msgid "\"oldenv\""
-msgstr ""
+msgstr "\"oldenv\""
 
 #: src/commands/migrate.md:190 src/commands/migrate.md:195
 msgid "\"2.7.18\""
-msgstr ""
+msgstr "\"2.7.18\""
 
 #: src/commands/migrate.md:191
 msgid "\"/home/u/.pyenv/versions/oldenv\""
-msgstr ""
+msgstr "\"/home/u/.pyenv/versions/oldenv\""
 
 #: src/commands/migrate.md:194
 msgid "\"python_eol\""
-msgstr ""
+msgstr "\"python_eol\""
 
 #: src/commands/migrate.md:198 src/commands/migrate.md:238
 #: src/commands/migrate.md:286 src/commands/verify.md:85
 #: src/commands/diff.md:126
 msgid "\"summary\""
-msgstr ""
+msgstr "\"summary\""
 
 #: src/commands/migrate.md:198
 msgid "\"conflict\""
-msgstr ""
+msgstr "\"conflict\""
 
 #: src/commands/migrate.md:198
 msgid "\"eol\""
-msgstr ""
+msgstr "\"eol\""
 
 #: src/commands/migrate.md:198
 msgid "\"corrupted\""
-msgstr ""
+msgstr "\"corrupted\""
 
 #: src/commands/migrate.md:203
 msgid ""
@@ -5435,62 +5706,72 @@ msgid ""
 "`\"corrupted\"` (`reason` payload). `size_bytes` is lazily computed and may "
 "be `null` if not yet requested."
 msgstr ""
+"`status` 필드는 serde 태그 열거형(`#[serde(tag = \"status\", rename_all = "
+"\"snake_case\")]`)으로, `\"ready\"`, `\"name_conflict\"`(`existing` 페이로드), "
+"`\"python_eol\"`(`version` 페이로드), `\"corrupted\"`(`reason` 페이로드) 중 하나입니다. "
+"`size_bytes`는 지연 계산되며, 아직 요청되지 않은 경우 `null`일 수 있습니다."
 
 #: src/commands/migrate.md:209
 msgid "`migrate all --json` — success path"
-msgstr ""
+msgstr "`migrate all --json` — 성공 경로"
 
 #: src/commands/migrate.md:211
 msgid ""
 "`MigrateAllData` carries five top-level data keys. `conflicts[]` (new in "
-"0.14) is **additive** — name-conflict envs continue to appear in `skipped[]` "
-"for backward compatibility, and `summary.total == migrated.len() + "
+"0.14) is **additive** — name-conflict envs continue to appear in `skipped[]`"
+" for backward compatibility, and `summary.total == migrated.len() + "
 "failed.len() + skipped.len()` still holds. `conflicts[]` is a structured "
 "view so consumers can branch on the failure class without parsing the "
 "localized `reason` string in `skipped[]`."
 msgstr ""
+"`MigrateAllData`는 다섯 가지 최상위 데이터 키를 포함합니다. `conflicts[]`(0.14에서 신규 추가)는 "
+"**가산적**입니다 — 이름 충돌 환경은 하위 호환성을 위해 계속 `skipped[]`에도 나타나며, `summary.total == "
+"migrated.len() + failed.len() + skipped.len()`은 여전히 성립합니다. `conflicts[]`는 "
+"구조화된 뷰이므로, 소비자가 `skipped[]`의 로컬라이즈된 `reason` 문자열을 파싱하지 않고도 실패 유형별로 분기할 수 "
+"있습니다."
 
 #: src/commands/migrate.md:221 src/commands/migrate.md:259
 msgid "\"migrate all\""
-msgstr ""
+msgstr "\"migrate all\""
 
 #: src/commands/migrate.md:223 src/commands/migrate.md:267
 msgid "\"migrated\""
-msgstr ""
+msgstr "\"migrated\""
 
 #: src/commands/migrate.md:227
 msgid "\"packages_migrated\""
-msgstr ""
+msgstr "\"packages_migrated\""
 
 #: src/commands/migrate.md:228
 msgid "\"packages_failed\""
-msgstr ""
+msgstr "\"packages_failed\""
 
 #: src/commands/migrate.md:230
 msgid "\"/home/u/.scoop/virtualenvs/myproject\""
-msgstr ""
+msgstr "\"/home/u/.scoop/virtualenvs/myproject\""
 
 #: src/commands/migrate.md:231
 msgid "\"source_deleted\""
-msgstr ""
+msgstr "\"source_deleted\""
 
 #: src/commands/migrate.md:232
 msgid "\"actual_python_version\""
-msgstr ""
+msgstr "\"actual_python_version\""
 
 #: src/commands/migrate.md:235 src/commands/migrate.md:238
 #: src/commands/migrate.md:268 src/commands/migrate.md:286
 msgid "\"failed\""
-msgstr ""
+msgstr "\"failed\""
 
 #: src/commands/migrate.md:236 src/commands/migrate.md:238
 #: src/commands/migrate.md:276 src/commands/migrate.md:286
+#: src/commands/self.md:53
 msgid "\"skipped\""
-msgstr ""
+msgstr "\"skipped\""
 
 #: src/commands/migrate.md:237 src/commands/migrate.md:279
 msgid "\"conflicts\""
-msgstr ""
+msgstr "\"conflicts\""
 
 #: src/commands/migrate.md:243
 msgid ""
@@ -5499,90 +5780,94 @@ msgid ""
 "`source_deleted` reflects whether `--delete-source` was honored for this "
 "env. `dry_run` mirrors the flag the command was invoked with."
 msgstr ""
+"`actual_python_version`은 uv가 호환 가능한 인터프리터를 선택한 경우(예: `3.12`를 요청했으나 `3.12.4`로"
+" 결정된 경우) `python_version`과 다를 수 있습니다. `source_deleted`는 이 환경에 대해 `--delete-"
+"source`가 적용되었는지를 반영합니다. `dry_run`은 커맨드 실행 시 사용한 플래그를 그대로 나타냅니다."
 
 #: src/commands/migrate.md:249
 msgid "`migrate all --json` — failure path (exit 2)"
-msgstr ""
+msgstr "`migrate all --json` — 실패 경로 (exit 2)"
 
 #: src/commands/migrate.md:251
 msgid ""
 "Returned when at least one per-env failure occurred, or at least one "
 "preflight name conflict was detected without `--force`. The envelope embeds "
-"the full data view so consumers don't lose detail on the failure side either."
+"the full data view so consumers don't lose detail on the failure side "
+"either."
 msgstr ""
+"환경별 실패가 하나 이상 발생하거나, `--force` 없이 사전 검증 단계에서 이름 충돌이 하나 이상 감지된 경우 반환됩니다. "
+"envelope에 전체 데이터 뷰가 포함되므로, 실패 측에서도 세부 정보를 잃지 않습니다."
 
 #: src/commands/migrate.md:258 src/commands/migrate.md:260
 #: src/commands/migrate.md:273 src/commands/diff.md:142
 #: src/commands/diff.md:144
 msgid "\"error\""
-msgstr ""
+msgstr "\"error\""
 
 #: src/commands/migrate.md:261 src/commands/diff.md:145
 msgid "\"code\""
-msgstr ""
+msgstr "\"code\""
 
 #: src/commands/migrate.md:261
 msgid "\"MIGRATE_BATCH_FAILED\""
-msgstr ""
+msgstr "\"MIGRATE_BATCH_FAILED\""
 
 #: src/commands/migrate.md:262 src/commands/diff.md:146
 msgid "\"message\""
-msgstr ""
+msgstr "\"message\""
 
 #: src/commands/migrate.md:262
 msgid "\"Migration finished with 1 failure(s) and 1 name conflict(s)\""
-msgstr ""
+msgstr "\"Migration finished with 1 failure(s) and 1 name conflict(s)\""
 
 #: src/commands/migrate.md:263
 msgid "\"failed_count\""
-msgstr ""
+msgstr "\"failed_count\""
 
 #: src/commands/migrate.md:264
 msgid "\"conflict_count\""
-msgstr ""
+msgstr "\"conflict_count\""
 
 #: src/commands/migrate.md:272
 msgid "\"error_code\""
-msgstr ""
+msgstr "\"error_code\""
 
 #: src/commands/migrate.md:272
 msgid "\"MIGRATE_EXTRACTION_FAILED\""
-msgstr ""
+msgstr "\"MIGRATE_EXTRACTION_FAILED\""
 
 #: src/commands/migrate.md:273
 msgid "\"Couldn't extract packages: pip not found at ...\""
-msgstr ""
+msgstr "\"Couldn't extract packages: pip not found at ...\""
 
 #: src/commands/migrate.md:277 src/commands/migrate.md:281
 msgid "\"myproj\""
-msgstr ""
+msgstr "\"myproj\""
 
 #: src/commands/migrate.md:277 src/commands/gc.md:114 src/commands/gc.md:115
 #: src/commands/gc.md:116
 msgid "\"reason\""
-msgstr ""
+msgstr "\"reason\""
 
 #: src/commands/migrate.md:277
 msgid "\"name conflict (use --force)\""
-msgstr ""
+msgstr "\"name conflict (use --force)\""
 
 #: src/commands/migrate.md:283
 msgid "\"existing\""
-msgstr ""
+msgstr "\"existing\""
 
 #: src/commands/migrate.md:283
 msgid "\"/home/u/.scoop/virtualenvs/myproj\""
-msgstr ""
+msgstr "\"/home/u/.scoop/virtualenvs/myproj\""
 
 #: src/commands/migrate.md:291
 msgid "Per-env failure objects carry two additive fields:"
-msgstr ""
+msgstr "환경별 실패 객체에는 두 가지 추가 필드가 있습니다:"
 
 #: src/commands/migrate.md:293
-msgid ""
-"`source_type` (`\"pyenv\"`, `\"virtualenvwrapper\"`, `\"conda\"`) — origin "
-"tool."
-msgstr ""
+msgid "`source_type` (`\"pyenv\"`, `\"virtualenvwrapper\"`, `\"conda\"`) — origin tool."
+msgstr "`source_type` (`\"pyenv\"`, `\"virtualenvwrapper\"`, `\"conda\"`) — 원본 도구."
 
 #: src/commands/migrate.md:294
 msgid ""
@@ -5591,10 +5876,14 @@ msgid ""
 "`\"UV_COMMAND_FAILED\"`). Scripts branch on this instead of parsing `error` "
 "(which is localized)."
 msgstr ""
+"`error_code` — 안정적인 `ScoopError::code()` 상수(예: "
+"`\"MIGRATE_EXTRACTION_FAILED\"`, `\"MIGRATE_NAME_CONFLICT\"`, "
+"`\"UV_COMMAND_FAILED\"`)입니다. 로컬라이즈된 `error` 문자열을 파싱하는 대신, 스크립트에서 이 값을 기반으로 "
+"분기할 수 있습니다."
 
 #: src/commands/migrate.md:299
 msgid "Exit-3 paths — no JSON envelope on stdout"
-msgstr ""
+msgstr "Exit-3 경로 — stdout에 JSON envelope 없음"
 
 #: src/commands/migrate.md:301
 msgid ""
@@ -5603,48 +5892,51 @@ msgid ""
 "suggestion are written to stderr as plain text; stdout stays empty. Detect "
 "via the exit code."
 msgstr ""
+"두 가지 별개의 exit-3 케이스가 존재합니다. **`--json` 옵션을 사용하더라도 어느 쪽도 stdout에 JSON "
+"envelope를 출력하지 않습니다.** 로컬라이즈된 오류 메시지와 설치/조회 제안은 일반 텍스트로 stderr에 기록되며, "
+"stdout은 비어 있습니다. 종료 코드로 구분하십시오."
 
 #: src/commands/migrate.md:306
 msgid "Error variant"
-msgstr ""
+msgstr "오류 변형"
 
 #: src/commands/migrate.md:308
 msgid "`MigrationSourcesNotFound`"
-msgstr ""
+msgstr "`MigrationSourcesNotFound`"
 
 #: src/commands/migrate.md:308
 msgid "No source tool detected at all (pyenv / virtualenvwrapper / conda)"
-msgstr ""
+msgstr "소스 도구(pyenv / virtualenvwrapper / conda)가 전혀 감지되지 않음"
 
 #: src/commands/migrate.md:309
 msgid "`PyenvEnvNotFound` / `VenvWrapperEnvNotFound` / `CondaEnvNotFound`"
-msgstr ""
+msgstr "`PyenvEnvNotFound` / `VenvWrapperEnvNotFound` / `CondaEnvNotFound`"
 
 #: src/commands/migrate.md:309
 msgid "The named env isn't present in the requested (or any) source"
-msgstr ""
+msgstr "지정한 환경이 요청한(또는 어떤) 소스에도 존재하지 않음"
 
 #: src/commands/migrate.md:310
 msgid "`CorruptedEnvironment`"
-msgstr ""
+msgstr "`CorruptedEnvironment`"
 
 #: src/commands/migrate.md:310
 msgid ""
 "The named env exists but its layout is broken (missing python, broken "
 "pyvenv.cfg, etc)"
-msgstr ""
+msgstr "지정한 환경은 존재하지만 레이아웃이 손상됨(Python 누락, pyvenv.cfg 손상 등)"
 
 #: src/commands/migrate.md:312
 msgid "Script template:"
-msgstr ""
+msgstr "스크립트 템플릿:"
 
 #: src/commands/migrate.md:317
 msgid "\"batch failure — read out.json for detail\""
-msgstr ""
+msgstr "\"batch failure — read out.json for detail\""
 
 #: src/commands/migrate.md:318
 msgid "\"no source tool installed\""
-msgstr ""
+msgstr "\"no source tool installed\""
 
 #: src/commands/migrate.md:323
 msgid ""
@@ -5653,64 +5945,71 @@ msgid ""
 "require `batch.rs` (and `single.rs`) to call `Output::json_error` before "
 "returning Err; tracked for a follow-up."
 msgstr ""
+"exit-2 경로(배치 실패)는 stdout에 구조화된 envelope를 출력하는 유일한 `migrate all` 실패 경로입니다. "
+"exit-3의 비대칭성을 해소하려면 `batch.rs`(및 `single.rs`)가 Err를 반환하기 전에 "
+"`Output::json_error`를 호출해야 합니다. 이는 후속 작업으로 추적 중입니다."
 
 #: src/commands/migrate.md:328
 msgid "Migration Process"
-msgstr ""
+msgstr "마이그레이션 프로세스"
 
 #: src/commands/migrate.md:330
 msgid "**Discovery**: Scans configured source paths for virtual environments"
-msgstr ""
+msgstr "**검색**: 가상 환경을 위해 설정된 소스 경로를 스캔합니다."
 
 #: src/commands/migrate.md:331
 msgid "**Extraction**: Identifies Python version and installed packages"
-msgstr ""
+msgstr "**추출**: Python 버전과 설치된 패키지를 식별합니다."
 
 #: src/commands/migrate.md:332
 msgid "**Recreation**: Creates new scoop environment with same Python version"
-msgstr ""
+msgstr "**재생성**: 동일한 Python 버전으로 새 scoop 환경을 생성합니다."
 
 #: src/commands/migrate.md:333
 msgid "**Package Install**: Reinstalls packages using `uv pip install`"
-msgstr ""
+msgstr "**패키지 설치**: `uv pip install`을 사용해 패키지를 재설치합니다."
 
 #: src/commands/migrate.md:334
 msgid ""
 "**Cleanup**: Originals are preserved by default; `--delete-source` removes "
 "them after successful migration"
 msgstr ""
+"**정리**: 원본은 기본적으로 보존됩니다. 마이그레이션 성공 후 `--delete-source`를 사용하면 원본이 제거됩니다."
 
-#: src/commands/migrate.md:336 src/commands/lang.md:121
-#: src/development/architecture.md:403
+#: src/commands/migrate.md:336 src/commands/lang.md:122
+#: src/development/architecture.md:407
 msgid "Notes"
-msgstr ""
+msgstr "참고 사항"
 
 #: src/commands/migrate.md:338
 msgid ""
 "Original environments are preserved by default; use `--delete-source` to "
 "remove sources after migration"
-msgstr ""
+msgstr "원본 환경은 기본적으로 보존됩니다. 마이그레이션 후 소스를 제거하려면 `--delete-source`를 사용하세요."
 
 #: src/commands/migrate.md:339
 msgid "Package versions are preserved where possible"
-msgstr ""
+msgstr "가능한 경우 패키지 버전이 보존됩니다."
 
 #: src/commands/migrate.md:340
 msgid ""
 "Migration creates fresh environments using `uv` for improved performance"
-msgstr ""
+msgstr "마이그레이션은 성능 향상을 위해 `uv`를 사용해 새 환경을 생성합니다."
 
 #: src/commands/migrate.md:342 src/development/code-quality.md:372
 msgid "Performance"
-msgstr ""
+msgstr "성능"
 
 #: src/commands/migrate.md:344
 msgid ""
-"`scoop migrate all` fans out across all CPU cores via [rayon](https://"
-"docs.rs/rayon) when migrating more than one environment. The dominant cost "
-"(uv venv + pip install per env) is I/O-bound on subprocesses, so wall-clock "
-"time scales close to linearly with core count."
+"`scoop migrate all` fans out across all CPU cores via "
+"[rayon](https://docs.rs/rayon) when migrating more than one environment. The"
+" dominant cost (uv venv + pip install per env) is I/O-bound on subprocesses,"
+" so wall-clock time scales close to linearly with core count."
 msgstr ""
+"`scoop migrate all`은 환경이 두 개 이상인 경우 [rayon](https://docs.rs/rayon)을 통해 모든 "
+"CPU 코어에 병렬로 작업을 분산합니다. 주된 비용(환경당 uv venv + pip install)은 서브프로세스의 I/O 바운드이므로,"
+" 처리 시간은 코어 수에 거의 선형적으로 비례합니다."
 
 #: src/commands/migrate.md:349
 msgid ""
@@ -5722,66 +6021,74 @@ msgid ""
 "order — which itself is deterministic (source-type then name; see "
 "`scan_all_environments`)."
 msgstr ""
+"`--dry-run`은 순차적으로 실행됩니다 — 정렬된 상태의 미리보기 출력이 더 유용하기 때문입니다. 여러 환경이 거의 동시에 완료되면"
+" 진행 상황 줄이 뒤섞일 수 있습니다. JSON 요약에서 `migrated[]`와 `failed[]` 배열은 환경 이름 기준으로 알파벳순"
+" 정렬됩니다(워커 스레드 스케줄링이 출력에 영향을 주지 않도록). `skipped[]`와 `conflicts[]`는 스캔/파티션 순서를 "
+"유지합니다 — 이 순서 자체는 결정론적입니다(소스 타입 → 이름 순; `scan_all_environments` 참조)."
 
 #: src/commands/gc.md:3
 msgid ""
-"Garbage-collect orphan virtual environments — directories under `~/.scoop/"
-"virtualenvs/` that no longer look like working environments, plus "
+"Garbage-collect orphan virtual environments — directories under "
+"`~/.scoop/virtualenvs/` that no longer look like working environments, plus "
 "(optionally) environments that haven't been activated in a while."
 msgstr ""
+"`~/.scoop/virtualenvs/`의 하위 디렉터리 중 더 이상 정상적인 환경처럼 보이지 않는 디렉터리(오펀), 그리고 "
+"(선택적으로) 일정 기간 동안 활성화되지 않은 환경을 가비지 컬렉션합니다."
 
 #: src/commands/gc.md:8
 msgid "# Preview orphans only (default)\n"
-msgstr ""
+msgstr "# Preview orphans only (default)\n"
 
 #: src/commands/gc.md:9
 msgid "# Actually remove orphans\n"
-msgstr ""
+msgstr "# Actually remove orphans\n"
 
 #: src/commands/gc.md:10
 msgid "# Also flag unused Python versions\n"
-msgstr ""
+msgstr "# Also flag unused Python versions\n"
 
 #: src/commands/gc.md:11
 msgid "# Remove orphans + unused Pythons\n"
-msgstr ""
+msgstr "# Remove orphans + unused Pythons\n"
 
 #: src/commands/gc.md:12
 msgid "# Also preview envs idle >30 days\n"
-msgstr ""
+msgstr "# Also preview envs idle >30 days\n"
 
 #: src/commands/gc.md:13
 msgid "# Remove orphans + stale envs (≥6 weeks idle)\n"
-msgstr ""
+msgstr "# Remove orphans + stale envs (≥6 weeks idle)\n"
 
 #: src/commands/gc.md:16
 msgid "What counts as an orphan?"
-msgstr ""
+msgstr "오펀이란 무엇인가?"
 
 #: src/commands/gc.md:18
 msgid "An environment directory is considered an orphan if either:"
-msgstr ""
+msgstr "환경 디렉터리는 다음 중 하나에 해당하면 오펀으로 간주됩니다:"
 
 #: src/commands/gc.md:20
 msgid ""
 "It has no `.scoop-metadata.json` (it wasn't created by scoop, or the "
 "metadata was deleted), or"
-msgstr ""
+msgstr "`.scoop-metadata.json`이 없는 경우(scoop이 생성한 환경이 아니거나 메타데이터가 삭제된 경우), 또는"
 
 #: src/commands/gc.md:21
 msgid ""
-"Its Python interpreter is missing (`bin/python` on Unix / `Scripts/"
-"python.exe` on Windows) — typically because the Python version was "
+"Its Python interpreter is missing (`bin/python` on Unix / "
+"`Scripts/python.exe` on Windows) — typically because the Python version was "
 "uninstalled out from under it"
 msgstr ""
+"Python 인터프리터가 없는 경우(Unix에서는 `bin/python`, Windows에서는 `Scripts/python.exe`) —"
+" 일반적으로 Python 버전이 환경 아래에서 삭제되어 발생합니다."
 
 #: src/commands/gc.md:23
 msgid "Healthy environments are left untouched."
-msgstr ""
+msgstr "정상적인 환경은 그대로 유지됩니다."
 
 #: src/commands/gc.md:25 src/commands/gc.md:80
 msgid "`--aggressive`"
-msgstr ""
+msgstr "`--aggressive`"
 
 #: src/commands/gc.md:27
 msgid ""
@@ -5789,17 +6096,21 @@ msgid ""
 "surviving environment references. Pair with `--yes` to uninstall them via "
 "`uv python uninstall`."
 msgstr ""
+"`--aggressive` 옵션을 사용하면 `gc`가 남아 있는 환경에서 참조하지 않는 uv 관리 Python 버전도 보고합니다. "
+"`--yes`와 함께 사용하면 `uv python uninstall`을 통해 해당 버전을 제거합니다."
 
 #: src/commands/gc.md:29
 msgid ""
 "Without `--aggressive`, Python versions are never touched — even ones that "
-"look unused — because manually installed interpreters might be intentionally "
-"kept around for ad-hoc use."
+"look unused — because manually installed interpreters might be intentionally"
+" kept around for ad-hoc use."
 msgstr ""
+"`--aggressive` 없이는 Python 버전은 절대 건드리지 않습니다 — 사용되지 않는 것처럼 보이는 경우에도 마찬가지입니다. "
+"수동으로 설치한 인터프리터를 임시 사용 목적으로 의도적으로 유지해 둘 수 있기 때문입니다."
 
 #: src/commands/gc.md:31 src/commands/gc.md:81
 msgid "`--older-than <DURATION>`"
-msgstr ""
+msgstr "`--older-than <DURATION>`"
 
 #: src/commands/gc.md:33
 msgid ""
@@ -5807,6 +6118,8 @@ msgid ""
 "duration. Accepts `<n>d` (days), `<n>w` (weeks = 7d), and `<n>y` (years = "
 "365d). Examples: `30d`, `2w`, `1y`."
 msgstr ""
+"`last_used` 타임스탬프가 지정한 기간보다 오래된 환경을 표시합니다. `<n>d`(일), `<n>w`(주 = 7일), "
+"`<n>y`(년 = 365일) 형식을 허용합니다. 예: `30d`, `2w`, `1y`."
 
 #: src/commands/gc.md:35
 msgid ""
@@ -5815,43 +6128,54 @@ msgid ""
 "for a marginal gain in accuracy on a stale-env heuristic. Use `30d` or `1y` "
 "instead."
 msgstr ""
+"**월 단위는 의도적으로 거부합니다** — `m`은 \"분(minute)\"과 \"월(month)\" 사이에 모호성이 있으며, 캘린더 "
+"기반 월 계산은 시간대를 고려한 산술이 필요하지만 유휴 환경 휴리스틱의 정확도 개선 효과는 미미합니다. 대신 `30d` 또는 `1y`를 "
+"사용하세요."
 
 #: src/commands/gc.md:37
 msgid ""
 "The maximum allowed value is 200 years (`200y`); larger values are rejected "
 "to keep the resulting cutoff inside chrono's representable range."
 msgstr ""
+"허용되는 최대값은 200년(`200y`)입니다. 더 큰 값은 결과로 산출되는 컷오프 시점이 chrono의 표현 가능 범위를 벗어나므로 "
+"거부됩니다."
 
 #: src/commands/gc.md:39
 msgid ""
 "**Note on system clock**: the cutoff is `Utc::now() - <duration>`, so the "
 "threshold moves with the system clock. A host whose clock is wrong (NTP "
 "compromise, manual `date` set, or hibernated VM that woke up with a stale "
-"time) can shift which envs `gc --older-than` considers stale. This is a best-"
-"effort heuristic, not a security boundary — pair it with `--yes` only when "
-"you trust the clock."
+"time) can shift which envs `gc --older-than` considers stale. This is a "
+"best-effort heuristic, not a security boundary — pair it with `--yes` only "
+"when you trust the clock."
 msgstr ""
+"**시스템 클록 참고**: 컷오프는 `Utc::now() - <duration>`으로 계산되므로 임계값이 시스템 클록과 함께 이동합니다."
+" NTP 침해, 수동 `date` 설정, 또는 오래된 시간으로 깨어난 최대 절전 모드 VM의 경우 `gc --older-than`이 "
+"유휴로 판단하는 환경이 달라질 수 있습니다. 이는 보안 경계가 아닌 최선 노력 휴리스틱이므로, 클록을 신뢰할 수 있을 때만 "
+"`--yes`와 함께 사용하세요."
 
 #: src/commands/gc.md:46
 msgid "Conservative rules"
-msgstr ""
+msgstr "보수적인 규칙"
 
 #: src/commands/gc.md:48
 msgid "Two cases are **never** flagged as stale, by design:"
-msgstr ""
+msgstr "설계상 **절대로** 유휴 상태로 표시되지 않는 두 가지 케이스가 있습니다:"
 
 #: src/commands/gc.md:50
 msgid ""
-"**`last_used = None`** — fresh envs that have never been activated since the "
-"field landed, _and_ envs whose metadata predates the field. Either way we "
+"**`last_used = None`** — fresh envs that have never been activated since the"
+" field landed, _and_ envs whose metadata predates the field. Either way we "
 "have no positive evidence the env is unused."
 msgstr ""
+"**`last_used = None`** — 이 필드가 도입된 이후 한 번도 활성화되지 않은 새 환경, _그리고_ 필드 도입 이전에 "
+"생성된 메타데이터를 가진 환경. 어느 경우든 환경이 사용되지 않는다는 양성 근거가 없습니다."
 
 #: src/commands/gc.md:51
 msgid ""
 "**Corrupt metadata** — if we can't read the metadata, we don't pretend to "
 "know its age."
-msgstr ""
+msgstr "**손상된 메타데이터** — 메타데이터를 읽을 수 없으면, 해당 환경의 나이를 알 수 없다고 판단합니다."
 
 #: src/commands/gc.md:53
 msgid ""
@@ -5860,10 +6184,13 @@ msgid ""
 "— and remove individual ones with `scoop remove <name>`. For scripted "
 "enumeration:"
 msgstr ""
+"활성화되지 않은 환경을 정리하고 싶다면 `scoop list --sort last-used`로 확인하세요 — `last_used`가 없는"
+" 환경은 항상 목록 하단으로 정렬됩니다 — 그런 다음 `scoop remove <name>`으로 개별 환경을 제거합니다. 스크립트로 "
+"열거하려면:"
 
 #: src/commands/gc.md:59
 msgid "'.data.virtualenvs[] | select(.last_used == null) | .name'"
-msgstr ""
+msgstr "'.data.virtualenvs[] | select(.last_used == null) | .name'"
 
 #: src/commands/gc.md:62
 msgid ""
@@ -5871,136 +6198,146 @@ msgid ""
 "manifest drift — and intentionally does NOT flag a healthy env just because "
 "it has never been activated.)"
 msgstr ""
+"(참고: `scoop verify`는 환경별 상태 — 메타데이터 / 인터프리터 / 매니페스트 드리프트 — 를 검사하며, 한 번도 "
+"활성화되지 않은 정상적인 환경을 유휴로 표시하지 **않습니다**.)"
 
 #: src/commands/gc.md:66
 msgid "TOCTOU guard"
-msgstr ""
+msgstr "TOCTOU 가드"
 
 #: src/commands/gc.md:68
 msgid ""
 "Between the `--older-than` scan and the actual delete, an env may be "
 "activated. Each candidate is re-checked just before removal:"
-msgstr ""
+msgstr "`--older-than` 스캔과 실제 삭제 사이에 환경이 활성화될 수 있습니다. 각 후보는 제거 직전에 다시 확인합니다:"
 
 #: src/commands/gc.md:70
 msgid ""
 "`SkippedRecentlyUsed` — the env was touched after the scan; `last_used` is "
 "now at-or-newer than the original cutoff, so it is no longer stale."
 msgstr ""
+"`SkippedRecentlyUsed` — 스캔 이후 환경이 사용되었습니다. `last_used`가 원래 컷오프 이상으로 업데이트되어 더"
+" 이상 유휴 상태가 아닙니다."
 
 #: src/commands/gc.md:71
 msgid ""
 "`SkippedNoData` — metadata became unreadable or missing between scan and "
 "remove. We refuse to delete envs we can no longer reason about."
 msgstr ""
+"`SkippedNoData` — 스캔과 제거 사이에 메타데이터를 읽을 수 없거나 사라진 경우. 더 이상 판단할 수 없는 환경은 삭제하지 "
+"않습니다."
 
 #: src/commands/gc.md:73
 msgid ""
 "Both surface in the JSON envelope as `outcome` values so scripts can "
 "distinguish them from `Removed` / `Failed`."
 msgstr ""
+"두 가지 모두 JSON envelope에서 `outcome` 값으로 나타나므로, 스크립트에서 `Removed` / `Failed`와 "
+"구분할 수 있습니다."
 
 #: src/commands/gc.md:79
 msgid "`-y`, `--yes`"
-msgstr ""
+msgstr "`-y`, `--yes`"
 
 #: src/commands/gc.md:79
 msgid "Actually remove the candidates (default: preview only)"
-msgstr ""
+msgstr "후보를 실제로 제거합니다(기본값: 미리보기만)."
 
 #: src/commands/gc.md:80
 msgid "Also remove uv-managed Python versions that no environment uses"
-msgstr ""
+msgstr "어떤 환경에서도 사용하지 않는 uv 관리 Python 버전도 함께 제거합니다."
 
 #: src/commands/gc.md:81
 msgid "Also flag envs idle past the cutoff (`30d` / `2w` / `1y`)"
-msgstr ""
+msgstr "컷오프 이후 유휴 상태인 환경도 표시합니다(`30d` / `2w` / `1y`)."
 
 #: src/commands/gc.md:87
 msgid "# See what would be removed\n"
-msgstr ""
+msgstr "# See what would be removed\n"
 
 #: src/commands/gc.md:89
 msgid "# Sample output:\n"
-msgstr ""
+msgstr "# Sample output:\n"
 
 #: src/commands/gc.md:91
 msgid ""
 "#   - broken-env (Python interpreter missing)  ~/.scoop/virtualenvs/broken-"
 "env\n"
 msgstr ""
+"#   - broken-env (Python interpreter missing)  ~/.scoop/virtualenvs/broken-"
+"env\n"
 
 #: src/commands/gc.md:93
 msgid "# (dry run — pass `--yes` to actually remove)\n"
-msgstr ""
+msgstr "# (dry run — pass `--yes` to actually remove)\n"
 
 #: src/commands/gc.md:95
 msgid "# Actually clean up\n"
-msgstr ""
+msgstr "# Actually clean up\n"
 
 #: src/commands/gc.md:100 src/commands/verify.md:63 src/commands/diff.md:99
 msgid "JSON output"
-msgstr ""
+msgstr "JSON 출력"
 
 #: src/commands/gc.md:110
 msgid "\"gc\""
-msgstr ""
+msgstr "\"gc\""
 
 #: src/commands/gc.md:113 src/commands/verify.md:70
 msgid "\"envs\""
-msgstr ""
+msgstr "\"envs\""
 
 #: src/commands/gc.md:114
 msgid "\"broken-env\""
-msgstr ""
+msgstr "\"broken-env\""
 
 #: src/commands/gc.md:114
 msgid "\"/Users/x/.scoop/virtualenvs/broken-env\""
-msgstr ""
+msgstr "\"/Users/x/.scoop/virtualenvs/broken-env\""
 
 #: src/commands/gc.md:114
 msgid "\"broken_python\""
-msgstr ""
+msgstr "\"broken_python\""
 
 #: src/commands/gc.md:114 src/commands/gc.md:115 src/commands/gc.md:116
 msgid "\"outcome\""
-msgstr ""
+msgstr "\"outcome\""
 
 #: src/commands/gc.md:114 src/commands/gc.md:115 src/commands/gc.md:116
 msgid "\"pending\""
-msgstr ""
+msgstr "\"pending\""
 
 #: src/commands/gc.md:115
 msgid "\"rogue-dir\""
-msgstr ""
+msgstr "\"rogue-dir\""
 
 #: src/commands/gc.md:115
 msgid "\"/Users/x/.scoop/virtualenvs/rogue-dir\""
-msgstr ""
+msgstr "\"/Users/x/.scoop/virtualenvs/rogue-dir\""
 
 #: src/commands/gc.md:115
 msgid "\"missing_metadata\""
-msgstr ""
+msgstr "\"missing_metadata\""
 
 #: src/commands/gc.md:116
 msgid "\"old-poc\""
-msgstr ""
+msgstr "\"old-poc\""
 
 #: src/commands/gc.md:116
 msgid "\"/Users/x/.scoop/virtualenvs/old-poc\""
-msgstr ""
+msgstr "\"/Users/x/.scoop/virtualenvs/old-poc\""
 
 #: src/commands/gc.md:116
 msgid "\"stale\""
-msgstr ""
+msgstr "\"stale\""
 
 #: src/commands/gc.md:116
 msgid "\"age_days\""
-msgstr ""
+msgstr "\"age_days\""
 
 #: src/commands/gc.md:118
 msgid "\"pythons\""
-msgstr ""
+msgstr "\"pythons\""
 
 #: src/commands/gc.md:123
 msgid ""
@@ -6010,255 +6347,273 @@ msgid ""
 "`reason` keep working unchanged; the only additive change is the new "
 "`outcome` values `skipped_recently_used` and `skipped_no_data`."
 msgstr ""
+"`reason`은 모든 변형에서 단순 문자열로 유지됩니다 — 고아 항목은 기존의 `\"missing_metadata\"` / "
+"`\"broken_python\"` 값을 사용하고, 오래된 기록은 `\"stale\"`과 형제 `age_days` 정수를 추가합니다. "
+"`reason`으로 매칭하는 기존 소비자는 변경 없이 계속 동작하며, 유일한 추가 변경은 새로운 `outcome` 값인 "
+"`skipped_recently_used`와 `skipped_no_data`입니다."
 
 #: src/commands/gc.md:130 src/commands/prune.md:35 src/commands/verify.md:90
-#: src/commands/diff.md:183 src/commands/man.md:43
+#: src/commands/diff.md:183 src/commands/self.md:61 src/commands/man.md:43
 msgid "See also"
-msgstr ""
+msgstr "참고 항목"
 
 #: src/commands/gc.md:132
 msgid "[`prune`](prune.md) — clean the uv cache"
-msgstr ""
+msgstr "[`prune`](prune.md) — uv cache 정리"
 
 #: src/commands/gc.md:133
 msgid "[`doctor`](doctor.md) — diagnose without removing"
-msgstr ""
+msgstr "[`doctor`](doctor.md) — 삭제 없이 진단"
 
 #: src/commands/gc.md:134
 msgid "[`remove`](remove.md) — delete a specific environment by name"
-msgstr ""
+msgstr "[`remove`](remove.md) — 이름으로 특정 환경 삭제"
 
 #: src/commands/prune.md:3
 msgid ""
 "Prune the uv cache — deletes unused download archives, wheels, and source "
 "artifacts that uv has cached but no longer needs."
 msgstr ""
+"uv cache를 정리합니다 — uv가 캐시해 두었지만 더 이상 필요하지 않은 미사용 다운로드 아카이브, wheel, 소스 아티팩트를 "
+"삭제합니다."
 
 #: src/commands/prune.md:11
 msgid ""
-"This is a thin wrapper around [`uv cache prune`](https://docs.astral.sh/uv/"
-"reference/cli/#uv-cache-prune). uv decides what's safe to delete; scoop just "
-"forwards the result so you don't have to remember the exact invocation."
+"This is a thin wrapper around [`uv cache "
+"prune`](https://docs.astral.sh/uv/reference/cli/#uv-cache-prune). uv decides"
+" what's safe to delete; scoop just forwards the result so you don't have to "
+"remember the exact invocation."
 msgstr ""
+"이것은 [`uv cache prune`](https://docs.astral.sh/uv/reference/cli/#uv-cache-"
+"prune)의 얇은 래퍼입니다. 무엇을 삭제해도 안전한지는 uv가 결정하며, scoop은 정확한 명령어를 외울 필요가 없도록 결과를 "
+"그대로 전달합니다."
 
 #: src/commands/prune.md:13
 msgid "When to use"
-msgstr ""
+msgstr "사용 시기"
 
 #: src/commands/prune.md:15
 msgid "After uninstalling Python versions you no longer need"
-msgstr ""
+msgstr "더 이상 필요하지 않은 Python 버전을 제거한 후"
 
 #: src/commands/prune.md:16
 msgid "When disk space on `~/.cache/uv/` is filling up"
-msgstr ""
+msgstr "`~/.cache/uv/`의 디스크 공간이 부족할 때"
 
 #: src/commands/prune.md:17
 msgid ""
 "As part of regular cleanup, paired with [`scoop gc`](gc.md) for orphan "
 "virtualenvs"
-msgstr ""
+msgstr "정기적인 정리 작업의 일환으로, 고아 virtualenv를 위한 [`scoop gc`](gc.md)와 함께 사용"
 
 #: src/commands/prune.md:23
 msgid "Output the result as JSON"
-msgstr ""
+msgstr "결과를 JSON으로 출력"
 
 #: src/commands/prune.md:28
 msgid "# Standard cleanup\n"
-msgstr ""
+msgstr "# 표준 정리\n"
 
 #: src/commands/prune.md:30
 msgid "# Capture freed-bytes for a script\n"
-msgstr ""
+msgstr "# 스크립트용으로 해제된 바이트 캡처\n"
 
 #: src/commands/prune.md:32
 msgid "'.data.output'"
-msgstr ""
+msgstr "'.data.output'"
 
 #: src/commands/prune.md:37
 msgid "[`gc`](gc.md) — garbage-collect orphan virtual environments"
-msgstr ""
+msgstr "[`gc`](gc.md) — 고아 가상 환경 가비지 컬렉션"
 
 #: src/commands/prune.md:38
 msgid "[`doctor`](doctor.md) — health check (does not delete anything)"
-msgstr ""
+msgstr "[`doctor`](doctor.md) — 상태 확인 (아무것도 삭제하지 않음)"
 
 #: src/commands/verify.md:3
 msgid ""
-"Verify the health of one or all virtual environments. Where [`doctor`]"
-"(doctor.md) checks system-wide setup (uv installed, shell wrapper wired up, "
-"etc.), `verify` looks inside each env directory and answers: \"does Python "
-"actually work in here?\""
+"Verify the health of one or all virtual environments. Where "
+"[`doctor`](doctor.md) checks system-wide setup (uv installed, shell wrapper "
+"wired up, etc.), `verify` looks inside each env directory and answers: "
+"\"does Python actually work in here?\""
 msgstr ""
+"하나 또는 모든 가상 환경의 상태를 점검합니다. [`doctor`](doctor.md)가 시스템 전체 설정(uv 설치 여부, shell "
+"wrapper 연결 여부 등)을 확인하는 반면, `verify`는 각 환경 디렉터리 내부를 들여다보고 \"여기서 Python이 실제로 "
+"작동하는가?\"라는 질문에 답합니다."
 
 #: src/commands/verify.md:8
 msgid "# Check every environment\n"
-msgstr ""
+msgstr "# 모든 환경 확인\n"
 
-#: src/commands/verify.md:10
+#: src/commands/verify.md:10 src/commands/self.md:39
 msgid "# Machine-readable output\n"
-msgstr ""
+msgstr "# 기계 판독 가능한 출력\n"
 
 #: src/commands/verify.md:11
 msgid "# Exit 1 if any check has Fail status (default: always 0)\n"
-msgstr ""
+msgstr "# 검사가 Fail 상태인 경우 종료 1 (기본값: 항상 0)\n"
 
 #: src/commands/verify.md:14
 msgid "What gets checked"
-msgstr ""
+msgstr "검사 항목"
 
 #: src/commands/verify.md:16
 msgid "Six checks run per environment, in order:"
-msgstr ""
+msgstr "환경마다 순서대로 6가지 검사가 실행됩니다:"
 
 #: src/commands/verify.md:18
 msgid "What it means"
-msgstr ""
+msgstr "의미"
 
-#: src/commands/verify.md:20 src/development/architecture.md:84
+#: src/commands/verify.md:20 src/development/architecture.md:88
 msgid "`metadata`"
-msgstr ""
+msgstr "`metadata`"
 
 #: src/commands/verify.md:20 src/commands/verify.md:21
 #: src/commands/verify.md:22 src/commands/verify.md:23
 #: src/commands/verify.md:24
 msgid "Fail"
-msgstr ""
+msgstr "Fail"
 
 #: src/commands/verify.md:20
 msgid "`.scoop-metadata.json` is missing or unreadable"
-msgstr ""
+msgstr "`.scoop-metadata.json`이 없거나 읽을 수 없음"
 
 #: src/commands/verify.md:21
 msgid "`python_binary`"
-msgstr ""
+msgstr "`python_binary`"
 
 #: src/commands/verify.md:21
 msgid "`bin/python` (`Scripts/python.exe` on Windows) is missing"
-msgstr ""
+msgstr "`bin/python` (Windows에서는 `Scripts/python.exe`)이 없음"
 
 #: src/commands/verify.md:22
 msgid "`pyvenv_cfg`"
-msgstr ""
+msgstr "`pyvenv_cfg`"
 
 #: src/commands/verify.md:22
 msgid "`pyvenv.cfg` venv marker is missing"
-msgstr ""
+msgstr "`pyvenv.cfg` venv 마커가 없음"
 
 #: src/commands/verify.md:23
 msgid "`activate_script`"
-msgstr ""
+msgstr "`activate_script`"
 
 #: src/commands/verify.md:23
 msgid "`bin/activate` (`Scripts/Activate.ps1` on Windows) is missing"
-msgstr ""
+msgstr "`bin/activate` (Windows에서는 `Scripts/Activate.ps1`)이 없음"
 
 #: src/commands/verify.md:24
 msgid "`python_executes`"
-msgstr ""
+msgstr "`python_executes`"
 
 #: src/commands/verify.md:24
-msgid "`python --version` fails to run (Skip if the binary is already missing)"
-msgstr ""
+msgid ""
+"`python --version` fails to run (Skip if the binary is already missing)"
+msgstr "`python --version`을 실행하지 못함 (바이너리가 이미 없는 경우 건너뜀)"
 
 #: src/commands/verify.md:25
 msgid "`manifest_match`"
-msgstr ""
+msgstr "`manifest_match`"
 
 #: src/commands/verify.md:25 src/development/code-quality.md:105
 #: src/development/code-quality.md:106 src/development/code-quality.md:107
 #: src/development/code-quality.md:108 src/development/code-quality.md:109
 msgid "Warn"
-msgstr ""
+msgstr "Warn"
 
 #: src/commands/verify.md:25
 msgid ""
 "env's Python doesn't match `.scoop.toml` if a manifest exists in the cwd "
 "hierarchy (Skip otherwise)"
 msgstr ""
+"현재 디렉터리 계층에 `.scoop.toml`이 있으면 환경의 Python이 해당 매니페스트와 일치하지 않음 (그렇지 않으면 건너뜀)"
 
 #: src/commands/verify.md:27
 msgid "A check returns one of:"
-msgstr ""
+msgstr "검사는 다음 중 하나를 반환합니다:"
 
 #: src/commands/verify.md:29
 msgid "**Pass** — everything looks right"
-msgstr ""
+msgstr "**Pass** — 모두 정상"
 
 #: src/commands/verify.md:30
 msgid ""
 "**Skip** — irrelevant for this env (e.g. no `.scoop.toml`, or the "
 "prerequisite already failed)"
-msgstr ""
+msgstr "**Skip** — 이 환경과 무관함 (예: `.scoop.toml`이 없거나 전제 조건이 이미 실패한 경우)"
 
 #: src/commands/verify.md:31
 msgid "**Warn** — soft issue; env may still work"
-msgstr ""
+msgstr "**Warn** — 가벼운 문제; 환경이 여전히 동작할 수도 있음"
 
 #: src/commands/verify.md:32
 msgid "**Fail** — hard breakage; env likely unusable"
-msgstr ""
+msgstr "**Fail** — 심각한 오류; 환경을 사용할 수 없을 가능성이 높음"
 
 #: src/commands/verify.md:34
 msgid "An env is considered **healthy** when every check is Pass or Skip."
-msgstr ""
+msgstr "모든 검사가 Pass 또는 Skip인 경우 환경은 **정상(healthy)**으로 간주됩니다."
 
 #: src/commands/verify.md:38
 msgid ""
 "By default, `verify` always exits 0 — even when checks fail. This matches "
-"`doctor`'s philosophy: surfacing information shouldn't break CI just because "
-"someone wanted to look at the report. Pass `--strict` to opt into `exit 1` "
+"`doctor`'s philosophy: surfacing information shouldn't break CI just because"
+" someone wanted to look at the report. Pass `--strict` to opt into `exit 1` "
 "when any env has at least one **Fail** check (Warn alone does not trigger "
 "the non-zero exit)."
 msgstr ""
+"기본적으로 `verify`는 검사가 실패하더라도 항상 0으로 종료됩니다. 이는 `doctor`의 철학과 같습니다: 보고서를 보고 싶다는 "
+"이유만으로 정보 표시가 CI를 중단시켜서는 안 됩니다. `--strict`를 전달하면 환경에 **Fail** 검사가 하나라도 있을 때 "
+"`exit 1`이 실행됩니다(Warn만으로는 비정상 종료가 트리거되지 않습니다)."
 
 #: src/commands/verify.md:40
 msgid "verify vs doctor vs gc"
-msgstr ""
+msgstr "verify vs doctor vs gc"
 
 #: src/commands/verify.md:42
 msgid "Scope"
-msgstr ""
+msgstr "범위"
 
 #: src/commands/verify.md:42
 msgid "Action"
-msgstr ""
+msgstr "동작"
 
-#: src/commands/verify.md:44 src/development/architecture.md:83 src/api.md:714
+#: src/commands/verify.md:44 src/development/architecture.md:87 src/api.md:714
 msgid "`doctor`"
-msgstr ""
+msgstr "`doctor`"
 
 #: src/commands/verify.md:44
 msgid "System (uv install, shell wrapper, paths)"
-msgstr ""
+msgstr "시스템 (uv 설치, shell wrapper, 경로)"
 
 #: src/commands/verify.md:44
 msgid "Diagnose + optional `--fix`"
-msgstr ""
+msgstr "진단 + 선택적 `--fix`"
 
 #: src/commands/verify.md:45 src/api.md:711
 msgid "`verify`"
-msgstr ""
+msgstr "`verify`"
 
 #: src/commands/verify.md:45
 msgid "Per-env (file presence, exec, manifest)"
-msgstr ""
+msgstr "환경별 (파일 존재 여부, 실행, 매니페스트)"
 
 #: src/commands/verify.md:45
 msgid "Diagnose only"
-msgstr ""
+msgstr "진단만"
 
 #: src/commands/verify.md:46
 msgid "`gc`"
-msgstr ""
+msgstr "`gc`"
 
 #: src/commands/verify.md:46
 msgid "All envs (orphan detection)"
-msgstr ""
+msgstr "모든 환경 (고아 탐지)"
 
 #: src/commands/verify.md:46
 msgid "Diagnose + optional removal"
-msgstr ""
+msgstr "진단 + 선택적 삭제"
 
 #: src/commands/verify.md:48
 msgid ""
@@ -6266,85 +6621,87 @@ msgid ""
 "\"which envs are so broken they should just be removed?\" tool. They share "
 "territory but differ in granularity and intent."
 msgstr ""
+"`verify`는 \"이 특정 환경에 어떤 문제가 있는가?\"를 확인하는 도구입니다. `gc`는 \"너무 손상되어 그냥 삭제해야 하는 "
+"환경이 어느 것인가?\"를 확인하는 도구입니다. 두 도구는 영역을 공유하지만 세분성과 의도가 다릅니다."
 
 #: src/commands/verify.md:53
 msgid "# Quick health check on every env\n"
-msgstr ""
+msgstr "# 모든 환경에 대한 빠른 상태 확인\n"
 
 #: src/commands/verify.md:55
 msgid "# Specific env, JSON for scripting\n"
-msgstr ""
+msgstr "# 특정 환경, 스크립팅용 JSON\n"
 
 #: src/commands/verify.md:57
 msgid "'.data.envs[0].healthy'"
-msgstr ""
+msgstr "'.data.envs[0].healthy'"
 
 #: src/commands/verify.md:58
 msgid "# CI gate: fail the build if any env is broken\n"
-msgstr ""
+msgstr "# CI 게이트: 환경이 손상된 경우 빌드 실패\n"
 
-#: src/commands/verify.md:68
+#: src/commands/verify.md:68 src/commands/self.md:54
 msgid "\"verify\""
-msgstr ""
+msgstr "\"verify\""
 
 #: src/commands/verify.md:73 src/commands/verify.md:85
 msgid "\"healthy\""
-msgstr ""
+msgstr "\"healthy\""
 
 #: src/commands/verify.md:75
 msgid "\"checks\""
-msgstr ""
+msgstr "\"checks\""
 
 #: src/commands/verify.md:76 src/commands/diff.md:120
 msgid "\"metadata\""
-msgstr ""
+msgstr "\"metadata\""
 
 #: src/commands/verify.md:76 src/commands/verify.md:77
 #: src/commands/verify.md:78 src/commands/verify.md:79
 #: src/commands/verify.md:80
 msgid "\"pass\""
-msgstr ""
+msgstr "\"pass\""
 
 #: src/commands/verify.md:77
 msgid "\"python_binary\""
-msgstr ""
+msgstr "\"python_binary\""
 
 #: src/commands/verify.md:78
 msgid "\"pyvenv_cfg\""
-msgstr ""
+msgstr "\"pyvenv_cfg\""
 
 #: src/commands/verify.md:79
 msgid "\"activate_script\""
-msgstr ""
+msgstr "\"activate_script\""
 
 #: src/commands/verify.md:80
 msgid "\"python_executes\""
-msgstr ""
+msgstr "\"python_executes\""
 
 #: src/commands/verify.md:81
 msgid "\"manifest_match\""
-msgstr ""
+msgstr "\"manifest_match\""
 
 #: src/commands/verify.md:81
 msgid "\"skip\""
-msgstr ""
+msgstr "\"skip\""
 
 #: src/commands/verify.md:85
 msgid "\"issues\""
-msgstr ""
+msgstr "\"issues\""
 
 #: src/commands/verify.md:92
 msgid "[`doctor`](doctor.md) — system-level diagnostics"
-msgstr ""
+msgstr "[`doctor`](doctor.md) — 시스템 수준 진단"
 
 #: src/commands/verify.md:93
 msgid "[`gc`](gc.md) — remove broken envs detected here"
-msgstr ""
+msgstr "[`gc`](gc.md) — 여기서 감지된 손상된 환경 제거"
 
 #: src/commands/verify.md:94
 msgid ""
 "[`info`](info.md) — detailed view of a single env (without health checks)"
-msgstr ""
+msgstr "[`info`](info.md) — 단일 환경의 상세 보기 (상태 검사 없음)"
 
 #: src/commands/diff.md:3
 msgid ""
@@ -6353,120 +6710,127 @@ msgid ""
 "env and an export, or between a baseline and a working env when something "
 "breaks."
 msgstr ""
+"Python 버전, 설치된 패키지, 메타데이터를 기준으로 두 virtualenv를 비교합니다. 팀원 간 환경의 드리프트를 파악하거나, "
+"개발 환경과 내보낸 파일을 비교하거나, 무언가 깨졌을 때 기준 환경과 작동 환경을 비교하는 데 유용합니다."
 
 #: src/commands/diff.md:13
 msgid "# exit 1 if any diff\n"
-msgstr ""
+msgstr "# 차이가 있으면 exit 1\n"
 
 #: src/commands/diff.md:14
 msgid "# skip metadata section\n"
-msgstr ""
+msgstr "# 메타데이터 섹션 건너뜀\n"
 
 #: src/commands/diff.md:15
 msgid "# skip package enumeration\n"
-msgstr ""
+msgstr "# 패키지 열거 건너뜀\n"
 
 #: src/commands/diff.md:18
 msgid "What gets compared"
-msgstr ""
+msgstr "비교 항목"
 
 #: src/commands/diff.md:20
 msgid "Three independent sections, all enabled by default:"
-msgstr ""
+msgstr "기본적으로 모두 활성화된 세 가지 독립 섹션:"
 
 #: src/commands/diff.md:22
 msgid "Section"
-msgstr ""
+msgstr "섹션"
 
 #: src/commands/diff.md:22
 msgid "Fields"
-msgstr ""
+msgstr "필드"
 
 #: src/commands/diff.md:24
 msgid "**Python**"
-msgstr ""
+msgstr "**Python**"
 
 #: src/commands/diff.md:24
 msgid "`python_version` from each env's metadata"
-msgstr ""
+msgstr "각 환경의 메타데이터에서 가져온 `python_version`"
 
 #: src/commands/diff.md:25
 msgid "**Packages**"
-msgstr ""
+msgstr "**패키지**"
 
 #: src/commands/diff.md:25
 msgid "`name==version` set via `uv pip list --format=json` on each env"
-msgstr ""
+msgstr "각 환경에서 `uv pip list --format=json`으로 얻은 `name==version` 집합"
 
 #: src/commands/diff.md:26
 msgid "**Metadata**"
-msgstr ""
+msgstr "**메타데이터**"
 
 #: src/commands/diff.md:26
 msgid "`python_version`, `created_at`, `last_used`, `uv_version`"
-msgstr ""
+msgstr "`python_version`, `created_at`, `last_used`, `uv_version`"
 
 #: src/commands/diff.md:28
 msgid ""
-"Package matching uses [PEP 503](https://peps.python.org/pep-0503/) canonical "
-"names (lowercase, `-`/`_`/`.` collapsed to single `-`), so `Requests` vs "
+"Package matching uses [PEP 503](https://peps.python.org/pep-0503/) canonical"
+" names (lowercase, `-`/`_`/`.` collapsed to single `-`), so `Requests` vs "
 "`requests` and `flask_sqlalchemy` vs `Flask-SQLAlchemy` are treated as the "
 "same package."
 msgstr ""
+"패키지 매칭은 [PEP 503](https://peps.python.org/pep-0503/) 정규화 이름(소문자, "
+"`-`/`_`/`.`를 단일 `-`로 축소)을 사용하므로 `Requests`와 `requests`, `flask_sqlalchemy`와 "
+"`Flask-SQLAlchemy`는 동일한 패키지로 처리됩니다."
 
 #: src/commands/diff.md:37
 msgid "Output as JSON (see [JSON Output](#json-output))"
-msgstr ""
+msgstr "JSON으로 출력 ([JSON 출력](#json-output) 참고)"
 
 #: src/commands/diff.md:38
 msgid "Exit `1` if any differences are detected (default: always exit 0)"
-msgstr ""
+msgstr "차이가 감지되면 `1`로 종료 (기본값: 항상 0으로 종료)"
 
 #: src/commands/diff.md:39
 msgid "`--packages-only`"
-msgstr ""
+msgstr "`--packages-only`"
 
 #: src/commands/diff.md:39
 msgid "Skip the metadata section; package enumeration still runs"
-msgstr ""
+msgstr "메타데이터 섹션 건너뜀; 패키지 열거는 계속 실행"
 
 #: src/commands/diff.md:40
 msgid "`--metadata-only`"
-msgstr ""
+msgstr "`--metadata-only`"
 
 #: src/commands/diff.md:40
 msgid "Skip package enumeration (no `uv` subprocess); metadata section only"
-msgstr ""
+msgstr "패키지 열거 건너뜀 (`uv` 서브프로세스 없음); 메타데이터 섹션만"
 
 #: src/commands/diff.md:42
 msgid ""
-"`--packages-only` and `--metadata-only` are mutually exclusive (`clap`\\-"
-"enforced)."
-msgstr ""
+"`--packages-only` and `--metadata-only` are mutually exclusive "
+"(`clap`\\-enforced)."
+msgstr "`--packages-only`와 `--metadata-only`는 함께 사용할 수 없습니다(`clap`\\-강제)."
 
 #: src/commands/diff.md:45
 msgid "Global flags (`--quiet`, `--no-color`) apply."
-msgstr ""
+msgstr "전역 플래그(`--quiet`, `--no-color`)가 적용됩니다."
 
 #: src/commands/diff.md:49
 msgid ""
-"`scoop diff` follows the [layered exit-code contract](../api.md#process-exit-"
-"codes):"
-msgstr ""
+"`scoop diff` follows the [layered exit-code contract](../api.md#process-"
+"exit-codes):"
+msgstr "`scoop diff`는 [계층형 종료 코드 계약](../api.md#process-exit-codes)을 따릅니다:"
 
 #: src/commands/diff.md:53
 msgid "Default — diff reported (even if envs differ)"
-msgstr ""
+msgstr "기본값 — diff 결과 출력 (환경이 달라도)"
 
 #: src/commands/diff.md:54 src/api.md:703
 msgid "`1`"
-msgstr ""
+msgstr "`1`"
 
 #: src/commands/diff.md:54
 msgid ""
 "`--strict` was set AND at least one difference was detected "
 "(`DiffMismatch`). Same precedent as `verify --strict`."
 msgstr ""
+"`--strict`가 설정된 상태에서 차이가 하나 이상 감지된 경우(`DiffMismatch`). `verify --strict`와 같은"
+" 선례를 따릅니다."
 
 #: src/commands/diff.md:56
 msgid ""
@@ -6474,219 +6838,225 @@ msgid ""
 "the appropriate underlying `ScoopError` variant via the catchall exit `1` "
 "path; `--strict` is not required for those."
 msgstr ""
+"운영 장애(환경을 찾을 수 없음, `uv` 없음, 메타데이터 손상)는 catchall exit `1` 경로를 통해 적절한 "
+"`ScoopError` 변형을 반환합니다; 이 경우 `--strict`는 필요하지 않습니다."
 
 #: src/commands/diff.md:62
 msgid "Identical envs"
-msgstr ""
+msgstr "동일한 환경"
 
 #: src/commands/diff.md:69
 msgid "Mixed differences"
-msgstr ""
+msgstr "여러 차이 혼재"
 
 #: src/commands/diff.md:89
 msgid ""
 "The `~` marker flags changed scalar fields; `-`/`+` flag removed/added "
 "packages; absent metadata values render as `-`."
 msgstr ""
+"`~` 마커는 변경된 스칼라 필드를 표시하고, `-`/`+`는 제거/추가된 패키지를 표시하며, 없는 메타데이터 값은 `-`로 "
+"렌더링됩니다."
 
 #: src/commands/diff.md:92
 msgid "CI gate (fail the build on drift)"
-msgstr ""
+msgstr "CI 게이트 (드리프트 시 빌드 실패)"
 
 #: src/commands/diff.md:95
 msgid "# exits 1 if baseline and production diverge\n"
-msgstr ""
+msgstr "# 기준과 프로덕션이 다르면 exit 1\n"
 
 #: src/commands/diff.md:101
 msgid ""
 "`--json` emits one envelope to stdout. Success and failure envelopes share "
 "the same `data` shape; only the top-level wrapper differs."
 msgstr ""
+"`--json`은 stdout에 하나의 엔벨로프를 내보냅니다. 성공 및 실패 엔벨로프는 동일한 `data` 형태를 공유하며, 최상위 "
+"래퍼만 다릅니다."
 
 #: src/commands/diff.md:104
 msgid "Success envelope (default exit 0)"
-msgstr ""
+msgstr "성공 엔벨로프 (기본 exit 0)"
 
 #: src/commands/diff.md:109 src/commands/diff.md:143
 msgid "\"diff\""
-msgstr ""
+msgstr "\"diff\""
 
 #: src/commands/diff.md:111 src/commands/diff.md:147
 msgid "\"env_a\""
-msgstr ""
+msgstr "\"env_a\""
 
 #: src/commands/diff.md:112 src/commands/diff.md:148
 msgid "\"env_b\""
-msgstr ""
+msgstr "\"env_b\""
 
 #: src/commands/diff.md:112 src/commands/diff.md:148
 msgid "\"webapp-mirror\""
-msgstr ""
+msgstr "\"webapp-mirror\""
 
 #: src/commands/diff.md:113
 msgid "\"identical\""
-msgstr ""
+msgstr "\"identical\""
 
 #: src/commands/diff.md:114 src/commands/diff.md:121 src/commands/diff.md:122
 #: src/commands/diff.md:123 src/commands/diff.md:124
 msgid "\"a\""
-msgstr ""
+msgstr "\"a\""
 
 #: src/commands/diff.md:114 src/commands/diff.md:121 src/commands/diff.md:122
 #: src/commands/diff.md:123 src/commands/diff.md:124
 msgid "\"b\""
-msgstr ""
+msgstr "\"b\""
 
 #: src/commands/diff.md:114 src/commands/diff.md:121
 msgid "\"3.11.9\""
-msgstr ""
+msgstr "\"3.11.9\""
 
 #: src/commands/diff.md:114 src/commands/diff.md:118 src/commands/diff.md:121
 #: src/commands/diff.md:122 src/commands/diff.md:123 src/commands/diff.md:124
 msgid "\"changed\""
-msgstr ""
+msgstr "\"changed\""
 
 #: src/commands/diff.md:116
 msgid "\"added\""
-msgstr ""
+msgstr "\"added\""
 
 #: src/commands/diff.md:116
 msgid "\"pandas\""
-msgstr ""
+msgstr "\"pandas\""
 
 #: src/commands/diff.md:116
 msgid "\"2.2.0\""
-msgstr ""
+msgstr "\"2.2.0\""
 
 #: src/commands/diff.md:116 src/commands/diff.md:117
 msgid "\"display_name\""
-msgstr ""
+msgstr "\"display_name\""
 
 #: src/commands/diff.md:117
 msgid "\"removed\""
-msgstr ""
+msgstr "\"removed\""
 
 #: src/commands/diff.md:117
 msgid "\"numpy\""
-msgstr ""
+msgstr "\"numpy\""
 
 #: src/commands/diff.md:117
 msgid "\"1.26.0\""
-msgstr ""
+msgstr "\"1.26.0\""
 
 #: src/commands/diff.md:118
 msgid "\"version_a\""
-msgstr ""
+msgstr "\"version_a\""
 
 #: src/commands/diff.md:118
 msgid "\"version_b\""
-msgstr ""
+msgstr "\"version_b\""
 
 #: src/commands/diff.md:118
 msgid "\"2.32.0\""
-msgstr ""
+msgstr "\"2.32.0\""
 
 #: src/commands/diff.md:122
 msgid "\"2025-01-10T00:00:00Z\""
-msgstr ""
+msgstr "\"2025-01-10T00:00:00Z\""
 
 #: src/commands/diff.md:122
 msgid "\"2025-03-22T00:00:00Z\""
-msgstr ""
+msgstr "\"2025-03-22T00:00:00Z\""
 
 #: src/commands/diff.md:124 src/api.md:159
 msgid "\"uv_version\""
-msgstr ""
+msgstr "\"uv_version\""
 
 #: src/commands/diff.md:124
 msgid "\"0.5.14\""
-msgstr ""
+msgstr "\"0.5.14\""
 
 #: src/commands/diff.md:127 src/commands/diff.md:149
 msgid "\"differences\""
-msgstr ""
+msgstr "\"differences\""
 
 #: src/commands/diff.md:128
 msgid "\"python_changed\""
-msgstr ""
+msgstr "\"python_changed\""
 
 #: src/commands/diff.md:129
 msgid "\"packages_added\""
-msgstr ""
+msgstr "\"packages_added\""
 
 #: src/commands/diff.md:130
 msgid "\"packages_removed\""
-msgstr ""
+msgstr "\"packages_removed\""
 
 #: src/commands/diff.md:131
 msgid "\"packages_changed\""
-msgstr ""
+msgstr "\"packages_changed\""
 
 #: src/commands/diff.md:132
 msgid "\"metadata_fields_changed\""
-msgstr ""
+msgstr "\"metadata_fields_changed\""
 
 #: src/commands/diff.md:138
 msgid "Strict failure envelope (`--strict` with differences, exit 1)"
-msgstr ""
+msgstr "Strict 실패 엔벨로프 (`--strict`로 차이 감지, exit 1)"
 
 #: src/commands/diff.md:145
 msgid "\"DIFF_MISMATCH\""
-msgstr ""
+msgstr "\"DIFF_MISMATCH\""
 
 #: src/commands/diff.md:146
 msgid "\"'webapp' and 'webapp-mirror' differ (5 difference(s))\""
-msgstr ""
+msgstr "\"'webapp' and 'webapp-mirror' differ (5 difference(s))\""
 
 #: src/commands/diff.md:151
 msgid "\"...\""
-msgstr ""
+msgstr "\"...\""
 
 #: src/commands/diff.md:151
 msgid "\"same shape as success\""
-msgstr ""
+msgstr "\"same shape as success\""
 
 #: src/commands/diff.md:155
 msgid "Scalar diff fields — 2-state contract"
-msgstr ""
+msgstr "스칼라 diff 필드 — 2-상태 계약"
 
 #: src/commands/diff.md:157
 msgid ""
-"Each metadata field in `data.metadata` is a `ScalarDiff` carrying both sides "
-"as `Option<T>`:"
-msgstr ""
+"Each metadata field in `data.metadata` is a `ScalarDiff` carrying both sides"
+" as `Option<T>`:"
+msgstr "`data.metadata`의 각 메타데이터 필드는 양쪽 값을 `Option<T>`로 담은 `ScalarDiff`입니다:"
 
 #: src/commands/diff.md:160
 msgid "`a`"
-msgstr ""
+msgstr "`a`"
 
 #: src/commands/diff.md:160
 msgid "`b`"
-msgstr ""
+msgstr "`b`"
 
 #: src/commands/diff.md:160
 msgid "`changed`"
-msgstr ""
+msgstr "`changed`"
 
 #: src/commands/diff.md:162 src/commands/diff.md:163 src/commands/diff.md:164
 msgid "`\"x\"`"
-msgstr ""
+msgstr "`\"x\"`"
 
 #: src/commands/diff.md:162 src/commands/diff.md:165
 msgid "`false`"
-msgstr ""
+msgstr "`false`"
 
 #: src/commands/diff.md:163
 msgid "`\"y\"`"
-msgstr ""
+msgstr "`\"y\"`"
 
 #: src/commands/diff.md:163 src/commands/diff.md:164
 msgid "`true`"
-msgstr ""
+msgstr "`true`"
 
 #: src/commands/diff.md:164 src/commands/diff.md:165
 msgid "`null`"
-msgstr ""
+msgstr "`null`"
 
 #: src/commands/diff.md:167
 msgid ""
@@ -6694,445 +7064,557 @@ msgid ""
 "regardless of whether the metadata file was missing, the field was absent, "
 "or the field was present-as-null in the JSON. Diff intentionally does not "
 "surface the cause; if you need to know why, run `scoop info` on the env "
-"directly. (The `data.packages` shape uses non-nullable inner objects because "
-"pip never emits a \"package present but no version\" state.)"
+"directly. (The `data.packages` shape uses non-nullable inner objects because"
+" pip never emits a \"package present but no version\" state.)"
 msgstr ""
+"`null` 쪽은 **해당 쪽에서 값을 관측할 수 없음**을 의미합니다 — 메타데이터 파일이 없거나, 필드가 없거나, JSON에서 해당 "
+"필드가 null로 존재하는 경우 모두 동일합니다. diff는 의도적으로 원인을 표시하지 않습니다; 이유를 알고 싶다면 환경에서 직접 "
+"`scoop info`를 실행하세요. (`data.packages` 형태는 pip가 \"패키지는 있지만 버전 없음\" 상태를 내보내지 "
+"않으므로 내부 객체에 nullable을 사용하지 않습니다.)"
 
 #: src/commands/diff.md:175
 msgid "Mode-suppressed sections"
-msgstr ""
+msgstr "모드로 억제된 섹션"
 
 #: src/commands/diff.md:177
 msgid "`--packages-only` → `data.metadata` is `null`."
-msgstr ""
+msgstr "`--packages-only` → `data.metadata`는 `null`입니다."
 
 #: src/commands/diff.md:178
 msgid ""
-"`--metadata-only` → `data.packages` is `null`; no `uv` subprocess is spawned."
+"`--metadata-only` → `data.packages` is `null`; no `uv` subprocess is "
+"spawned."
 msgstr ""
+"`--metadata-only` → `data.packages`는 `null`이며, `uv` 서브프로세스가 실행되지 않습니다."
 
 #: src/commands/diff.md:181
 msgid "`data.python` and `data.summary` are always present."
-msgstr ""
+msgstr "`data.python`과 `data.summary`는 항상 존재합니다."
 
 #: src/commands/diff.md:185
 msgid ""
-"[`verify`](verify.md) — per-env health checks (different scope: one env at a "
-"time, not pairwise)"
-msgstr ""
+"[`verify`](verify.md) — per-env health checks (different scope: one env at a"
+" time, not pairwise)"
+msgstr "[`verify`](verify.md) — 환경별 상태 검사 (다른 범위: 쌍 비교가 아닌 한 번에 하나의 환경)"
 
 #: src/commands/diff.md:187
 msgid "[`info`](info.md) — detailed view of a single env"
-msgstr ""
+msgstr "[`info`](info.md) — 단일 환경의 상세 보기"
 
 #: src/commands/diff.md:188
 msgid "[`list`](list.md) — enumerate all envs"
-msgstr ""
+msgstr "[`list`](list.md) — 모든 환경 열거"
 
 #: src/commands/diff.md:189
 msgid "[`api.md`](../api.md) — full process exit-code contract"
-msgstr ""
+msgstr "[`api.md`](../api.md) — 전체 프로세스 종료 코드 계약"
 
 #: src/commands/lang.md:3
 msgid "Get or set the display language for scoop CLI messages."
-msgstr ""
+msgstr "scoop CLI 메시지의 표시 언어를 조회하거나 설정합니다."
 
 #: src/commands/lang.md:8
 msgid "# Show current language\n"
-msgstr ""
+msgstr "# 현재 언어 표시\n"
 
 #: src/commands/lang.md:10
 msgid "# Set language\n"
-msgstr ""
+msgstr "# 언어 설정\n"
 
 #: src/commands/lang.md:16
 msgid "# Reset to system default\n"
-msgstr ""
+msgstr "# 시스템 기본값으로 초기화\n"
 
 #: src/commands/lang.md:25
 msgid "`<code>`"
-msgstr ""
+msgstr "`<code>`"
 
 #: src/commands/lang.md:25
 msgid "Language code to set (e.g., `en`, `ko`)"
-msgstr ""
+msgstr "설정할 언어 코드 (예: `en`, `ko`)"
 
 #: src/commands/lang.md:31
 msgid "`--list`"
-msgstr ""
+msgstr "`--list`"
 
 #: src/commands/lang.md:31
 msgid "List all supported languages"
-msgstr ""
+msgstr "지원되는 언어 목록 표시"
 
 #: src/commands/lang.md:32
 msgid "`--reset`"
-msgstr ""
+msgstr "`--reset`"
 
 #: src/commands/lang.md:32
 msgid "Reset to system default language"
-msgstr ""
+msgstr "시스템 기본 언어로 초기화"
 
 #: src/commands/lang.md:35
 msgid "Supported Languages"
-msgstr ""
+msgstr "지원 언어"
 
 #: src/commands/lang.md:37
 msgid "Language"
-msgstr ""
+msgstr "언어"
 
 #: src/commands/lang.md:39
 msgid "`en`"
-msgstr ""
+msgstr "`en`"
 
 #: src/commands/lang.md:39
 msgid "English (default)"
-msgstr ""
+msgstr "English (기본값)"
 
 #: src/commands/lang.md:40
 msgid "`ko`"
-msgstr ""
+msgstr "`ko`"
 
 #: src/commands/lang.md:40
 msgid "한국어 (Korean)"
-msgstr ""
+msgstr "한국어 (Korean)"
 
 #: src/commands/lang.md:41
 msgid "`ja`"
-msgstr ""
+msgstr "`ja`"
 
 #: src/commands/lang.md:41
 msgid "日本語 (Japanese)"
-msgstr ""
+msgstr "日本語 (Japanese)"
 
 #: src/commands/lang.md:42
 msgid "`pt-BR`"
-msgstr ""
+msgstr "`pt-BR`"
 
 #: src/commands/lang.md:42
 msgid "Português (Brazilian Portuguese)"
-msgstr ""
+msgstr "Português (Brazilian Portuguese)"
 
 #: src/commands/lang.md:44
 msgid "Language Detection Priority"
-msgstr ""
+msgstr "언어 감지 우선순위"
 
 #: src/commands/lang.md:46
 msgid "`SCOOP_LANG` environment variable"
-msgstr ""
+msgstr "`SCOOP_LANG` 환경 변수"
 
 #: src/commands/lang.md:47
 msgid "`~/.scoop/config.json` setting"
-msgstr ""
+msgstr "`~/.scoop/config.json` 설정"
 
 #: src/commands/lang.md:48
 msgid "System locale (via `sys-locale`)"
-msgstr ""
+msgstr "시스템 로케일 (`sys-locale` 경유)"
 
 #: src/commands/lang.md:49
 msgid "Default: `en`"
-msgstr ""
+msgstr "기본값: `en`"
 
 #: src/commands/lang.md:53
 msgid "Show Current Language"
-msgstr ""
+msgstr "현재 언어 표시"
 
 #: src/commands/lang.md:60
 msgid "Set Korean"
-msgstr ""
+msgstr "한국어 설정"
 
 #: src/commands/lang.md:67
 msgid "List Languages"
-msgstr ""
+msgstr "언어 목록"
 
 #: src/commands/lang.md:78
 msgid "Reset to System Default"
-msgstr ""
+msgstr "시스템 기본값으로 초기화"
 
-#: src/commands/lang.md:92
+#: src/commands/lang.md:91 src/commands/lang.md:109
+msgid "\"lang\""
+msgstr "\"lang\""
+
+#: src/commands/lang.md:93
 msgid "\"current\""
-msgstr ""
+msgstr "\"current\""
 
-#: src/commands/lang.md:92 src/commands/lang.md:108
+#: src/commands/lang.md:93 src/commands/lang.md:109
 #: src/development/translation.md:48
 msgid "\"ko\""
-msgstr ""
+msgstr "\"ko\""
 
-#: src/commands/lang.md:93 src/development/translation.md:48
+#: src/commands/lang.md:94 src/development/translation.md:48
 msgid "\"한국어\""
-msgstr ""
+msgstr "\"한국어\""
 
-#: src/commands/lang.md:94
+#: src/commands/lang.md:95
 msgid "\"config\""
-msgstr ""
+msgstr "\"config\""
 
-#: src/commands/lang.md:99 src/development/code-quality.md:23
-#: src/development/code-quality.md:150 src/llms.md:192
+#: src/commands/lang.md:100 src/development/code-quality.md:23
+#: src/development/code-quality.md:150 src/llms.md:194
 msgid "Configuration"
-msgstr ""
+msgstr "설정"
 
-#: src/commands/lang.md:101
+#: src/commands/lang.md:102
 msgid "Language preference is stored in:"
-msgstr ""
+msgstr "언어 설정은 다음 위치에 저장됩니다:"
 
-#: src/commands/lang.md:108
-msgid "\"lang\""
-msgstr ""
-
-#: src/commands/lang.md:111
+#: src/commands/lang.md:112
 msgid "Environment Variable Override"
-msgstr ""
+msgstr "환경 변수 덮어쓰기"
 
-#: src/commands/lang.md:114
+#: src/commands/lang.md:115
 msgid "# Temporarily use English regardless of config\n"
-msgstr ""
+msgstr "# 설정과 관계없이 일시적으로 영어 사용\n"
 
-#: src/commands/lang.md:115 src/development/translation.md:29
+#: src/commands/lang.md:116 src/development/translation.md:29
 msgid "en"
-msgstr ""
+msgstr "en"
 
-#: src/commands/lang.md:116
+#: src/commands/lang.md:117
 msgid "# Set for current session\n"
-msgstr ""
-
-#: src/commands/lang.md:123
-msgid "CLI help text (`--help`) remains in English (industry standard)"
-msgstr ""
+msgstr "# 현재 세션에 설정\n"
 
 #: src/commands/lang.md:124
-msgid "JSON output keys remain in English (machine-readable)"
-msgstr ""
+msgid "CLI help text (`--help`) remains in English (industry standard)"
+msgstr "CLI 도움말 텍스트(`--help`)는 영어로 유지됩니다 (업계 표준)"
 
 #: src/commands/lang.md:125
+msgid "JSON output keys remain in English (machine-readable)"
+msgstr "JSON 출력 키는 영어로 유지됩니다 (기계 판독용)"
+
+#: src/commands/lang.md:126
 msgid "Error messages, success messages, and prompts are translated"
+msgstr "오류 메시지, 성공 메시지, 프롬프트는 번역됩니다"
+
+#: src/commands/self.md:1
+msgid "self update"
+msgstr "self update"
+
+#: src/commands/self.md:3
+msgid ""
+"Reinstall scoop from crates.io to update (or pin) the installed version."
+msgstr "crates.io에서 scoop을 재설치하여 업데이트하거나 특정 버전을 고정합니다."
+
+#: src/commands/self.md:15
+msgid "Reinstall even if already on the latest version"
+msgstr "이미 최신 버전인 경우에도 재설치"
+
+#: src/commands/self.md:16
+msgid "`--version <VERSION>`"
+msgstr "`--version <VERSION>`"
+
+#: src/commands/self.md:16
+msgid "Install a specific version instead of the latest"
+msgstr "최신 버전 대신 특정 버전 설치"
+
+#: src/commands/self.md:17
+msgid "`--no-verify`"
+msgstr "`--no-verify`"
+
+#: src/commands/self.md:17
+msgid "Skip the post-update `scoop doctor` verification"
+msgstr "업데이트 후 `scoop doctor` 검증 건너뜀"
+
+#: src/commands/self.md:22
+msgid ""
+"Queries crates.io (via `cargo search`) for the latest `scoop-uv` version."
+msgstr "`cargo search`를 통해 crates.io에서 최신 `scoop-uv` 버전을 조회합니다."
+
+#: src/commands/self.md:23
+msgid "Runs `cargo install --force --locked scoop-uv --version <target>`."
+msgstr "`cargo install --force --locked scoop-uv --version <target>`을 실행합니다."
+
+#: src/commands/self.md:24
+msgid ""
+"Unless `--no-verify` is set, runs `scoop doctor` with the freshly installed "
+"binary and reports the outcome."
+msgstr "`--no-verify`가 설정되지 않으면 새로 설치된 바이너리로 `scoop doctor`를 실행하고 결과를 보고합니다."
+
+#: src/commands/self.md:26
+msgid ""
+"Use `--force` to reinstall the current version (useful for repairing a "
+"broken install). Use `--version` to pin to a specific release."
 msgstr ""
+"현재 버전을 재설치하려면 `--force`를 사용하세요 (손상된 설치를 복구할 때 유용합니다). 특정 릴리스에 고정하려면 "
+"`--version`을 사용하세요."
+
+#: src/commands/self.md:31
+msgid "# Update to the latest release\n"
+msgstr "# 최신 릴리스로 업데이트\n"
+
+#: src/commands/self.md:33
+msgid "# Pin to a specific version\n"
+msgstr "# 특정 버전으로 고정\n"
+
+#: src/commands/self.md:36
+msgid "# Force reinstall of the current version\n"
+msgstr "# 현재 버전 강제 재설치\n"
+
+#: src/commands/self.md:49
+msgid "\"self update\""
+msgstr "\"self update\""
+
+#: src/commands/self.md:51
+msgid "\"from\""
+msgstr "\"from\""
+
+#: src/commands/self.md:51
+msgid "\"0.14.0\""
+msgstr "\"0.14.0\""
+
+#: src/commands/self.md:52
+msgid "\"to\""
+msgstr "\"to\""
+
+#: src/commands/self.md:52
+msgid "\"0.14.1\""
+msgstr "\"0.14.1\""
+
+#: src/commands/self.md:54
+msgid "\"passed\""
+msgstr "\"passed\""
+
+#: src/commands/self.md:59
+msgid ""
+"The `verify.status` field is one of `skipped`, `passed`, `warned`, "
+"`errored`, or `launch_failed`."
+msgstr ""
+"`verify.status` 필드는 `skipped`, `passed`, `warned`, `errored`, "
+"`launch_failed` 중 하나입니다."
+
+#: src/commands/self.md:63
+msgid "[`scoop doctor`](doctor.md) — diagnose the current installation"
+msgstr "[`scoop doctor`](doctor.md) — 현재 설치 진단"
 
 #: src/commands/init.md:3
 msgid "Output shell initialization script."
-msgstr ""
+msgstr "shell 초기화 스크립트를 출력합니다."
 
 #: src/commands/init.md:15 src/commands/completions.md:15
-#: src/development/translation.md:165
+#: src/development/translation.md:166
 msgid "`shell`"
-msgstr ""
+msgstr "`shell`"
 
 #: src/commands/init.md:15 src/commands/completions.md:15
-msgid "Shell type: `bash`, `zsh`, `fish`, `powershell`"
-msgstr ""
+msgid "Shell type: `bash`, `zsh`, `fish`, `powershell` (alias: `pwsh`)"
+msgstr "Shell 타입: `bash`, `zsh`, `fish`, `powershell` (별칭: `pwsh`)"
 
 #: src/commands/init.md:19
 msgid "Add to your shell configuration:"
-msgstr ""
+msgstr "shell 설정 파일에 추가하세요:"
 
 #: src/commands/init.md:22
 msgid "# Bash (~/.bashrc)\n"
-msgstr ""
+msgstr "# Bash (~/.bashrc)\n"
 
 #: src/commands/init.md:23
 msgid "\"$(scoop init bash)\""
-msgstr ""
+msgstr "\"$(scoop init bash)\""
 
 #: src/commands/init.md:24
 msgid "# Zsh (~/.zshrc)\n"
-msgstr ""
+msgstr "# Zsh (~/.zshrc)\n"
 
 #: src/commands/init.md:26
 msgid "\"$(scoop init zsh)\""
-msgstr ""
+msgstr "\"$(scoop init zsh)\""
 
 #: src/commands/init.md:30
 msgid "# Fish (~/.config/fish/config.fish)\n"
-msgstr ""
+msgstr "# Fish (~/.config/fish/config.fish)\n"
 
 #: src/commands/init.md:39
 msgid "Features Enabled"
-msgstr ""
+msgstr "활성화된 기능"
 
 #: src/commands/init.md:41
 msgid "Auto-activation when entering directories with `.scoop-version`"
-msgstr ""
+msgstr "`.scoop-version`이 있는 디렉터리 진입 시 자동 활성화"
 
 #: src/commands/init.md:42
 msgid "Tab completion for commands, environments, and options"
-msgstr ""
+msgstr "명령어, 환경, 옵션에 대한 탭 자동 완성"
 
 #: src/commands/init.md:43
 msgid "Wrapper function for `activate`/`deactivate`/`use`"
-msgstr ""
+msgstr "`activate`/`deactivate`/`use`용 래퍼 함수"
 
 #: src/commands/init.md:48
 msgid "# Output bash init script\n"
-msgstr ""
+msgstr "# bash 초기화 스크립트 출력\n"
 
 #: src/commands/init.md:49
 msgid "# Output zsh init script\n"
-msgstr ""
+msgstr "# zsh 초기화 스크립트 출력\n"
 
 #: src/commands/init.md:50
 msgid "# Output fish init script\n"
-msgstr ""
+msgstr "# fish 초기화 스크립트 출력\n"
 
 #: src/commands/init.md:51
 msgid "# Output PowerShell init script\n"
-msgstr ""
+msgstr "# PowerShell 초기화 스크립트 출력\n"
 
 #: src/commands/shell.md:3
 msgid "Set shell-specific environment (current shell session only)."
-msgstr ""
+msgstr "shell별 환경 설정 (현재 shell 세션에만 적용)."
 
 #: src/commands/shell.md:5
 msgid ""
 "Unlike `scoop use` which writes to a file, `scoop shell` sets the "
 "`SCOOP_VERSION` environment variable for the current shell session only."
 msgstr ""
+"파일에 기록하는 `scoop use`와 달리, `scoop shell`은 현재 shell 세션에 한해 `SCOOP_VERSION` 환경 "
+"변수를 설정합니다."
 
 #: src/commands/shell.md:10
 msgid "\"$(scoop shell <name>)\"    # Bash/Zsh\n"
-msgstr ""
+msgstr "\"$(scoop shell <name>)\"    # Bash/Zsh\n"
 
 #: src/commands/shell.md:11
 msgid "# Fish\n"
-msgstr ""
+msgstr "# Fish\n"
 
 #: src/commands/shell.md:14
 msgid ""
-"**Note:** If you have shell integration set up (`scoop init`), the `eval` is "
-"automatic:"
-msgstr ""
+"**Note:** If you have shell integration set up (`scoop init`), the `eval` is"
+" automatic:"
+msgstr "**참고:** shell 통합을 설정한 경우(`scoop init`), `eval`은 자동으로 실행됩니다:"
 
 #: src/commands/shell.md:16
 msgid "# Works directly\n"
-msgstr ""
+msgstr "# 직접 실행 가능\n"
 
 #: src/commands/shell.md:23
 msgid "Environment name or `system`"
-msgstr ""
+msgstr "환경 이름 또는 `system`"
 
 #: src/commands/shell.md:29
 msgid "Clear shell-specific environment"
-msgstr ""
+msgstr "shell별 환경 설정 초기화"
 
 #: src/commands/shell.md:30
 msgid "`--shell <SHELL>`"
-msgstr ""
+msgstr "`--shell <SHELL>`"
 
 #: src/commands/shell.md:30
 msgid "Target shell type (auto-detected if not specified)"
-msgstr ""
+msgstr "대상 shell 유형 (지정하지 않으면 자동 감지)"
 
 #: src/commands/shell.md:34
 msgid "Sets `SCOOP_VERSION` environment variable"
-msgstr ""
+msgstr "`SCOOP_VERSION` 환경 변수를 설정합니다"
 
 #: src/commands/shell.md:35
 msgid "If `name` is an environment: also outputs activation script"
-msgstr ""
+msgstr "`name`이 환경인 경우: 활성화 스크립트도 출력합니다"
 
 #: src/commands/shell.md:36
 msgid "If `name` is `system`: also outputs deactivation script"
-msgstr ""
+msgstr "`name`이 `system`인 경우: 비활성화 스크립트도 출력합니다"
 
 #: src/commands/shell.md:37
 msgid "`--unset`: outputs `unset SCOOP_VERSION`"
-msgstr ""
+msgstr "`--unset`: outputs `unset SCOOP_VERSION`"
 
 #: src/commands/shell.md:41
 msgid "`SCOOP_VERSION` has the **highest priority** in version resolution:"
-msgstr ""
+msgstr "`SCOOP_VERSION`은 버전 결정에서 **최우선 순위**를 갖습니다:"
 
 #: src/commands/shell.md:49
 msgid "This means `scoop shell` **overrides** any file-based settings until:"
-msgstr ""
+msgstr "이는 `scoop shell`이 다음 시점까지 파일 기반 설정을 **재정의**한다는 의미입니다:"
 
 #: src/commands/shell.md:50
 msgid "You run `scoop shell --unset`"
-msgstr ""
+msgstr "`scoop shell --unset`을 실행할 때"
 
 #: src/commands/shell.md:51
 msgid "You close the terminal"
-msgstr ""
+msgstr "터미널을 닫을 때"
 
 #: src/commands/shell.md:56
 msgid "# Use a specific environment in this terminal\n"
-msgstr ""
+msgstr "# 이 터미널에서 특정 환경 사용\n"
 
 #: src/commands/shell.md:58
 msgid "# Use system Python in this terminal\n"
-msgstr ""
+msgstr "# 이 터미널에서 system Python 사용\n"
 
 #: src/commands/shell.md:61
 msgid "# Clear the shell setting (return to file-based resolution)\n"
-msgstr ""
+msgstr "# shell 설정 초기화 (파일 기반 결정으로 복귀)\n"
 
 #: src/commands/shell.md:64
 msgid "# Explicit shell type\n"
-msgstr ""
+msgstr "# shell 유형 명시 지정\n"
 
 #: src/commands/shell.md:69
 msgid "Use Cases"
-msgstr ""
+msgstr "사용 사례"
 
 #: src/commands/shell.md:71
 msgid "Temporary Testing"
-msgstr ""
+msgstr "임시 테스트"
 
 #: src/commands/shell.md:74
 msgid "# Currently using myproject\n"
-msgstr ""
+msgstr "# 현재 myproject 사용 중\n"
 
 #: src/commands/shell.md:75
 msgid "# Switch to testenv temporarily\n"
-msgstr ""
+msgstr "# testenv로 임시 전환\n"
 
 #: src/commands/shell.md:76
 msgid "# Test something\n"
-msgstr ""
+msgstr "# 테스트 실행\n"
 
 #: src/commands/shell.md:77
 msgid "# Switch back\n"
-msgstr ""
+msgstr "# 다시 원래대로 전환\n"
 
 #: src/commands/shell.md:80
 msgid "Override Project Settings"
-msgstr ""
+msgstr "프로젝트 설정 재정의"
 
 #: src/commands/shell.md:83
 msgid "# Has .scoop-version = projectenv\n"
-msgstr ""
+msgstr "# .scoop-version = projectenv 설정되어 있음\n"
 
 #: src/commands/shell.md:84
 msgid "# Use system Python anyway\n"
-msgstr ""
+msgstr "# system Python 강제 사용\n"
 
 #: src/commands/shell.md:85
 msgid "# System Python\n"
-msgstr ""
+msgstr "# System Python\n"
 
 #: src/commands/shell.md:86
 msgid "# Back to projectenv\n"
-msgstr ""
+msgstr "# projectenv로 복귀\n"
 
 #: src/commands/completions.md:3
 msgid "Generate shell completion script."
-msgstr ""
+msgstr "shell 자동 완성 스크립트를 생성합니다."
 
 #: src/commands/completions.md:20
 msgid "# Output bash completions\n"
-msgstr ""
+msgstr "# bash 자동 완성 출력\n"
 
 #: src/commands/completions.md:21
 msgid "# Output zsh completions\n"
-msgstr ""
+msgstr "# zsh 자동 완성 출력\n"
 
 #: src/commands/completions.md:22
 msgid "# Output fish completions\n"
-msgstr ""
+msgstr "# fish 자동 완성 출력\n"
 
-#: src/commands/completions.md:25
+#: src/commands/completions.md:23
+msgid "# Output PowerShell completions\n"
+msgstr "# PowerShell 자동 완성 출력\n"
+
+#: src/commands/completions.md:31
 msgid ""
 "**Tip:** Usually you don't need this separately - `scoop init` includes "
 "completions."
-msgstr ""
+msgstr "**팁:** 보통 별도로 실행할 필요가 없습니다 — `scoop init`에 자동 완성이 포함되어 있습니다."
 
 #: src/commands/man.md:3
 msgid ""
@@ -7140,591 +7622,607 @@ msgid ""
 "rendered from the live CLI definition, the man pages always reflect the "
 "actual `--help` text — no separate documentation to keep in sync."
 msgstr ""
+"scoop의 `clap::Command` 트리에서 Unix man 페이지를 생성합니다. 실제 CLI 정의를 기반으로 렌더링하므로 man "
+"페이지는 항상 실제 `--help` 텍스트를 반영합니다 — 별도로 문서를 동기화할 필요가 없습니다."
 
 #: src/commands/man.md:8
 msgid "# Print the top-level scoop.1 to stdout\n"
-msgstr ""
+msgstr "# 최상위 scoop.1을 stdout으로 출력\n"
 
 #: src/commands/man.md:10
 msgid "# Preview with `man -l`\n"
-msgstr ""
+msgstr "# `man -l`로 미리보기\n"
 
 #: src/commands/man.md:13
 msgid "# Write scoop.1 + scoop-<sub>.1 (one per subcommand) into a directory\n"
-msgstr ""
+msgstr "# scoop.1 + scoop-<sub>.1 (서브커맨드별 1개)을 디렉터리에 저장\n"
 
 #: src/commands/man.md:22
 msgid "`[DIR]`"
-msgstr ""
+msgstr "`[DIR]`"
 
 #: src/commands/man.md:22
 msgid ""
 "Write `scoop.1` + `scoop-<sub>.1` files into this directory. Omit to print "
 "the top-level page to stdout."
 msgstr ""
+"`scoop.1` + `scoop-<sub>.1` 파일을 이 디렉터리에 씁니다. 생략하면 최상위 페이지를 stdout으로 출력합니다."
 
 #: src/commands/man.md:28
 msgid "Output as JSON (only meaningful with `DIR`)"
-msgstr ""
+msgstr "JSON으로 출력 (`DIR`이 지정된 경우에만 유효)"
 
 #: src/commands/man.md:30
 msgid "Packager usage"
-msgstr ""
+msgstr "패키저 사용 방법"
 
 #: src/commands/man.md:32
 msgid "Distro packagers can wire this into their build recipe:"
-msgstr ""
+msgstr "배포 패키지 관리자는 이를 빌드 레시피에 연결할 수 있습니다:"
 
 #: src/commands/man.md:35
 msgid "# In your build script\n"
-msgstr ""
+msgstr "# 빌드 스크립트에서\n"
 
 #: src/commands/man.md:41
 msgid ""
 "Hidden subcommands (`activate`, `deactivate`, `resolve` — internal to the "
 "shell wrapper) are intentionally **not** rendered: they're not user-facing."
 msgstr ""
+"숨겨진 서브커맨드(`activate`, `deactivate`, `resolve` — shell 래퍼 내부용)는 의도적으로 렌더링하지 "
+"**않습니다**: 사용자에게 노출되는 명령이 아니기 때문입니다."
 
 #: src/commands/man.md:45
 msgid ""
 "[`completions`](completions.md) — shell completion scripts (also generated "
 "from `clap::Command`)"
 msgstr ""
+"[`completions`](completions.md) — shell 자동 완성 스크립트 (`clap::Command`에서도 생성)"
 
 #: src/development/contributing.md:3
 msgid "Guide for contributing to scoop development."
-msgstr ""
+msgstr "scoop 개발에 기여하기 위한 가이드입니다."
 
 #: src/development/contributing.md:7
 msgid "**Rust 1.85+** (Edition 2024)"
-msgstr ""
+msgstr "**Rust 1.85+** (Edition 2024)"
 
 #: src/development/contributing.md:8
 msgid ""
 "**uv** - Python package manager ([install](https://github.com/astral-sh/uv))"
-msgstr ""
+msgstr "**uv** - Python 패키지 관리자 ([설치](https://github.com/astral-sh/uv))"
 
 #: src/development/contributing.md:9
 msgid "**prek** - Pre-commit hooks ([install](https://github.com/j178/prek))"
-msgstr ""
+msgstr "**prek** - Pre-commit hooks ([설치](https://github.com/j178/prek))"
 
 #: src/development/contributing.md:14
 msgid "# Clone the repository\n"
-msgstr ""
+msgstr "# 저장소 클론\n"
 
 #: src/development/contributing.md:17
 msgid "# Install prek (Rust-native pre-commit alternative)\n"
-msgstr ""
+msgstr "# prek 설치 (Rust 기반 pre-commit 대안)\n"
 
 #: src/development/contributing.md:19
 msgid "# or: cargo install prek\n"
-msgstr ""
+msgstr "# or: cargo install prek\n"
 
 #: src/development/contributing.md:21
 msgid "# Install git hooks\n"
-msgstr ""
+msgstr "# git hooks 설치\n"
 
 #: src/development/contributing.md:24
 msgid "# Build\n"
-msgstr ""
+msgstr "# 빌드\n"
 
 #: src/development/contributing.md:27
 msgid "# Run tests\n"
-msgstr ""
+msgstr "# 테스트 실행\n"
 
 #: src/development/contributing.md:32
 msgid "Project Structure"
-msgstr ""
-
-#: src/development/contributing.md:85
-msgid "Build and Run"
-msgstr ""
-
-#: src/development/contributing.md:88
-msgid "# Debug build\n"
-msgstr ""
+msgstr "프로젝트 구조"
 
 #: src/development/contributing.md:89
-msgid "# Release build (optimized)\n"
-msgstr ""
-
-#: src/development/contributing.md:90
-msgid "# Show help\n"
-msgstr ""
-
-#: src/development/contributing.md:91
-msgid "# Run commands\n"
-msgstr ""
+msgid "Build and Run"
+msgstr "빌드 및 실행"
 
 #: src/development/contributing.md:92
-msgid "# Check setup health\n"
-msgstr ""
+msgid "# Debug build\n"
+msgstr "# 디버그 빌드\n"
+
+#: src/development/contributing.md:93
+msgid "# Release build (optimized)\n"
+msgstr "# 릴리스 빌드 (최적화)\n"
+
+#: src/development/contributing.md:94
+msgid "# Show help\n"
+msgstr "# 도움말 표시\n"
 
 #: src/development/contributing.md:95
-msgid "Quick Quality Check"
-msgstr ""
+msgid "# Run commands\n"
+msgstr "# 명령 실행\n"
 
-#: src/development/contributing.md:98
-msgid "# All checks at once (recommended before commit)\n"
-msgstr ""
+#: src/development/contributing.md:96
+msgid "# Check setup health\n"
+msgstr "# 설정 상태 점검\n"
+
+#: src/development/contributing.md:99
+msgid "Quick Quality Check"
+msgstr "빠른 품질 검사"
 
 #: src/development/contributing.md:102
+msgid "# All checks at once (recommended before commit)\n"
+msgstr "# 모든 검사 한 번에 실행 (커밋 전 권장)\n"
+
+#: src/development/contributing.md:106
 msgid "For detailed guides, see:"
-msgstr ""
+msgstr "자세한 가이드는 다음을 참고하세요:"
 
-#: src/development/contributing.md:104
+#: src/development/contributing.md:108
 msgid "**[Testing](testing.md)** - Comprehensive testing guide"
-msgstr ""
-
-#: src/development/contributing.md:105
-msgid ""
-"**[Code Quality](code-quality.md)** - Formatting, linting, pre-commit hooks"
-msgstr ""
+msgstr "**[테스트](testing.md)** - 종합 테스트 가이드"
 
 #: src/development/contributing.md:109
-msgid "Key Services"
-msgstr ""
-
-#: src/development/contributing.md:111
-msgid "**VirtualenvService** (`src/core/virtualenv/`)"
-msgstr ""
+msgid ""
+"**[Code Quality](code-quality.md)** - Formatting, linting, pre-commit hooks"
+msgstr "**[코드 품질](code-quality.md)** - 포매팅, 린팅, pre-commit hooks"
 
 #: src/development/contributing.md:113
+msgid "Key Services"
+msgstr "핵심 서비스"
+
+#: src/development/contributing.md:115
+msgid "**VirtualenvService** (`src/core/virtualenv/`)"
+msgstr "**VirtualenvService** (`src/core/virtualenv/`)"
+
+#: src/development/contributing.md:117
 msgid "Manages virtualenvs in `~/.scoop/virtualenvs/`"
-msgstr ""
-
-#: src/development/contributing.md:114
-msgid "Wraps uv commands for venv creation"
-msgstr ""
-
-#: src/development/contributing.md:116
-msgid "**VersionService** (`src/core/version.rs`)"
-msgstr ""
+msgstr "`~/.scoop/virtualenvs/`에서 virtualenv를 관리합니다"
 
 #: src/development/contributing.md:118
+msgid "Wraps uv commands for venv creation"
+msgstr "venv 생성을 위해 uv 명령을 래핑합니다"
+
+#: src/development/contributing.md:120
+msgid "**VersionService** (`src/core/version.rs`)"
+msgstr "**VersionService** (`src/core/version.rs`)"
+
+#: src/development/contributing.md:122
 msgid "Manages `.scoop-version` files"
-msgstr ""
-
-#: src/development/contributing.md:119
-msgid "Resolves current directory to active environment"
-msgstr ""
-
-#: src/development/contributing.md:121
-msgid "**Doctor** (`src/core/doctor.rs`)"
-msgstr ""
+msgstr "`.scoop-version` 파일을 관리합니다"
 
 #: src/development/contributing.md:123
+msgid "Resolves current directory to active environment"
+msgstr "현재 디렉터리를 활성 환경으로 결정합니다"
+
+#: src/development/contributing.md:125
+msgid "**Doctor** (`src/core/doctor.rs`)"
+msgstr "**Doctor** (`src/core/doctor.rs`)"
+
+#: src/development/contributing.md:127
 msgid "Health diagnostics for scoop setup"
-msgstr ""
-
-#: src/development/contributing.md:124
-msgid "Checks uv, shell integration, paths, environments"
-msgstr ""
-
-#: src/development/contributing.md:126
-msgid "**UvClient** (`src/uv/client.rs`)"
-msgstr ""
+msgstr "scoop 설정의 상태를 진단합니다"
 
 #: src/development/contributing.md:128
-msgid "Wrapper for `uv` CLI commands"
-msgstr ""
+msgid "Checks uv, shell integration, paths, environments"
+msgstr "uv, shell 통합, 경로, 환경을 점검합니다"
 
-#: src/development/contributing.md:129
-msgid "Python version management"
-msgstr ""
+#: src/development/contributing.md:130
+msgid "**UvClient** (`src/uv/client.rs`)"
+msgstr "**UvClient** (`src/uv/client.rs`)"
+
+#: src/development/contributing.md:132
+msgid "Wrapper for `uv` CLI commands"
+msgstr "`uv` CLI 명령의 래퍼입니다"
 
 #: src/development/contributing.md:133
+msgid "Python version management"
+msgstr "Python 버전 관리"
+
+#: src/development/contributing.md:137
 msgid "Shell scripts are embedded in Rust code:"
-msgstr ""
+msgstr "Shell 스크립트는 Rust 코드에 내장되어 있습니다:"
 
-#: src/development/contributing.md:135
+#: src/development/contributing.md:139
 msgid "`src/shell/bash.rs` - Bash init script"
-msgstr ""
-
-#: src/development/contributing.md:136
-msgid "`src/shell/zsh.rs` - Zsh init script"
-msgstr ""
-
-#: src/development/contributing.md:138
-msgid "Key components:"
-msgstr ""
+msgstr "`src/shell/bash.rs` - Bash 초기화 스크립트"
 
 #: src/development/contributing.md:140
-msgid "**Wrapper function** - Intercepts `use`/`activate`/`deactivate`"
-msgstr ""
-
-#: src/development/contributing.md:141
-msgid "**Hook function** - Auto-activation on directory change"
-msgstr ""
+msgid "`src/shell/zsh.rs` - Zsh init script"
+msgstr "`src/shell/zsh.rs` - Zsh 초기화 스크립트"
 
 #: src/development/contributing.md:142
-msgid "**Completion function** - Tab completion"
-msgstr ""
+msgid "Key components:"
+msgstr "핵심 구성 요소:"
 
-#: src/development/contributing.md:144 src/api.md:593
-msgid "Adding a New Command"
-msgstr ""
+#: src/development/contributing.md:144
+msgid "**Wrapper function** - Intercepts `use`/`activate`/`deactivate`"
+msgstr "**래퍼 함수** - `use`/`activate`/`deactivate`를 가로챕니다"
+
+#: src/development/contributing.md:145
+msgid "**Hook function** - Auto-activation on directory change"
+msgstr "**Hook 함수** - 디렉터리 변경 시 자동 활성화"
 
 #: src/development/contributing.md:146
-msgid "Define command in `src/cli/mod.rs`:"
-msgstr ""
+msgid "**Completion function** - Tab completion"
+msgstr "**자동 완성 함수** - Tab 자동 완성"
 
-#: src/development/contributing.md:151 src/development/contributing.md:187
-#: src/development/architecture.md:145 src/development/architecture.md:155
+#: src/development/contributing.md:148 src/api.md:593
+msgid "Adding a New Command"
+msgstr "새 명령 추가하기"
+
+#: src/development/contributing.md:150
+msgid "Define command in `src/cli/mod.rs`:"
+msgstr "`src/cli/mod.rs`에 명령을 정의합니다:"
+
+#: src/development/contributing.md:155 src/development/contributing.md:191
+#: src/development/architecture.md:149 src/development/architecture.md:159
 #: src/development/code-quality.md:292
 msgid "// ...\n"
-msgstr ""
+msgstr "// ...\n"
 
-#: src/development/contributing.md:159
+#: src/development/contributing.md:163
 msgid "Create handler in `src/cli/commands/my_command.rs`:"
-msgstr ""
+msgstr "`src/cli/commands/my_command.rs`에 핸들러를 생성합니다:"
 
-#: src/development/contributing.md:163 src/api.md:613
+#: src/development/contributing.md:167 src/api.md:613
 msgid "// Implementation\n"
-msgstr ""
-
-#: src/development/contributing.md:168
-msgid "Export in `src/cli/commands/mod.rs`"
-msgstr ""
-
-#: src/development/contributing.md:170
-msgid "Wire up in `src/main.rs`"
-msgstr ""
+msgstr "// Implementation\n"
 
 #: src/development/contributing.md:172
+msgid "Export in `src/cli/commands/mod.rs`"
+msgstr "`src/cli/commands/mod.rs`에서 export합니다"
+
+#: src/development/contributing.md:174
+msgid "Wire up in `src/main.rs`"
+msgstr "`src/main.rs`에 연결합니다"
+
+#: src/development/contributing.md:176
 msgid "Add shell completion in `src/shell/{bash,zsh}.rs`"
-msgstr ""
+msgstr "`src/shell/{bash,zsh}.rs`에 shell 자동 완성을 추가합니다"
 
-#: src/development/contributing.md:176 src/development/testing.md:99
+#: src/development/contributing.md:180 src/development/testing.md:99
 msgid "Unit Tests"
-msgstr ""
+msgstr "단위 테스트"
 
-#: src/development/contributing.md:178
+#: src/development/contributing.md:182
 msgid "Located within source files:"
-msgstr ""
+msgstr "소스 파일 내에 위치합니다:"
 
-#: src/development/contributing.md:192
+#: src/development/contributing.md:196
 msgid "Integration Tests"
-msgstr ""
+msgstr "통합 테스트"
 
-#: src/development/contributing.md:194
+#: src/development/contributing.md:198
 msgid "Located in `tests/`:"
-msgstr ""
+msgstr "`tests/`에 위치합니다:"
 
-#: src/development/contributing.md:201 src/development/testing.md:270
+#: src/development/contributing.md:205 src/development/testing.md:270
 #: src/development/testing.md:280
 msgid "\"scoop\""
-msgstr ""
+msgstr "\"scoop\""
 
-#: src/development/contributing.md:203 src/development/testing.md:272
+#: src/development/contributing.md:207 src/development/testing.md:272
 msgid "\"list\""
-msgstr ""
-
-#: src/development/contributing.md:209
-msgid "Release Process"
-msgstr ""
-
-#: src/development/contributing.md:211
-msgid "Releases are automated via [release-plz](https://release-plz.dev/):"
-msgstr ""
+msgstr "\"list\""
 
 #: src/development/contributing.md:213
-msgid "Create PR with changes"
-msgstr ""
-
-#: src/development/contributing.md:214
-msgid "Merge to main"
-msgstr ""
+msgid "Release Process"
+msgstr "릴리스 프로세스"
 
 #: src/development/contributing.md:215
-msgid "release-plz creates release PR"
-msgstr ""
+msgid "Releases are automated via [release-plz](https://release-plz.dev/):"
+msgstr "릴리스는 [release-plz](https://release-plz.dev/)를 통해 자동화됩니다:"
 
-#: src/development/contributing.md:216
-msgid "Merge release PR to publish to crates.io"
-msgstr ""
+#: src/development/contributing.md:217
+msgid "Create PR with changes"
+msgstr "변경 사항을 담은 PR 생성"
 
 #: src/development/contributing.md:218
-msgid "Internal Documentation"
-msgstr ""
+msgid "Merge to main"
+msgstr "main으로 병합"
+
+#: src/development/contributing.md:219
+msgid "release-plz creates release PR"
+msgstr "release-plz가 릴리스 PR을 생성합니다"
 
 #: src/development/contributing.md:220
-msgid "See `.docs/` for internal technical references:"
-msgstr ""
+msgid "Merge release PR to publish to crates.io"
+msgstr "릴리스 PR을 병합하여 crates.io에 게시"
 
 #: src/development/contributing.md:222
-msgid "`TECHNICAL_REFERENCE.md` - Implementation details"
-msgstr ""
-
-#: src/development/contributing.md:223
-msgid "`SHELL_GOTCHAS.md` - Shell integration pitfalls"
-msgstr ""
+msgid "Internal Documentation"
+msgstr "내부 문서"
 
 #: src/development/contributing.md:224
-msgid "`IMPLEMENTATION_PLAN.md` - Development roadmap"
-msgstr ""
+msgid "See `.docs/` for internal technical references:"
+msgstr "내부 기술 참고 문서는 `.docs/`를 참고하세요:"
 
-#: src/development/contributing.md:225
-msgid "`brand/brand.md` - Brand guidelines"
-msgstr ""
+#: src/development/contributing.md:226
+msgid "`TECHNICAL_REFERENCE.md` - Implementation details"
+msgstr "`TECHNICAL_REFERENCE.md` - 구현 세부 사항"
 
 #: src/development/contributing.md:227
-msgid "Code Style"
-msgstr ""
+msgid "`SHELL_GOTCHAS.md` - Shell integration pitfalls"
+msgstr "`SHELL_GOTCHAS.md` - Shell 통합 시 주의 사항"
+
+#: src/development/contributing.md:228
+msgid "`IMPLEMENTATION_PLAN.md` - Development roadmap"
+msgstr "`IMPLEMENTATION_PLAN.md` - 개발 로드맵"
 
 #: src/development/contributing.md:229
-msgid "Follow Rust conventions"
-msgstr ""
-
-#: src/development/contributing.md:230
-msgid "Run `cargo fmt` before committing"
-msgstr ""
+msgid "`brand/brand.md` - Brand guidelines"
+msgstr "`brand/brand.md` - 브랜드 가이드라인"
 
 #: src/development/contributing.md:231
-msgid "Keep functions small and focused"
-msgstr ""
-
-#: src/development/contributing.md:232
-msgid "Document public APIs with `///` comments"
-msgstr ""
+msgid "Code Style"
+msgstr "코드 스타일"
 
 #: src/development/contributing.md:233
-msgid "Use `thiserror` for error types"
-msgstr ""
+msgid "Follow Rust conventions"
+msgstr "Rust 관례를 따릅니다"
 
 #: src/development/contributing.md:234
+msgid "Run `cargo fmt` before committing"
+msgstr "커밋 전에 `cargo fmt`를 실행합니다"
+
+#: src/development/contributing.md:235
+msgid "Keep functions small and focused"
+msgstr "함수는 작고 명확하게 유지합니다"
+
+#: src/development/contributing.md:236
+msgid "Document public APIs with `///` comments"
+msgstr "공개 API는 `///` 주석으로 문서화합니다"
+
+#: src/development/contributing.md:237
+msgid "Use `thiserror` for error types"
+msgstr "오류 타입에는 `thiserror`를 사용합니다"
+
+#: src/development/contributing.md:238
 msgid "Translated error messages with solutions (en, ko, ja, pt-BR)"
-msgstr ""
+msgstr "다국어 오류 메시지와 해결 방법 (en, ko, ja, pt-BR)"
 
 #: src/development/translation.md:1
 msgid "Translation Guide"
-msgstr ""
+msgstr "번역 가이드"
 
 #: src/development/translation.md:3
 msgid ""
 "This document provides guidelines for contributing translations to scoop."
-msgstr ""
+msgstr "이 문서는 scoop에 번역을 기여하기 위한 가이드라인을 제공합니다."
 
 #: src/development/translation.md:5
 msgid "Current Status"
-msgstr ""
+msgstr "현재 상태"
 
 #: src/development/translation.md:7
 msgid "For the latest translation status, see:"
-msgstr ""
+msgstr "최신 번역 현황은 다음을 참고하세요:"
 
 #: src/development/translation.md:9
 msgid ""
-"**[Issue #42: i18n Translation Tracking](https://github.com/ai-screams/scoop-"
-"uv/issues/42)**"
+"**[Issue #42: i18n Translation Tracking](https://github.com/ai-"
+"screams/scoop-uv/issues/42)**"
 msgstr ""
+"**[Issue #42: i18n 번역 현황 추적](https://github.com/ai-screams/scoop-"
+"uv/issues/42)**"
 
 #: src/development/translation.md:10
 msgid "Run `scoop lang --list` to see currently supported languages"
-msgstr ""
+msgstr "`scoop lang --list`를 실행해 현재 지원 언어를 확인하세요"
 
 #: src/development/translation.md:14
 msgid "Contribution Process"
-msgstr ""
+msgstr "기여 프로세스"
 
 #: src/development/translation.md:16
 msgid "Step 1: Fork and Clone"
-msgstr ""
+msgstr "1단계: Fork 및 Clone"
 
 #: src/development/translation.md:23
 msgid "Step 2: Add Translations"
-msgstr ""
+msgstr "2단계: 번역 추가"
 
 #: src/development/translation.md:25
 msgid "Edit `locales/app.yml` and add your language to **every key**:"
-msgstr ""
+msgstr "`locales/app.yml`을 편집하여 **모든 키**에 언어를 추가합니다:"
 
 #: src/development/translation.md:28
 msgid "create.success"
-msgstr ""
+msgstr "create.success"
 
 #: src/development/translation.md:29
 msgid "\"Created '%{name}' environment\""
-msgstr ""
+msgstr "\"Created '%{name}' environment\""
 
 #: src/development/translation.md:30 src/development/docs-translation.md:85
 msgid "ko"
-msgstr ""
+msgstr "ko"
 
 #: src/development/translation.md:30
 msgid "\"'%{name}' 환경 생성됨\""
-msgstr ""
+msgstr "\"'%{name}' 환경 생성됨\""
 
 #: src/development/translation.md:31
 msgid "pt-BR"
-msgstr ""
+msgstr "pt-BR"
 
 #: src/development/translation.md:31
 msgid "\"Ambiente '%{name}' criado\""
-msgstr ""
+msgstr "\"Ambiente '%{name}' criado\""
 
 #: src/development/translation.md:32
 msgid "\"Your translation here\"  # Add your language code and translation\n"
-msgstr ""
+msgstr "\"Your translation here\"  # Add your language code and translation\n"
 
 #: src/development/translation.md:35
 msgid "**Important:**"
-msgstr ""
+msgstr "**중요:**"
 
 #: src/development/translation.md:37
-msgid "Add translations to all ~115 keys"
-msgstr ""
+msgid "Add translations to all ~220 keys"
+msgstr "모든 ~220개 키에 번역을 추가합니다"
 
 #: src/development/translation.md:38
 msgid "Keep placeholder syntax exactly: `%{name}`, `%{version}`, etc."
-msgstr ""
+msgstr "플레이스홀더 문법을 정확히 유지합니다: `%{name}`, `%{version}` 등"
 
 #: src/development/translation.md:39
 msgid "Preserve special characters: `→`, quotes, backticks"
-msgstr ""
+msgstr "특수 문자를 그대로 유지합니다: `→`, 따옴표, 백틱"
 
 #: src/development/translation.md:41
 msgid "Step 3: Register Language"
-msgstr ""
+msgstr "3단계: 언어 등록"
 
 #: src/development/translation.md:43
 msgid "Edit `src/i18n.rs` and add your language to `SUPPORTED_LANGS`:"
-msgstr ""
+msgstr "`src/i18n.rs`를 편집하여 `SUPPORTED_LANGS`에 언어를 추가합니다:"
 
-#: src/development/translation.md:47 src/development/translation.md:245
+#: src/development/translation.md:47 src/development/translation.md:246
 msgid "\"en\""
-msgstr ""
+msgstr "\"en\""
 
-#: src/development/translation.md:47 src/development/translation.md:245
+#: src/development/translation.md:47 src/development/translation.md:246
 msgid "\"English\""
-msgstr ""
+msgstr "\"English\""
 
 #: src/development/translation.md:49
+msgid "\"ja\""
+msgstr "\"ja\""
+
+#: src/development/translation.md:49
+msgid "\"日本語\""
+msgstr "\"日本語\""
+
+#: src/development/translation.md:50
 msgid "\"pt-BR\""
-msgstr ""
+msgstr "\"pt-BR\""
 
-#: src/development/translation.md:49
+#: src/development/translation.md:50
 msgid "\"Português (Brasil)\""
-msgstr ""
+msgstr "\"Português (Brasil)\""
 
-#: src/development/translation.md:50
+#: src/development/translation.md:51
 msgid "\"{lang}\""
-msgstr ""
+msgstr "\"{lang}\""
 
-#: src/development/translation.md:50
+#: src/development/translation.md:51
 msgid "\"Your Language Name\""
-msgstr ""
+msgstr "\"Your Language Name\""
 
-#: src/development/translation.md:50
+#: src/development/translation.md:51
 msgid "// Add your language\n"
-msgstr ""
+msgstr "// Add your language\n"
 
-#: src/development/translation.md:54
+#: src/development/translation.md:55
 msgid "**Language Code Format:**"
-msgstr ""
-
-#: src/development/translation.md:56
-msgid "Use [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) format"
-msgstr ""
+msgstr "**언어 코드 형식:**"
 
 #: src/development/translation.md:57
-msgid "Simple languages: `ja`, `fr`, `es`, `de`, `it`"
-msgstr ""
+msgid "Use [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) format"
+msgstr "[BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) 형식을 사용합니다"
 
 #: src/development/translation.md:58
+msgid "Simple languages: `ja`, `fr`, `es`, `de`, `it`"
+msgstr "단순 언어: `ja`, `fr`, `es`, `de`, `it`"
+
+#: src/development/translation.md:59
 msgid "Regional variants: `pt-BR`, `zh-CN`, `zh-TW`, `es-MX`"
-msgstr ""
+msgstr "지역 변형: `pt-BR`, `zh-CN`, `zh-TW`, `es-MX`"
 
-#: src/development/translation.md:60
+#: src/development/translation.md:61
 msgid "Step 4: Test Locally"
-msgstr ""
+msgstr "4단계: 로컬 테스트"
 
-#: src/development/translation.md:63
+#: src/development/translation.md:64
 msgid "# Build and test\n"
-msgstr ""
+msgstr "# 빌드 및 테스트\n"
 
-#: src/development/translation.md:66
+#: src/development/translation.md:67
 msgid "# Test your language (replace {lang} with your language code)\n"
-msgstr ""
+msgstr "# 언어 테스트 ({lang}을 언어 코드로 교체)\n"
 
-#: src/development/translation.md:69
+#: src/development/translation.md:70
 msgid "{lang}"
-msgstr ""
+msgstr "{lang}"
 
-#: src/development/translation.md:72
+#: src/development/translation.md:73
 msgid "Step 5: Create Pull Request"
-msgstr ""
+msgstr "5단계: Pull Request 생성"
 
-#: src/development/translation.md:74
+#: src/development/translation.md:75
 msgid "**Required files in PR:**"
-msgstr ""
-
-#: src/development/translation.md:76
-msgid "`locales/app.yml` - All 115 keys translated"
-msgstr ""
+msgstr "**PR에 필요한 파일:**"
 
 #: src/development/translation.md:77
+msgid "`locales/app.yml` - All 220 keys translated"
+msgstr "`locales/app.yml` - 220개 키 모두 번역"
+
+#: src/development/translation.md:78
 msgid "`src/i18n.rs` - Language registered in SUPPORTED_LANGS"
-msgstr ""
+msgstr "`src/i18n.rs` - SUPPORTED_LANGS에 언어 등록"
 
-#: src/development/translation.md:79
+#: src/development/translation.md:80
 msgid "**PR Title Format:**"
-msgstr ""
+msgstr "**PR 제목 형식:**"
 
-#: src/development/translation.md:87
+#: src/development/translation.md:88
 msgid "Style Guidelines"
-msgstr ""
+msgstr "스타일 가이드라인"
 
-#: src/development/translation.md:89
+#: src/development/translation.md:90
 msgid "Philosophy: Your Language, Your Style"
-msgstr ""
+msgstr "철학: 내 언어, 내 스타일"
 
-#: src/development/translation.md:91
+#: src/development/translation.md:92
 msgid "**We trust translators.** You know your language and community best."
-msgstr ""
-
-#: src/development/translation.md:93
-msgid ""
-"**Word choice is yours** — Pick terms that feel natural to native speakers"
-msgstr ""
+msgstr "**번역자를 신뢰합니다.** 본인의 언어와 커뮤니티를 가장 잘 아는 분은 번역자 자신입니다."
 
 #: src/development/translation.md:94
 msgid ""
-"**Creativity welcome** — Witty expressions are fine if they're clear and "
-"widely understood"
-msgstr ""
+"**Word choice is yours** — Pick terms that feel natural to native speakers"
+msgstr "**단어 선택은 번역자의 몫입니다** — 원어민에게 자연스럽게 느껴지는 표현을 선택하세요"
 
 #: src/development/translation.md:95
 msgid ""
+"**Creativity welcome** — Witty expressions are fine if they're clear and "
+"widely understood"
+msgstr "**창의성을 환영합니다** — 의미가 명확하고 널리 이해되는 재치 있는 표현도 좋습니다"
+
+#: src/development/translation.md:96
+msgid ""
 "**Casual over formal** — scoop is a friendly CLI tool, not enterprise "
 "software"
-msgstr ""
+msgstr "**격식보다 친근함** — scoop은 친근한 CLI 도구이지, 기업용 소프트웨어가 아닙니다"
 
-#: src/development/translation.md:97
+#: src/development/translation.md:98
 msgid "General Principles"
-msgstr ""
-
-#: src/development/translation.md:99
-msgid "**Concise**: CLI messages should be short and clear"
-msgstr ""
+msgstr "기본 원칙"
 
 #: src/development/translation.md:100
-msgid "**Natural**: Use natural phrasing, not word-for-word translation"
-msgstr ""
+msgid "**Concise**: CLI messages should be short and clear"
+msgstr "**간결함**: CLI 메시지는 짧고 명확해야 합니다"
 
 #: src/development/translation.md:101
-msgid "**Casual**: Friendly, approachable tone — like talking to a colleague"
-msgstr ""
+msgid "**Natural**: Use natural phrasing, not word-for-word translation"
+msgstr "**자연스러움**: 단어 대 단어 번역이 아닌 자연스러운 표현을 사용합니다"
 
 #: src/development/translation.md:102
+msgid "**Casual**: Friendly, approachable tone — like talking to a colleague"
+msgstr "**친근함**: 동료에게 말하듯 친근하고 편안한 어조"
+
+#: src/development/translation.md:103
 msgid "**Clear**: Wit is great, but clarity comes first"
-msgstr ""
+msgstr "**명확함**: 재치도 좋지만 명확함이 우선입니다"
 
-#: src/development/translation.md:104
+#: src/development/translation.md:105
 msgid "Tone Examples"
-msgstr ""
+msgstr "어조 예시"
 
-#: src/development/translation.md:106
+#: src/development/translation.md:107
 msgid ""
 "```\n"
 "# Too formal (avoid)\n"
@@ -7738,456 +8236,470 @@ msgid ""
 "\"'myenv' is ready\"\n"
 "```"
 msgstr ""
+"```\n"
+"# 너무 격식체 (지양)\n"
+"\"The environment has been successfully created.\"\n"
+"\n"
+"# 너무 기계적 (지양)\n"
+"\"Environment creation: complete.\"\n"
+"\n"
+"# 좋은 예 - 친근하고 명확함\n"
+"\"Created 'myenv' — ready to go!\"\n"
+"\"'myenv' is ready\"\n"
+"```"
 
-#: src/development/translation.md:118
+#: src/development/translation.md:119
 msgid "Message Types"
-msgstr ""
+msgstr "메시지 유형"
 
-#: src/development/translation.md:120
+#: src/development/translation.md:121
 msgid "Type"
-msgstr ""
+msgstr "유형"
 
-#: src/development/translation.md:120
+#: src/development/translation.md:121
 msgid "English Example"
-msgstr ""
+msgstr "영어 예시"
 
-#: src/development/translation.md:120 src/development/translation.md:207
+#: src/development/translation.md:121 src/development/translation.md:208
 msgid "Guidance"
-msgstr ""
+msgstr "안내"
 
-#: src/development/translation.md:122
+#: src/development/translation.md:123
 msgid "Progress"
-msgstr ""
+msgstr "진행 중"
 
-#: src/development/translation.md:122
+#: src/development/translation.md:123
 msgid "\"Installing...\""
-msgstr ""
+msgstr "\"Installing...\""
 
-#: src/development/translation.md:122
+#: src/development/translation.md:123
 msgid "Use progressive/ongoing form"
-msgstr ""
+msgstr "진행형을 사용합니다"
 
-#: src/development/translation.md:123 src/api.md:702
+#: src/development/translation.md:124 src/api.md:702
 msgid "Success"
-msgstr ""
+msgstr "완료"
 
-#: src/development/translation.md:123
+#: src/development/translation.md:124
 msgid "\"Created 'myenv'\""
-msgstr ""
+msgstr "\"Created 'myenv'\""
 
-#: src/development/translation.md:123
+#: src/development/translation.md:124
 msgid "Completion — feel free to add flair"
-msgstr ""
+msgstr "완료 — 자유롭게 개성을 더해도 좋습니다"
 
-#: src/development/translation.md:124
+#: src/development/translation.md:125
 msgid "Error"
-msgstr ""
+msgstr "오류"
 
-#: src/development/translation.md:124
+#: src/development/translation.md:125
 msgid "\"Can't find 'myenv'\""
-msgstr ""
+msgstr "\"Can't find 'myenv'\""
 
-#: src/development/translation.md:124
+#: src/development/translation.md:125
 msgid "Clear and actionable"
-msgstr ""
+msgstr "명확하고 조치 가능해야 합니다"
 
-#: src/development/translation.md:125
+#: src/development/translation.md:126
 msgid "Hint"
-msgstr ""
+msgstr "힌트"
 
-#: src/development/translation.md:125
+#: src/development/translation.md:126
 msgid "\"→ Create: scoop create...\""
-msgstr ""
+msgstr "\"→ Create: scoop create...\""
 
-#: src/development/translation.md:125
+#: src/development/translation.md:126
 msgid "Helpful, not lecturing"
-msgstr ""
+msgstr "도움이 되되 설교하지 않습니다"
 
-#: src/development/translation.md:127
+#: src/development/translation.md:128
 msgid "Translator's Discretion"
-msgstr ""
+msgstr "번역자의 재량"
 
-#: src/development/translation.md:129
+#: src/development/translation.md:130
 msgid "These decisions are **up to you**:"
-msgstr ""
-
-#: src/development/translation.md:131
-msgid "**Vocabulary**: Choose words that resonate with your community"
-msgstr ""
+msgstr "다음 사항들은 **번역자에게 달려 있습니다**:"
 
 #: src/development/translation.md:132
-msgid "**Idioms**: Use local expressions if they fit naturally"
-msgstr ""
+msgid "**Vocabulary**: Choose words that resonate with your community"
+msgstr "**어휘**: 커뮤니티에 잘 맞는 단어를 선택합니다"
 
 #: src/development/translation.md:133
-msgid "**Humor**: Light wit is welcome (e.g., ice cream puns if appropriate)"
-msgstr ""
+msgid "**Idioms**: Use local expressions if they fit naturally"
+msgstr "**관용구**: 자연스럽게 맞는 경우 현지 표현을 사용합니다"
 
 #: src/development/translation.md:134
+msgid "**Humor**: Light wit is welcome (e.g., ice cream puns if appropriate)"
+msgstr "**유머**: 가벼운 재치는 환영합니다 (예: 적절하다면 아이스크림 말장난도 좋습니다)"
+
+#: src/development/translation.md:135
 msgid "**Formality level**: Lean casual, but match your culture's CLI norms"
-msgstr ""
+msgstr "**격식 수준**: 친근한 어조를 유지하되, 언어/문화권의 CLI 관행에 맞게 조정합니다"
 
-#: src/development/translation.md:136
+#: src/development/translation.md:137
 msgid "**Only requirement**: The meaning must be clear to users."
-msgstr ""
+msgstr "**유일한 필수 요건**: 사용자에게 의미가 명확해야 합니다."
 
-#: src/development/translation.md:138
+#: src/development/translation.md:139
 msgid "Technical Terms"
-msgstr ""
+msgstr "기술 용어"
 
-#: src/development/translation.md:140
+#: src/development/translation.md:141
 msgid "For technical vocabulary:"
-msgstr ""
-
-#: src/development/translation.md:142
-msgid ""
-"**Check your community** — What do Python developers in your language use?"
-msgstr ""
+msgstr "기술 용어에 대해:"
 
 #: src/development/translation.md:143
-msgid "**Consistency** — Pick one term and stick with it throughout"
-msgstr ""
+msgid ""
+"**Check your community** — What do Python developers in your language use?"
+msgstr "**커뮤니티를 확인하세요** — 해당 언어권의 Python 개발자들이 어떤 용어를 사용하나요?"
 
 #: src/development/translation.md:144
-msgid ""
-"**Loanwords OK** — If your community uses English terms (e.g., \"install\"), "
-"that's fine"
-msgstr ""
+msgid "**Consistency** — Pick one term and stick with it throughout"
+msgstr "**일관성** — 한 가지 용어를 선택하고 일관되게 사용합니다"
 
-#: src/development/translation.md:146
+#: src/development/translation.md:145
 msgid ""
-"**Tip:** Study existing translations in `locales/app.yml` for reference, but "
-"don't feel bound by them."
-msgstr ""
+"**Loanwords OK** — If your community uses English terms (e.g., \"install\"),"
+" that's fine"
+msgstr "**외래어 허용** — 커뮤니티에서 영어 용어를 사용한다면 (예: \"install\"), 그대로 사용해도 됩니다"
 
-#: src/development/translation.md:150
+#: src/development/translation.md:147
+msgid ""
+"**Tip:** Study existing translations in `locales/app.yml` for reference, but"
+" don't feel bound by them."
+msgstr "**팁:** `locales/app.yml`의 기존 번역을 참고로 살펴보되, 그대로 따를 필요는 없습니다."
+
+#: src/development/translation.md:151
 msgid "Glossary"
-msgstr ""
+msgstr "용어 설명"
 
-#: src/development/translation.md:152
+#: src/development/translation.md:153
 msgid "Do NOT Translate"
-msgstr ""
+msgstr "번역하지 않는 항목"
 
-#: src/development/translation.md:154
+#: src/development/translation.md:155
 msgid "These terms should remain in English in all languages:"
-msgstr ""
+msgstr "다음 용어는 모든 언어에서 영어 그대로 유지합니다:"
 
-#: src/development/translation.md:156 src/development/translation.md:207
+#: src/development/translation.md:157 src/development/translation.md:208
 msgid "Term"
-msgstr ""
+msgstr "용어"
 
-#: src/development/translation.md:156
+#: src/development/translation.md:157
 msgid "Reason"
-msgstr ""
-
-#: src/development/translation.md:158
-msgid "`scoop`"
-msgstr ""
-
-#: src/development/translation.md:158
-msgid "Brand name"
-msgstr ""
+msgstr "이유"
 
 #: src/development/translation.md:159
-msgid "`uv`"
-msgstr ""
+msgid "`scoop`"
+msgstr "`scoop`"
 
-#: src/development/translation.md:159 src/development/translation.md:160
-#: src/development/translation.md:161 src/development/translation.md:163
-#: src/development/translation.md:168
-msgid "Tool name"
-msgstr ""
+#: src/development/translation.md:159
+msgid "Brand name"
+msgstr "브랜드 이름"
 
 #: src/development/translation.md:160
-msgid "`pyenv`"
-msgstr ""
+msgid "`uv`"
+msgstr "`uv`"
+
+#: src/development/translation.md:160 src/development/translation.md:161
+#: src/development/translation.md:162 src/development/translation.md:164
+#: src/development/translation.md:169
+msgid "Tool name"
+msgstr "도구 이름"
 
 #: src/development/translation.md:161
-msgid "`conda`"
-msgstr ""
-
-#: src/development/translation.md:162 src/development/architecture.md:86
-msgid "`virtualenv`"
-msgstr ""
+msgid "`pyenv`"
+msgstr "`pyenv`"
 
 #: src/development/translation.md:162
-msgid "Technical term"
-msgstr ""
+msgid "`conda`"
+msgstr "`conda`"
+
+#: src/development/translation.md:163 src/development/architecture.md:90
+msgid "`virtualenv`"
+msgstr "`virtualenv`"
 
 #: src/development/translation.md:163
+msgid "Technical term"
+msgstr "기술 용어"
+
+#: src/development/translation.md:164
 msgid "`virtualenvwrapper`"
-msgstr ""
-
-#: src/development/translation.md:164
-msgid "`Python`"
-msgstr ""
-
-#: src/development/translation.md:164
-msgid "Language name"
-msgstr ""
+msgstr "`virtualenvwrapper`"
 
 #: src/development/translation.md:165
+msgid "`Python`"
+msgstr "`Python`"
+
+#: src/development/translation.md:165
+msgid "Language name"
+msgstr "언어 이름"
+
+#: src/development/translation.md:166
 msgid "Technical term (bash, zsh, fish)"
-msgstr ""
-
-#: src/development/translation.md:166
-msgid "`JSON`"
-msgstr ""
-
-#: src/development/translation.md:166
-msgid "Format name"
-msgstr ""
+msgstr "기술 용어 (bash, zsh, fish)"
 
 #: src/development/translation.md:167
-msgid "Environment variable"
-msgstr ""
+msgid "`JSON`"
+msgstr "`JSON`"
+
+#: src/development/translation.md:167
+msgid "Format name"
+msgstr "형식 이름"
 
 #: src/development/translation.md:168
+msgid "Environment variable"
+msgstr "환경 변수"
+
+#: src/development/translation.md:169
 msgid "`pip`"
-msgstr ""
+msgstr "`pip`"
 
-#: src/development/translation.md:170
+#: src/development/translation.md:171
 msgid "Commands - Never Translate"
-msgstr ""
+msgstr "명령어 - 절대 번역하지 않음"
 
-#: src/development/translation.md:172
+#: src/development/translation.md:173
 msgid "All commands and code examples must stay in English:"
-msgstr ""
+msgstr "모든 명령어와 코드 예시는 반드시 영어로 유지합니다:"
 
-#: src/development/translation.md:175 src/development/translation.md:274
+#: src/development/translation.md:176 src/development/translation.md:275
 msgid ""
 "# WRONG - Command translated\n"
 "hint"
 msgstr ""
+"# 잘못된 예 - 명령어가 번역된 경우\n"
+"hint"
 
-#: src/development/translation.md:176
+#: src/development/translation.md:177
 msgid "\"→ Create: {translated_command} myenv 3.12\""
-msgstr ""
-
-#: src/development/translation.md:178
-msgid "CORRECT - Only description translated"
-msgstr ""
-
-#: src/development/translation.md:178 src/development/translation.md:277
-msgid "hint"
-msgstr ""
+msgstr "\"→ Create: {translated_command} myenv 3.12\""
 
 #: src/development/translation.md:179
+msgid "CORRECT - Only description translated"
+msgstr "올바른 예 - 설명 부분만 번역"
+
+#: src/development/translation.md:179 src/development/translation.md:278
+msgid "hint"
+msgstr "hint"
+
+#: src/development/translation.md:180
 msgid "\"→ {translated_word}: scoop create myenv 3.12\""
-msgstr ""
+msgstr "\"→ {translated_word}: scoop create myenv 3.12\""
 
-#: src/development/translation.md:182
+#: src/development/translation.md:183
 msgid "Common Terms to Translate"
-msgstr ""
+msgstr "번역해야 할 일반 용어"
 
-#: src/development/translation.md:184
+#: src/development/translation.md:185
 msgid ""
 "These are core concepts you'll need to translate. Reference existing "
 "translations for consistency:"
-msgstr ""
+msgstr "다음은 번역이 필요한 핵심 개념들입니다. 일관성을 위해 기존 번역을 참고하세요:"
 
-#: src/development/translation.md:186
+#: src/development/translation.md:187
 msgid "English"
-msgstr ""
+msgstr "영어"
 
-#: src/development/translation.md:186
+#: src/development/translation.md:187
 msgid "What to look for"
-msgstr ""
-
-#: src/development/translation.md:188
-msgid "environment"
-msgstr ""
-
-#: src/development/translation.md:188
-msgid "Your language's term for \"environment\""
-msgstr ""
+msgstr "찾아야 할 표현"
 
 #: src/development/translation.md:189
+msgid "environment"
+msgstr "environment"
+
+#: src/development/translation.md:189
+msgid "Your language's term for \"environment\""
+msgstr "해당 언어에서 \"environment\"에 해당하는 표현"
+
+#: src/development/translation.md:190
 msgid "Common verb for \"make/create\""
-msgstr ""
-
-#: src/development/translation.md:190
-msgid "remove/delete"
-msgstr ""
-
-#: src/development/translation.md:190
-msgid "Common verb for \"delete/remove\""
-msgstr ""
+msgstr "\"만들다/생성하다\"에 해당하는 일반적인 동사"
 
 #: src/development/translation.md:191
-msgid "Standard software installation term"
-msgstr ""
+msgid "remove/delete"
+msgstr "remove/delete"
+
+#: src/development/translation.md:191
+msgid "Common verb for \"delete/remove\""
+msgstr "\"삭제/제거\"에 해당하는 일반적인 동사"
 
 #: src/development/translation.md:192
+msgid "Standard software installation term"
+msgstr "소프트웨어 설치를 나타내는 표준 용어"
+
+#: src/development/translation.md:193
 msgid "Standard software removal term"
-msgstr ""
+msgstr "소프트웨어 제거를 나타내는 표준 용어"
 
-#: src/development/translation.md:193
+#: src/development/translation.md:194
 msgid "activate"
-msgstr ""
+msgstr "activate"
 
-#: src/development/translation.md:193
+#: src/development/translation.md:194
 msgid "Term for \"enable/turn on\""
-msgstr ""
-
-#: src/development/translation.md:194
-msgid "deactivate"
-msgstr ""
-
-#: src/development/translation.md:194
-msgid "Term for \"disable/turn off\""
-msgstr ""
+msgstr "\"활성화/켜다\"에 해당하는 표현"
 
 #: src/development/translation.md:195
+msgid "deactivate"
+msgstr "deactivate"
+
+#: src/development/translation.md:195
+msgid "Term for \"disable/turn off\""
+msgstr "\"비활성화/끄다\"에 해당하는 표현"
+
+#: src/development/translation.md:196
 msgid "IT term for migration (often kept as loanword)"
-msgstr ""
+msgstr "마이그레이션을 나타내는 IT 용어 (외래어로 그대로 사용하는 경우가 많음)"
 
-#: src/development/translation.md:196
+#: src/development/translation.md:197
 msgid "version"
-msgstr ""
+msgstr "version"
 
-#: src/development/translation.md:196
+#: src/development/translation.md:197
 msgid "Your language's term for \"version\""
-msgstr ""
-
-#: src/development/translation.md:197
-msgid "path"
-msgstr ""
-
-#: src/development/translation.md:197
-msgid "Your language's term for file path"
-msgstr ""
-
-#: src/development/translation.md:198 src/development/translation.md:267
-#: src/api.md:714
-msgid "error"
-msgstr ""
+msgstr "해당 언어에서 \"version\"에 해당하는 표현"
 
 #: src/development/translation.md:198
-msgid "Your language's term for \"error\""
-msgstr ""
+msgid "path"
+msgstr "path"
 
-#: src/development/translation.md:199 src/api.md:713 src/api.md:715
-msgid "success"
-msgstr ""
+#: src/development/translation.md:198
+msgid "Your language's term for file path"
+msgstr "해당 언어에서 파일 경로에 해당하는 표현"
+
+#: src/development/translation.md:199 src/development/translation.md:268
+#: src/api.md:714
+msgid "error"
+msgstr "error"
 
 #: src/development/translation.md:199
-msgid "Your language's term for \"success\""
-msgstr ""
+msgid "Your language's term for \"error\""
+msgstr "해당 언어에서 \"error\"에 해당하는 표현"
 
-#: src/development/translation.md:201
+#: src/development/translation.md:200 src/api.md:713 src/api.md:715
+msgid "success"
+msgstr "success"
+
+#: src/development/translation.md:200
+msgid "Your language's term for \"success\""
+msgstr "해당 언어에서 \"success\"에 해당하는 표현"
+
+#: src/development/translation.md:202
 msgid ""
 "**Tip:** Check how these terms are translated in existing translations for "
 "reference."
-msgstr ""
+msgstr "**팁:** 참고로 기존 번역에서 이 용어들이 어떻게 번역되어 있는지 확인하세요."
 
-#: src/development/translation.md:203
+#: src/development/translation.md:204
 msgid "Ice Cream Metaphor (README only)"
-msgstr ""
+msgstr "아이스크림 은유 (README 전용)"
 
-#: src/development/translation.md:205
+#: src/development/translation.md:206
 msgid "scoop uses ice cream metaphors in documentation:"
-msgstr ""
+msgstr "scoop은 문서에서 아이스크림 은유를 사용합니다:"
 
-#: src/development/translation.md:209
+#: src/development/translation.md:210
 msgid "scoop"
-msgstr ""
+msgstr "scoop"
 
-#: src/development/translation.md:209
+#: src/development/translation.md:210
 msgid "The tool"
-msgstr ""
+msgstr "도구"
 
-#: src/development/translation.md:209
+#: src/development/translation.md:210
 msgid "Always keep as \"scoop\""
-msgstr ""
+msgstr "항상 \"scoop\"으로 유지합니다"
 
-#: src/development/translation.md:210
+#: src/development/translation.md:211
 msgid "flavor"
-msgstr ""
+msgstr "flavor"
 
-#: src/development/translation.md:210
+#: src/development/translation.md:211
 msgid "virtualenv"
-msgstr ""
+msgstr "virtualenv"
 
-#: src/development/translation.md:210
+#: src/development/translation.md:211
 msgid "Translate if the metaphor works in your language"
-msgstr ""
+msgstr "해당 언어에서 은유가 자연스럽게 통한다면 번역해도 됩니다"
 
-#: src/development/translation.md:211
+#: src/development/translation.md:212
 msgid "freezer"
-msgstr ""
+msgstr "freezer"
 
-#: src/development/translation.md:211
+#: src/development/translation.md:212
 msgid "~/.scoop/ directory"
-msgstr ""
+msgstr "~/.scoop/ 디렉터리"
 
-#: src/development/translation.md:211
+#: src/development/translation.md:212
 msgid "Translate if the metaphor works"
-msgstr ""
+msgstr "은유가 자연스럽게 통한다면 번역해도 됩니다"
 
-#: src/development/translation.md:213
+#: src/development/translation.md:214
 msgid ""
-"**Note:** The metaphor is mainly in README.md, not in CLI messages (`locales/"
-"app.yml`)."
+"**Note:** The metaphor is mainly in README.md, not in CLI messages "
+"(`locales/app.yml`)."
 msgstr ""
+"**참고:** 이 은유는 주로 README.md에 사용되며, CLI 메시지(`locales/app.yml`)에는 사용되지 않습니다."
 
-#: src/development/translation.md:217
+#: src/development/translation.md:218
 msgid "File Structure"
-msgstr ""
+msgstr "파일 구조"
 
-#: src/development/translation.md:219
+#: src/development/translation.md:220
 msgid "locales/app.yml"
-msgstr ""
-
-#: src/development/translation.md:222
-msgid "# Categories in order:\n"
-msgstr ""
+msgstr "locales/app.yml"
 
 #: src/development/translation.md:223
-msgid "1. lang.*        - Language command messages"
-msgstr ""
+msgid "# Categories in order:\n"
+msgstr "# 카테고리 순서:\n"
 
 #: src/development/translation.md:224
-msgid "2. create.*      - Create command messages"
-msgstr ""
+msgid "1. lang.*        - Language command messages"
+msgstr "1. lang.*        - 언어 명령 메시지"
 
 #: src/development/translation.md:225
-msgid "3. remove.*      - Remove command messages"
-msgstr ""
+msgid "2. create.*      - Create command messages"
+msgstr "2. create.*      - create 명령 메시지"
 
 #: src/development/translation.md:226
-msgid "4. list.*        - List command messages"
-msgstr ""
+msgid "3. remove.*      - Remove command messages"
+msgstr "3. remove.*      - remove 명령 메시지"
 
 #: src/development/translation.md:227
-msgid "5. use.*         - Use command messages"
-msgstr ""
+msgid "4. list.*        - List command messages"
+msgstr "4. list.*        - list 명령 메시지"
 
 #: src/development/translation.md:228
-msgid "6. install.*     - Install command messages"
-msgstr ""
+msgid "5. use.*         - Use command messages"
+msgstr "5. use.*         - use 명령 메시지"
 
 #: src/development/translation.md:229
-msgid "7. uninstall.*   - Uninstall command messages"
-msgstr ""
+msgid "6. install.*     - Install command messages"
+msgstr "6. install.*     - install 명령 메시지"
 
 #: src/development/translation.md:230
-msgid "8. migrate.*     - Migrate command messages"
-msgstr ""
+msgid "7. uninstall.*   - Uninstall command messages"
+msgstr "7. uninstall.*   - uninstall 명령 메시지"
 
 #: src/development/translation.md:231
-msgid "9. error.*       - Error messages"
-msgstr ""
+msgid "8. migrate.*     - Migrate command messages"
+msgstr "8. migrate.*     - migrate 명령 메시지"
 
 #: src/development/translation.md:232
+msgid "9. error.*       - Error messages"
+msgstr "9. error.*       - 오류 메시지"
+
+#: src/development/translation.md:233
 msgid "10. suggestion.* - Suggestion/hint messages"
-msgstr ""
+msgstr "10. suggestion.* - 제안/힌트 메시지"
 
-#: src/development/translation.md:235
+#: src/development/translation.md:236
 msgid "src/i18n.rs"
-msgstr ""
+msgstr "src/i18n.rs"
 
-#: src/development/translation.md:238
+#: src/development/translation.md:239
 msgid ""
 "// Language detection priority:\n"
 "// 1. SCOOP_LANG environment variable\n"
@@ -8195,127 +8707,138 @@ msgid ""
 "// 3. System locale\n"
 "// 4. Default: \"en\"\n"
 msgstr ""
+"// 언어 감지 우선순위:\n"
+"// 1. SCOOP_LANG 환경 변수\n"
+"// 2. 설정 파일 (~/.scoop/config.json)\n"
+"// 3. 시스템 로케일\n"
+"// 4. 기본값: \"en\"\n"
 
-#: src/development/translation.md:246
+#: src/development/translation.md:247
 msgid ""
 "// ... existing languages\n"
 "    // Add new languages here\n"
 msgstr ""
+"// ... 기존 언어\n"
+"    // 여기에 새 언어를 추가하세요\n"
 
-#: src/development/translation.md:253
+#: src/development/translation.md:254
 msgid "Common Mistakes"
-msgstr ""
+msgstr "자주 하는 실수"
 
-#: src/development/translation.md:255
+#: src/development/translation.md:256
 msgid "1. Missing `SUPPORTED_LANGS` Registration"
-msgstr ""
+msgstr "1. `SUPPORTED_LANGS` 등록 누락"
 
-#: src/development/translation.md:257
+#: src/development/translation.md:258
 msgid "**Symptom:** Translation exists but `scoop lang {code}` doesn't work"
-msgstr ""
+msgstr "**증상:** 번역은 존재하지만 `scoop lang {code}`가 동작하지 않음"
 
-#: src/development/translation.md:259
+#: src/development/translation.md:260
 msgid "**Fix:** Add language to `src/i18n.rs` SUPPORTED_LANGS"
-msgstr ""
+msgstr "**수정 방법:** `src/i18n.rs`의 SUPPORTED_LANGS에 언어를 추가하세요"
 
-#: src/development/translation.md:261
+#: src/development/translation.md:262
 msgid "2. Broken Placeholders"
-msgstr ""
+msgstr "2. 깨진 플레이스홀더"
 
-#: src/development/translation.md:264
+#: src/development/translation.md:265
 msgid ""
 "# WRONG - Missing placeholder\n"
 "error"
 msgstr ""
+"# 잘못된 예 - 플레이스홀더 누락\n"
+"error"
 
-#: src/development/translation.md:265
+#: src/development/translation.md:266
 msgid "\"Cannot find environment\""
-msgstr ""
-
-#: src/development/translation.md:267
-msgid "CORRECT - Placeholder preserved"
-msgstr ""
+msgstr "\"Cannot find environment\""
 
 #: src/development/translation.md:268
+msgid "CORRECT - Placeholder preserved"
+msgstr "올바른 예 - 플레이스홀더 유지"
+
+#: src/development/translation.md:269
 msgid "\"Cannot find '%{name}' environment\""
-msgstr ""
+msgstr "\"Cannot find '%{name}' environment\""
 
-#: src/development/translation.md:271
+#: src/development/translation.md:272
 msgid "3. Translating Commands"
-msgstr ""
+msgstr "3. 커맨드 번역 시 주의사항"
 
-#: src/development/translation.md:275
+#: src/development/translation.md:276
 msgid "\"→ List: {translated} list\""
-msgstr ""
-
-#: src/development/translation.md:277
-msgid "CORRECT - Only label translated"
-msgstr ""
+msgstr "\"→ List: {translated} list\""
 
 #: src/development/translation.md:278
+msgid "CORRECT - Only label translated"
+msgstr "올바른 예 - 레이블만 번역"
+
+#: src/development/translation.md:279
 msgid "\"→ {Translated Label}: scoop list\""
-msgstr ""
+msgstr "\"→ {Translated Label}: scoop list\""
 
-#: src/development/translation.md:281
+#: src/development/translation.md:282
 msgid "4. Inconsistent Key Coverage"
-msgstr ""
+msgstr "4. 일관성 없는 키 범위"
 
-#: src/development/translation.md:283
+#: src/development/translation.md:284
 msgid "All languages must have ALL keys. Missing keys fall back to English."
-msgstr ""
+msgstr "모든 언어는 모든 키를 가져야 합니다. 누락된 키는 영어로 대체됩니다."
 
-#: src/development/translation.md:287
+#: src/development/translation.md:288
 msgid "Testing Checklist"
-msgstr ""
+msgstr "테스트 체크리스트"
 
-#: src/development/translation.md:289
+#: src/development/translation.md:290
 msgid "Before submitting PR:"
-msgstr ""
-
-#: src/development/translation.md:291
-msgid "All 115 keys translated"
-msgstr ""
+msgstr "PR 제출 전:"
 
 #: src/development/translation.md:292
-msgid "All placeholders preserved (`%{name}`, `%{version}`, etc.)"
-msgstr ""
+msgid "All 220 keys translated"
+msgstr "220개 키 전체 번역 완료"
 
 #: src/development/translation.md:293
-msgid "Language registered in SUPPORTED_LANGS"
-msgstr ""
+msgid "All placeholders preserved (`%{name}`, `%{version}`, etc.)"
+msgstr "모든 플레이스홀더 유지 (`%{name}`, `%{version}` 등)"
 
 #: src/development/translation.md:294
-msgid "`cargo build` succeeds"
-msgstr ""
+msgid "Language registered in SUPPORTED_LANGS"
+msgstr "SUPPORTED_LANGS에 언어 등록 완료"
 
 #: src/development/translation.md:295
-msgid "`cargo test` passes"
-msgstr ""
+msgid "`cargo build` succeeds"
+msgstr "`cargo build` 성공"
 
 #: src/development/translation.md:296
-msgid "`SCOOP_LANG={code} scoop lang` shows your language"
-msgstr ""
+msgid "`cargo test` passes"
+msgstr "`cargo test` 통과"
 
 #: src/development/translation.md:297
+msgid "`SCOOP_LANG={code} scoop lang` shows your language"
+msgstr "`SCOOP_LANG={code} scoop lang` 실행 시 해당 언어가 표시됨"
+
+#: src/development/translation.md:298
 msgid "Messages display correctly in terminal"
-msgstr ""
+msgstr "터미널에서 메시지가 올바르게 표시됨"
 
-#: src/development/translation.md:301
+#: src/development/translation.md:302
 msgid "Questions?"
-msgstr ""
-
-#: src/development/translation.md:303
-msgid ""
-"Open an issue: [GitHub Issues](https://github.com/ai-screams/scoop-uv/issues)"
-msgstr ""
+msgstr "질문이 있으신가요?"
 
 #: src/development/translation.md:304
-msgid "See existing translations for reference: `locales/app.yml`"
+msgid ""
+"Open an issue: [GitHub Issues](https://github.com/ai-screams/scoop-"
+"uv/issues)"
 msgstr ""
+"이슈를 열어보세요: [GitHub Issues](https://github.com/ai-screams/scoop-uv/issues)"
+
+#: src/development/translation.md:305
+msgid "See existing translations for reference: `locales/app.yml`"
+msgstr "참고용 기존 번역 파일: `locales/app.yml`"
 
 #: src/development/docs-translation.md:1
 msgid "Documentation Translation (mdBook)"
-msgstr ""
+msgstr "문서 번역 (mdBook)"
 
 #: src/development/docs-translation.md:3
 msgid ""
@@ -8323,171 +8846,187 @@ msgid ""
 "the Rust binary), see [translation](translation.md) instead. This page "
 "covers user-documentation translation only."
 msgstr ""
+"CLI 문자열(Rust 바이너리에서 사용하는 `locales/app.yml`의 약 115개 키) 번역에 대해서는 "
+"[translation](translation.md)을 참고하세요. 이 페이지는 사용자 문서 번역에 대해서만 다룹니다."
 
 #: src/development/docs-translation.md:7
 msgid ""
 "scoop's user documentation lives in `docs/src/*.md` and is the single "
-"English source of truth. Translations are layered on top via [gettext]"
-"(https://www.gnu.org/software/gettext/) `.po` files under `docs/po/`, "
-"processed by the [mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-"
-"helpers) preprocessor at render time. Untranslated strings automatically "
-"fall back to English, so a partial translation is always deployable."
+"English source of truth. Translations are layered on top via "
+"[gettext](https://www.gnu.org/software/gettext/) `.po` files under "
+"`docs/po/`, processed by the "
+"[mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers) "
+"preprocessor at render time. Untranslated strings automatically fall back to"
+" English, so a partial translation is always deployable."
 msgstr ""
+"scoop의 사용자 문서는 `docs/src/*.md`에 있으며 영어가 단일 정보 원천(source of truth)입니다. 번역은 "
+"`docs/po/` 아래의 [gettext](https://www.gnu.org/software/gettext/) `.po` 파일을 통해"
+" 영어 위에 덧씌워지며, 렌더링 시 "
+"[mdbook-i18n-helpers](https://github.com/google/mdbook-i18n-helpers) 전처리기가 "
+"처리합니다. 번역되지 않은 문자열은 자동으로 영어로 대체되므로, 부분 번역 상태에서도 항상 배포 가능합니다."
 
 #: src/development/docs-translation.md:16
 msgid "URL layout"
-msgstr ""
+msgstr "URL 구조"
 
 #: src/development/docs-translation.md:18
 msgid "English (canonical): `https://ai-screams.github.io/scoop-uv/`"
-msgstr ""
+msgstr "영어 (기본): `https://ai-screams.github.io/scoop-uv/`"
 
 #: src/development/docs-translation.md:19
 msgid "Korean: `https://ai-screams.github.io/scoop-uv/ko/`"
-msgstr ""
+msgstr "한국어: `https://ai-screams.github.io/scoop-uv/ko/`"
 
 #: src/development/docs-translation.md:21
 msgid ""
 "The locale switcher in the top-right of every page jumps between the same "
 "page on each side."
-msgstr ""
+msgstr "각 페이지 우측 상단의 언어 전환기를 사용하면 각 언어의 같은 페이지로 이동할 수 있습니다."
 
 #: src/development/docs-translation.md:27 src/development/testing.md:415
 msgid "# macOS\n"
-msgstr ""
+msgstr "# macOS\n"
 
 #: src/development/docs-translation.md:28
 msgid "# msginit / msgmerge / msgfmt\n"
-msgstr ""
+msgstr "# msginit / msgmerge / msgfmt\n"
 
 #: src/development/docs-translation.md:31 src/development/testing.md:417
 msgid "# Linux\n"
-msgstr ""
+msgstr "# Linux\n"
 
 #: src/development/docs-translation.md:33
 msgid "# Then the same `cargo install` lines as above.\n"
-msgstr ""
+msgstr "# 위와 동일한 `cargo install` 명령어를 실행하세요.\n"
 
 #: src/development/docs-translation.md:37
 msgid ""
 "The `cargo install` step needs Rust **1.88 or newer** (helpers' upstream "
 "MSRV). The project's `rust-toolchain.toml` pins 1.85 for the CRATE itself; "
-"for the docs tooling, use `cargo +stable install ...` from outside the repo, "
-"or just rely on whatever stable toolchain is on `ubuntu-latest` in CI."
+"for the docs tooling, use `cargo +stable install ...` from outside the repo,"
+" or just rely on whatever stable toolchain is on `ubuntu-latest` in CI."
 msgstr ""
+"`cargo install` 단계에는 Rust **1.88 이상**이 필요합니다(헬퍼 상위 MSRV 기준). 프로젝트의 `rust-"
+"toolchain.toml`은 CRATE 자체에 대해 1.85를 고정합니다. 문서 도구를 위해서는 저장소 외부에서 `cargo "
+"+stable install ...`을 실행하거나, CI의 `ubuntu-latest`에 있는 stable 툴체인을 그대로 사용하세요."
 
 #: src/development/docs-translation.md:43
 msgid "Workflow: updating an existing translation"
-msgstr ""
+msgstr "워크플로우: 기존 번역 업데이트"
 
 #: src/development/docs-translation.md:45
 msgid ""
-"When you edit a page in `docs/src/`, the existing translations need to learn "
-"about the new / changed strings."
-msgstr ""
+"When you edit a page in `docs/src/`, the existing translations need to learn"
+" about the new / changed strings."
+msgstr "`docs/src/`의 페이지를 편집하면 기존 번역이 새로 추가되거나 변경된 문자열을 반영해야 합니다."
 
 #: src/development/docs-translation.md:50
 msgid "# 1. Re-extract template (overwrites docs/po/messages.pot).\n"
-msgstr ""
+msgstr "# 1. 템플릿 재추출 (docs/po/messages.pot 덮어쓰기).\n"
 
 #: src/development/docs-translation.md:52
 #: src/development/docs-translation.md:124
 msgid "'{\"xgettext\": {}}'"
-msgstr ""
+msgstr "'{\"xgettext\": {}}'"
 
 #: src/development/docs-translation.md:53
 msgid "# 2. Merge the new template into your locale's .po file.\n"
-msgstr ""
+msgstr "# 2. 새 템플릿을 로케일 .po 파일에 병합.\n"
 
 #: src/development/docs-translation.md:57
 msgid "# 3. Open po/ko.po in your editor. Look for:\n"
-msgstr ""
+msgstr "# 3. 편집기에서 po/ko.po를 열고 다음을 확인하세요:\n"
 
 #: src/development/docs-translation.md:59
 msgid "#    - \"#, fuzzy\" markers              →  review and remove flag\n"
-msgstr ""
+msgstr "#    - \"#, fuzzy\" 마커              →  검토 후 플래그 제거\n"
 
 #: src/development/docs-translation.md:63
 msgid ""
 "`docs/po/messages.pot` is in `.gitignore` — it's regenerated on every CI "
-"run, committing it would create churn. The locale `.po` files (`docs/po/"
-"ko.po`, etc.) ARE committed; they're the translation memory."
+"run, committing it would create churn. The locale `.po` files "
+"(`docs/po/ko.po`, etc.) ARE committed; they're the translation memory."
 msgstr ""
+"`docs/po/messages.pot`은 `.gitignore`에 포함되어 있습니다 — CI 실행마다 재생성되므로 커밋하면 불필요한 "
+"변경이 발생합니다. 로케일 `.po` 파일(`docs/po/ko.po` 등)은 커밋 대상이며, 번역 메모리 역할을 합니다."
 
 #: src/development/docs-translation.md:68
 msgid "Workflow: previewing a translated build"
-msgstr ""
+msgstr "워크플로우: 번역된 빌드 미리보기"
 
 #: src/development/docs-translation.md:72
 msgid "# English (root)\n"
-msgstr ""
+msgstr "# 영어 (루트)\n"
 
 #: src/development/docs-translation.md:76
 msgid "# Korean (book/ko subdir)\n"
-msgstr ""
+msgstr "# 한국어 (book/ko 하위 디렉토리)\n"
 
 #: src/development/docs-translation.md:82
 msgid "`mdbook serve` works too if you want live reload:"
-msgstr ""
+msgstr "라이브 리로드를 원하면 `mdbook serve`도 사용할 수 있습니다:"
 
 #: src/development/docs-translation.md:88
 msgid "Workflow: adding a brand-new locale (e.g. `ja`)"
-msgstr ""
+msgstr "워크플로우: 새 로케일 추가 (예: `ja`)"
 
 #: src/development/docs-translation.md:92
 msgid "# Initialise an empty translation file.\n"
-msgstr ""
+msgstr "# 빈 번역 파일 초기화.\n"
 
 #: src/development/docs-translation.md:95
 msgid ""
 "# Translate msgids in po/ja.po (untranslated ones fall back to English).\n"
-msgstr ""
+msgstr "# po/ja.po의 msgid를 번역하세요 (미번역 항목은 영어로 대체됩니다).\n"
 
 #: src/development/docs-translation.md:97
 msgid "# Add a CI build step for the new locale in\n"
-msgstr ""
+msgstr "# 다음 경로에 새 로케일을 위한 CI 빌드 단계를 추가하세요:\n"
 
 #: src/development/docs-translation.md:99
 #: src/development/docs-translation.md:105
 msgid "#\n"
-msgstr ""
+msgstr "#\n"
 
 #: src/development/docs-translation.md:101
 msgid "#     working-directory: docs\n"
-msgstr ""
+msgstr "#     working-directory: docs\n"
 
 #: src/development/docs-translation.md:103
 msgid "#       MDBOOK_BOOK__LANGUAGE: ja\n"
-msgstr ""
+msgstr "#       MDBOOK_BOOK__LANGUAGE: ja\n"
 
 #: src/development/docs-translation.md:107
 msgid "# include the new locale link.\n"
-msgstr ""
+msgstr "# 새 로케일 링크를 포함하세요.\n"
 
 #: src/development/docs-translation.md:111
 msgid "CI guard: stale translations"
-msgstr ""
+msgstr "CI 가드: 번역 동기화 확인"
 
 #: src/development/docs-translation.md:113
 msgid ""
-"The `Verify ko translations are in sync` step in `.github/workflows/"
-"docs.yml` regenerates the pot template from the current English source, runs "
-"`msgmerge --update` against the committed `ko.po`, and fails the build if "
-"the result differs. This means English edits land with their corresponding "
-"`.po` updates in the same PR, or they don't land at all."
+"The `Verify ko translations are in sync` step in "
+"`.github/workflows/docs.yml` regenerates the pot template from the current "
+"English source, runs `msgmerge --update` against the committed `ko.po`, and "
+"fails the build if the result differs. This means English edits land with "
+"their corresponding `.po` updates in the same PR, or they don't land at all."
 msgstr ""
+"`.github/workflows/docs.yml`의 `Verify ko translations are in sync` 단계는 현재 영어"
+" 소스에서 pot 템플릿을 재생성하고, 커밋된 `ko.po`에 대해 `msgmerge --update`를 실행하여 결과가 다를 경우 "
+"빌드를 실패시킵니다. 이는 영어 편집이 같은 PR에 해당하는 `.po` 업데이트와 함께 반영되거나, 아예 반영되지 않도록 보장합니다."
 
 #: src/development/docs-translation.md:120
 msgid "To fix a CI failure on this step:"
-msgstr ""
+msgstr "이 단계의 CI 실패를 수정하려면:"
 
 #: src/development/docs-translation.md:127
 msgid "# or as a separate fixup commit\n"
-msgstr ""
+msgstr "# 또는 별도의 fixup 커밋으로\n"
 
 #: src/development/docs-translation.md:130
 msgid "Style guidelines"
-msgstr ""
+msgstr "스타일 가이드라인"
 
 #: src/development/docs-translation.md:132
 msgid ""
@@ -8499,16 +9038,22 @@ msgid ""
 "comments (`# Install Python`) as separate msgids so you can translate those "
 "if it helps readability."
 msgstr ""
+"[translation](translation.md)의 동일한 구어체 가이드라인이 여기에도 적용됩니다. 코드 샘플이나 CLI 커맨드를 "
+"직역하려 하지 마세요 — 그 주변의 설명 텍스트만 번역하면 됩니다. 코드 블록 내용은 로케일과 관계없이 그대로 표시됩니다. "
+"mdbook-i18n-helpers는 의도적으로 마킹되지 않은 코드의 펜스드 코드 블록 안에서 번역을 보간하지 않지만, 코드 주석(`# "
+"Install Python`)은 별도의 msgid로 추출하므로 가독성에 도움이 된다면 번역해도 됩니다."
 
 #: src/development/docs-translation.md:141
 msgid "Known limitations"
-msgstr ""
+msgstr "알려진 제한 사항"
 
 #: src/development/docs-translation.md:143
 msgid ""
 "Search index is built per-locale. Korean search results only hit Korean "
 "pages, English only hits English. This is the intended mdBook behaviour."
 msgstr ""
+"검색 인덱스는 로케일별로 구축됩니다. 한국어 검색 결과는 한국어 페이지만, 영어 검색은 영어 페이지만 검색합니다. 이는 mdBook의 "
+"의도된 동작입니다."
 
 #: src/development/docs-translation.md:146
 msgid ""
@@ -8516,406 +9061,416 @@ msgid ""
 "won't see it. They can navigate via direct URL (`/scoop-uv/ko/...`) or "
 "browser bookmarks."
 msgstr ""
+"언어 전환기는 JS로 삽입된 DOM 요소를 사용합니다. JS가 비활성화된 사용자는 이를 볼 수 없습니다. 직접 URL(`/scoop-"
+"uv/ko/...`)이나 브라우저 북마크를 통해 탐색할 수 있습니다."
 
 #: src/development/docs-translation.md:149
 msgid ""
 "mdbook-i18n-helpers' `xgettext` doesn't extract HTML tables' cell-by-cell "
 "content as separate msgids when the table is written in pipe-syntax — it "
 "extracts the whole table as a single block. For now this is acceptable; for "
-"fine-grained table translation we'd need to switch to per-row HTML tables in "
-"the source."
+"fine-grained table translation we'd need to switch to per-row HTML tables in"
+" the source."
 msgstr ""
+"mdbook-i18n-helpers의 `xgettext`는 파이프 구문으로 작성된 테이블의 셀별 내용을 별도의 msgid로 추출하지 "
+"않으며, 테이블 전체를 단일 블록으로 추출합니다. 현재로서는 이 방식이 허용 가능하며, 세밀한 테이블 번역이 필요하다면 소스를 행별 "
+"HTML 테이블 방식으로 전환해야 합니다."
 
 #: src/development/architecture.md:3
 msgid "scoop is built in Rust using a modular architecture."
-msgstr ""
+msgstr "scoop은 Rust로 구축되었으며 모듈형 아키텍처를 사용합니다."
 
 #: src/development/architecture.md:5
 msgid "Module Structure"
-msgstr ""
+msgstr "모듈 구조"
 
-#: src/development/architecture.md:38
+#: src/development/architecture.md:42
 msgid "Module Dependency Graph"
-msgstr ""
-
-#: src/development/architecture.md:70
-msgid "Key Components"
-msgstr ""
-
-#: src/development/architecture.md:72
-msgid "CLI Layer (`cli/`)"
-msgstr ""
+msgstr "모듈 의존성 그래프"
 
 #: src/development/architecture.md:74
-msgid "Uses [clap](https://docs.rs/clap) for argument parsing"
-msgstr ""
-
-#: src/development/architecture.md:75
-msgid "`Cli` struct defines global options"
-msgstr ""
+msgid "Key Components"
+msgstr "주요 구성 요소"
 
 #: src/development/architecture.md:76
-msgid "`Commands` enum defines subcommands"
-msgstr ""
+msgid "CLI Layer (`cli/`)"
+msgstr "CLI 레이어 (`cli/`)"
 
-#: src/development/architecture.md:77
-msgid "Each command has an `execute` function in `commands/`"
-msgstr ""
+#: src/development/architecture.md:78
+msgid "Uses [clap](https://docs.rs/clap) for argument parsing"
+msgstr "인수 파싱에 [clap](https://docs.rs/clap) 사용"
 
 #: src/development/architecture.md:79
-msgid "Core Layer (`core/`)"
-msgstr ""
+msgid "`Cli` struct defines global options"
+msgstr "`Cli` 구조체로 전역 옵션 정의"
 
-#: src/development/architecture.md:81 src/development/testing.md:117
-msgid "Module"
-msgstr ""
+#: src/development/architecture.md:80
+msgid "`Commands` enum defines subcommands"
+msgstr "`Commands` 열거형으로 서브커맨드 정의"
+
+#: src/development/architecture.md:81
+msgid "Each command has an `execute` function in `commands/`"
+msgstr "각 커맨드는 `commands/`에 `execute` 함수를 가집니다"
 
 #: src/development/architecture.md:83
+msgid "Core Layer (`core/`)"
+msgstr "Core 레이어 (`core/`)"
+
+#: src/development/architecture.md:85 src/development/testing.md:117
+msgid "Module"
+msgstr "모듈"
+
+#: src/development/architecture.md:87
 msgid "Health check system with `Check` trait"
-msgstr ""
-
-#: src/development/architecture.md:84
-msgid "JSON metadata for virtualenvs"
-msgstr ""
-
-#: src/development/architecture.md:85
-msgid "Version file discovery and parsing"
-msgstr ""
-
-#: src/development/architecture.md:86
-msgid "Virtualenv entity and operations"
-msgstr ""
+msgstr "`Check` 트레이트를 사용한 상태 확인 시스템"
 
 #: src/development/architecture.md:88
-msgid "Shell Layer (`shell/`)"
-msgstr ""
+msgid "JSON metadata for virtualenvs"
+msgstr "virtualenv용 JSON 메타데이터"
+
+#: src/development/architecture.md:89
+msgid "Version file discovery and parsing"
+msgstr "버전 파일 탐색 및 파싱"
 
 #: src/development/architecture.md:90
-msgid "Generates shell scripts for integration:"
-msgstr ""
+msgid "Virtualenv entity and operations"
+msgstr "virtualenv 엔티티 및 연산"
 
 #: src/development/architecture.md:92
-msgid "`init_script()` - Returns shell initialization code"
-msgstr ""
-
-#: src/development/architecture.md:93
-msgid "Wrapper function for `scoop` command"
-msgstr ""
+msgid "Shell Layer (`shell/`)"
+msgstr "Shell 레이어 (`shell/`)"
 
 #: src/development/architecture.md:94
-msgid "Auto-activation hooks"
-msgstr ""
+msgid "Generates shell scripts for integration:"
+msgstr "통합을 위한 shell 스크립트 생성:"
 
-#: src/development/architecture.md:95
-msgid "Tab completion definitions"
-msgstr ""
+#: src/development/architecture.md:96
+msgid "`init_script()` - Returns shell initialization code"
+msgstr "`init_script()` - shell 초기화 코드 반환"
 
 #: src/development/architecture.md:97
-msgid "Output Layer (`output/`)"
-msgstr ""
+msgid "Wrapper function for `scoop` command"
+msgstr "`scoop` 커맨드용 래퍼 함수"
+
+#: src/development/architecture.md:98
+msgid "Auto-activation hooks"
+msgstr "자동 활성화 hook"
 
 #: src/development/architecture.md:99
-msgid "Handles terminal output formatting:"
-msgstr ""
+msgid "Tab completion definitions"
+msgstr "탭 완성 정의"
 
 #: src/development/architecture.md:101
-msgid "Colored output using [owo-colors](https://docs.rs/owo-colors)"
-msgstr ""
-
-#: src/development/architecture.md:102
-msgid "JSON output for scripting"
-msgstr ""
+msgid "Output Layer (`output/`)"
+msgstr "Output 레이어 (`output/`)"
 
 #: src/development/architecture.md:103
-msgid "Progress indicators with [indicatif](https://docs.rs/indicatif)"
-msgstr ""
+msgid "Handles terminal output formatting:"
+msgstr "터미널 출력 형식 처리:"
 
 #: src/development/architecture.md:105
-msgid "UV Layer (`uv/`)"
-msgstr ""
+msgid "Colored output using [owo-colors](https://docs.rs/owo-colors)"
+msgstr "[owo-colors](https://docs.rs/owo-colors)를 사용한 컬러 출력"
+
+#: src/development/architecture.md:106
+msgid "JSON output for scripting"
+msgstr "스크립팅을 위한 JSON 출력"
 
 #: src/development/architecture.md:107
-msgid "Wraps the uv CLI for Python/virtualenv operations:"
-msgstr ""
+msgid "Progress indicators with [indicatif](https://docs.rs/indicatif)"
+msgstr "[indicatif](https://docs.rs/indicatif)를 사용한 진행 표시기"
 
 #: src/development/architecture.md:109
-msgid "Python installation"
-msgstr ""
-
-#: src/development/architecture.md:110
-msgid "Virtualenv creation"
-msgstr ""
+msgid "UV Layer (`uv/`)"
+msgstr "UV 레이어 (`uv/`)"
 
 #: src/development/architecture.md:111
-msgid "Version listing"
-msgstr ""
+msgid "Wraps the uv CLI for Python/virtualenv operations:"
+msgstr "Python/virtualenv 작업을 위해 uv CLI를 래핑합니다:"
 
 #: src/development/architecture.md:113
-msgid "Design Patterns"
-msgstr ""
+msgid "Python installation"
+msgstr "Python 설치"
+
+#: src/development/architecture.md:114
+msgid "Virtualenv creation"
+msgstr "Virtualenv 생성"
 
 #: src/development/architecture.md:115
-msgid "Shell Eval Pattern"
-msgstr ""
+msgid "Version listing"
+msgstr "버전 목록 조회"
 
 #: src/development/architecture.md:117
+msgid "Design Patterns"
+msgstr "디자인 패턴"
+
+#: src/development/architecture.md:119
+msgid "Shell Eval Pattern"
+msgstr "Shell Eval 패턴"
+
+#: src/development/architecture.md:121
 msgid "The CLI outputs shell code to stdout, which the shell evaluates:"
-msgstr ""
-
-#: src/development/architecture.md:120
-msgid "# User runs\n"
-msgstr ""
-
-#: src/development/architecture.md:122
-msgid "# CLI outputs\n"
-msgstr ""
+msgstr "CLI는 shell 코드를 stdout에 출력하고, shell이 이를 평가(eval)합니다:"
 
 #: src/development/architecture.md:124
+msgid "# User runs\n"
+msgstr "# 사용자 실행\n"
+
+#: src/development/architecture.md:126
+msgid "# CLI outputs\n"
+msgstr "# CLI 출력\n"
+
+#: src/development/architecture.md:128
 msgid "\"/Users/x/.scoop/virtualenvs/myenv\""
-msgstr ""
-
-#: src/development/architecture.md:125
-msgid "\"/Users/x/.scoop/virtualenvs/myenv/bin:$PATH\""
-msgstr ""
-
-#: src/development/architecture.md:127
-msgid "# Shell wrapper evaluates this output\n"
-msgstr ""
+msgstr "\"/Users/x/.scoop/virtualenvs/myenv\""
 
 #: src/development/architecture.md:129
+msgid "\"/Users/x/.scoop/virtualenvs/myenv/bin:$PATH\""
+msgstr "\"/Users/x/.scoop/virtualenvs/myenv/bin:$PATH\""
+
+#: src/development/architecture.md:131
+msgid "# Shell wrapper evaluates this output\n"
+msgstr "# shell 래퍼가 이 출력을 평가(eval)합니다\n"
+
+#: src/development/architecture.md:133
 msgid "\"$(command scoop activate myenv)\""
-msgstr ""
-
-#: src/development/architecture.md:132
-msgid "This pattern is used by pyenv, rbenv, and other version managers."
-msgstr ""
-
-#: src/development/architecture.md:134 src/api.md:317
-#: src/development/code-quality.md:296
-msgid "Error Handling"
-msgstr ""
+msgstr "\"$(command scoop activate myenv)\""
 
 #: src/development/architecture.md:136
-msgid "Uses [thiserror](https://docs.rs/thiserror) for error types:"
-msgstr ""
+msgid "This pattern is used by pyenv, rbenv, and other version managers."
+msgstr "이 패턴은 pyenv, rbenv 및 기타 버전 관리자에서 사용됩니다."
 
-#: src/development/architecture.md:139
+#: src/development/architecture.md:138 src/api.md:317
+#: src/development/code-quality.md:296
+msgid "Error Handling"
+msgstr "에러 처리"
+
+#: src/development/architecture.md:140
+msgid "Uses [thiserror](https://docs.rs/thiserror) for error types:"
+msgstr "에러 타입에 [thiserror](https://docs.rs/thiserror) 사용:"
+
+#: src/development/architecture.md:143
 msgid ""
 "// Uses thiserror for Error trait derive\n"
 "// Display impl is manual (not #[error] attributes) for i18n support\n"
 msgstr ""
+"// Error 트레이트 derive에 thiserror 사용\n"
+"// i18n 지원을 위해 Display impl은 수동 구현 (#[error] 속성 사용 안 함)\n"
 
-#: src/development/architecture.md:147
+#: src/development/architecture.md:151
 msgid "// Manual Display implementation using rust-i18n\n"
-msgstr ""
+msgstr "// rust-i18n을 사용한 수동 Display 구현\n"
 
-#: src/development/architecture.md:153
+#: src/development/architecture.md:157
 msgid "\"{}\""
-msgstr ""
+msgstr "\"{}\""
 
-#: src/development/architecture.md:153
+#: src/development/architecture.md:157
 msgid "\"error.virtualenv_not_found\""
-msgstr ""
-
-#: src/development/architecture.md:161
-msgid "Path Management"
-msgstr ""
-
-#: src/development/architecture.md:163
-msgid "Centralizes path logic in `paths.rs`:"
-msgstr ""
+msgstr "\"error.virtualenv_not_found\""
 
 #: src/development/architecture.md:165
-msgid "`scoop_home()` - Returns `SCOOP_HOME` or `~/.scoop`"
-msgstr ""
-
-#: src/development/architecture.md:166
-msgid "`virtualenvs_dir()` - Returns virtualenvs directory"
-msgstr ""
+msgid "Path Management"
+msgstr "경로 관리"
 
 #: src/development/architecture.md:167
-msgid ""
-"`global_version_file()` - Returns global version file path (~/.scoop/version)"
-msgstr ""
+msgid "Centralizes path logic in `paths.rs`:"
+msgstr "`paths.rs`에 경로 로직을 집중화합니다:"
 
-#: src/development/architecture.md:168
-msgid ""
-"`local_version_file(dir)` - Returns local version file path in directory"
-msgstr ""
+#: src/development/architecture.md:169
+msgid "`scoop_home()` - Returns `SCOOP_HOME` or `~/.scoop`"
+msgstr "`scoop_home()` - `SCOOP_HOME` 또는 `~/.scoop` 반환"
 
 #: src/development/architecture.md:170
-msgid "Data Flow"
-msgstr ""
+msgid "`virtualenvs_dir()` - Returns virtualenvs directory"
+msgstr "`virtualenvs_dir()` - virtualenvs 디렉토리 반환"
+
+#: src/development/architecture.md:171
+msgid ""
+"`global_version_file()` - Returns global version file path "
+"(~/.scoop/version)"
+msgstr "`global_version_file()` - 전역 버전 파일 경로 반환 (~/.scoop/version)"
 
 #: src/development/architecture.md:172
+msgid ""
+"`local_version_file(dir)` - Returns local version file path in directory"
+msgstr "`local_version_file(dir)` - 디렉토리 내 로컬 버전 파일 경로 반환"
+
+#: src/development/architecture.md:174
+msgid "Data Flow"
+msgstr "데이터 흐름"
+
+#: src/development/architecture.md:176
 msgid "Command Execution Flow"
-msgstr ""
+msgstr "커맨드 실행 흐름"
 
-#: src/development/architecture.md:193
+#: src/development/architecture.md:197
 msgid "Shell Integration Flow"
-msgstr ""
+msgstr "Shell 통합 흐름"
 
-#: src/development/architecture.md:212
+#: src/development/architecture.md:216
 msgid "Version Resolution Flow"
-msgstr ""
+msgstr "버전 결정 흐름"
 
-#: src/development/architecture.md:228
+#: src/development/architecture.md:232
 msgid ""
 "**Note**: `.python-version` is not supported. Version resolution walks up "
 "parent directories to find `.scoop-version`."
 msgstr ""
+"**참고**: `.python-version`은 지원되지 않습니다. 버전 결정 시 `.scoop-version`을 찾기 위해 상위 "
+"디렉토리를 탐색합니다."
 
-#: src/development/architecture.md:230
+#: src/development/architecture.md:234
 msgid "Health Check Flow"
-msgstr ""
+msgstr "상태 확인 흐름"
 
-#: src/development/architecture.md:273
+#: src/development/architecture.md:277
 msgid "Migration Architecture"
-msgstr ""
+msgstr "마이그레이션 아키텍처"
 
-#: src/development/architecture.md:275
+#: src/development/architecture.md:279
 msgid ""
 "scoop supports migrating environments from pyenv-virtualenv, "
 "virtualenvwrapper, and conda."
-msgstr ""
+msgstr "scoop은 pyenv-virtualenv, virtualenvwrapper, conda에서 환경 마이그레이션을 지원합니다."
 
-#: src/development/architecture.md:313
+#: src/development/architecture.md:317
 msgid "Dependencies"
-msgstr ""
+msgstr "의존성"
 
-#: src/development/architecture.md:315
+#: src/development/architecture.md:319
 msgid "Crate"
-msgstr ""
+msgstr "Crate"
 
-#: src/development/architecture.md:317
+#: src/development/architecture.md:321
 msgid "clap"
-msgstr ""
+msgstr "clap"
 
-#: src/development/architecture.md:317
+#: src/development/architecture.md:321
 msgid "Argument parsing & completion"
-msgstr ""
+msgstr "인수 파싱 및 완성"
 
-#: src/development/architecture.md:318
+#: src/development/architecture.md:322
 msgid "clap_complete"
-msgstr ""
+msgstr "clap_complete"
 
-#: src/development/architecture.md:318
+#: src/development/architecture.md:322
 msgid "Shell completion generation"
-msgstr ""
+msgstr "Shell 완성 생성"
 
-#: src/development/architecture.md:319
+#: src/development/architecture.md:323
 msgid "serde"
-msgstr ""
+msgstr "serde"
 
-#: src/development/architecture.md:319
+#: src/development/architecture.md:323
 msgid "JSON serialization"
-msgstr ""
+msgstr "JSON 직렬화"
 
-#: src/development/architecture.md:320
+#: src/development/architecture.md:324
 msgid "serde_json"
-msgstr ""
+msgstr "serde_json"
 
-#: src/development/architecture.md:320
+#: src/development/architecture.md:324
 msgid "Metadata persistence"
-msgstr ""
+msgstr "메타데이터 지속성"
 
-#: src/development/architecture.md:321
+#: src/development/architecture.md:325
 msgid "thiserror"
-msgstr ""
+msgstr "thiserror"
 
-#: src/development/architecture.md:321
+#: src/development/architecture.md:325
 msgid "Error type definitions"
-msgstr ""
-
-#: src/development/architecture.md:322
-msgid "owo-colors"
-msgstr ""
-
-#: src/development/architecture.md:322
-msgid "Terminal colors"
-msgstr ""
-
-#: src/development/architecture.md:323
-msgid "indicatif"
-msgstr ""
-
-#: src/development/architecture.md:323
-msgid "Progress bars & spinners"
-msgstr ""
-
-#: src/development/architecture.md:324
-msgid "dialoguer"
-msgstr ""
-
-#: src/development/architecture.md:324
-msgid "Interactive prompts"
-msgstr ""
-
-#: src/development/architecture.md:325
-msgid "dirs"
-msgstr ""
-
-#: src/development/architecture.md:325
-msgid "Home directory resolution"
-msgstr ""
+msgstr "에러 타입 정의"
 
 #: src/development/architecture.md:326
+msgid "owo-colors"
+msgstr "owo-colors"
+
+#: src/development/architecture.md:326
+msgid "Terminal colors"
+msgstr "터미널 색상"
+
+#: src/development/architecture.md:327
+msgid "indicatif"
+msgstr "indicatif"
+
+#: src/development/architecture.md:327
+msgid "Progress bars & spinners"
+msgstr "진행 표시줄 및 스피너"
+
+#: src/development/architecture.md:328
+msgid "dialoguer"
+msgstr "dialoguer"
+
+#: src/development/architecture.md:328
+msgid "Interactive prompts"
+msgstr "인터랙티브 프롬프트"
+
+#: src/development/architecture.md:329
+msgid "dirs"
+msgstr "dirs"
+
+#: src/development/architecture.md:329
+msgid "Home directory resolution"
+msgstr "홈 디렉토리 결정"
+
+#: src/development/architecture.md:330
 msgid "Binary lookup (uv, python)"
-msgstr ""
+msgstr "바이너리 조회 (uv, python)"
 
-#: src/development/architecture.md:327
+#: src/development/architecture.md:331
 msgid "regex"
-msgstr ""
+msgstr "regex"
 
-#: src/development/architecture.md:327
+#: src/development/architecture.md:331
 msgid "Version parsing & validation"
-msgstr ""
+msgstr "버전 파싱 및 검증"
 
-#: src/development/architecture.md:328
+#: src/development/architecture.md:332
 msgid "walkdir"
-msgstr ""
+msgstr "walkdir"
 
-#: src/development/architecture.md:328
+#: src/development/architecture.md:332
 msgid "Directory traversal"
-msgstr ""
-
-#: src/development/architecture.md:329
-msgid "rust-i18n"
-msgstr ""
-
-#: src/development/architecture.md:329
-msgid "Internationalization (en, ko, ja, pt-BR)"
-msgstr ""
-
-#: src/development/architecture.md:330
-msgid "sys-locale"
-msgstr ""
-
-#: src/development/architecture.md:330
-msgid "System locale detection"
-msgstr ""
-
-#: src/development/architecture.md:331
-msgid "chrono"
-msgstr ""
-
-#: src/development/architecture.md:331
-msgid "Timestamp generation"
-msgstr ""
+msgstr "디렉토리 순회"
 
 #: src/development/architecture.md:333
-msgid "Extension Points"
-msgstr ""
+msgid "rust-i18n"
+msgstr "rust-i18n"
+
+#: src/development/architecture.md:333
+msgid "Internationalization (en, ko, ja, pt-BR)"
+msgstr "국제화 (en, ko, ja, pt-BR)"
+
+#: src/development/architecture.md:334
+msgid "sys-locale"
+msgstr "sys-locale"
+
+#: src/development/architecture.md:334
+msgid "System locale detection"
+msgstr "시스템 로케일 감지"
 
 #: src/development/architecture.md:335
-msgid "Adding a New Shell"
-msgstr ""
+msgid "chrono"
+msgstr "chrono"
+
+#: src/development/architecture.md:335
+msgid "Timestamp generation"
+msgstr "타임스탬프 생성"
 
 #: src/development/architecture.md:337
-msgid "Create `shell/myshell.rs`:"
-msgstr ""
+msgid "Extension Points"
+msgstr "확장 포인트"
 
-#: src/development/architecture.md:340
+#: src/development/architecture.md:339
+msgid "Adding a New Shell"
+msgstr "새 Shell 추가"
+
+#: src/development/architecture.md:341
+msgid "Create `shell/myshell.rs`:"
+msgstr "`shell/myshell.rs` 생성:"
+
+#: src/development/architecture.md:344
 msgid ""
 "// Return shell-specific initialization code as static string\n"
 "    r#\"\n"
@@ -8923,774 +9478,801 @@ msgid ""
 "    scoop() { ... }\n"
 "    \"#"
 msgstr ""
+"// shell 전용 초기화 코드를 정적 문자열로 반환\n"
+"    r#\"\n"
+"    # Shell 초기화 코드를 여기에 작성\n"
+"    scoop() { ... }\n"
+"    \"#"
 
-#: src/development/architecture.md:348
+#: src/development/architecture.md:352
 msgid ""
 "**Note**: Completions are generated by clap via `clap_complete`, not per-"
 "shell functions."
-msgstr ""
+msgstr "**참고**: 완성 스크립트는 per-shell 함수가 아닌 `clap_complete`를 통해 clap으로 생성됩니다."
 
-#: src/development/architecture.md:350
+#: src/development/architecture.md:354
 msgid "Add to `ShellType` enum in `cli/mod.rs`:"
-msgstr ""
+msgstr "`cli/mod.rs`의 `ShellType` 열거형에 추가:"
 
-#: src/development/architecture.md:353 src/development/architecture.md:392
+#: src/development/architecture.md:357 src/development/architecture.md:396
 msgid "// ... existing\n"
-msgstr ""
+msgstr "// ... 기존 항목\n"
 
-#: src/development/architecture.md:358
+#: src/development/architecture.md:362
 msgid "Add detection to `shell::detect_shell()` in `src/shell/mod.rs`:"
-msgstr ""
+msgstr "`src/shell/mod.rs`의 `shell::detect_shell()`에 감지 로직 추가:"
 
-#: src/development/architecture.md:361
+#: src/development/architecture.md:365
 msgid "\"MYSHELL_VERSION\""
-msgstr ""
+msgstr "\"MYSHELL_VERSION\""
 
-#: src/development/architecture.md:364 src/api.md:653
+#: src/development/architecture.md:368 src/api.md:653
 msgid "// ... existing checks\n"
-msgstr ""
+msgstr "// ... 기존 검사 항목\n"
 
-#: src/development/architecture.md:368
+#: src/development/architecture.md:372
 msgid "Adding a New Migration Source"
-msgstr ""
+msgstr "새 마이그레이션 소스 추가"
 
-#: src/development/architecture.md:370
+#: src/development/architecture.md:374
 msgid "Create `core/migrate/mysource.rs`:"
-msgstr ""
-
-#: src/development/architecture.md:376
-msgid "// Check if source is available\n"
-msgstr ""
+msgstr "`core/migrate/mysource.rs` 생성:"
 
 #: src/development/architecture.md:380
-msgid "// Return list of environments\n"
-msgstr ""
+msgid "// Check if source is available\n"
+msgstr "// 소스가 사용 가능한지 확인\n"
 
 #: src/development/architecture.md:384
+msgid "// Return list of environments\n"
+msgstr "// 환경 목록 반환\n"
+
+#: src/development/architecture.md:388
 msgid "// Perform migration\n"
-msgstr ""
+msgstr "// 마이그레이션 수행\n"
 
-#: src/development/architecture.md:389
+#: src/development/architecture.md:393
 msgid "Register in `cli/commands/migrate.rs`:"
-msgstr ""
+msgstr "`cli/commands/migrate.rs`에 등록:"
 
-#: src/development/architecture.md:397
+#: src/development/architecture.md:401
 msgid "Adding a New Doctor Check"
-msgstr ""
+msgstr "새 Doctor 점검 항목 추가"
 
-#: src/development/architecture.md:399
+#: src/development/architecture.md:403
 msgid ""
 "See [API Reference - Adding a New Health Check](../api.md#adding-a-new-"
 "health-check) for details."
 msgstr ""
+"자세한 내용은 [API 레퍼런스 - 새 상태 점검 추가](../api.md#adding-a-new-health-check)를 참고하세요."
 
-#: src/development/architecture.md:401
+#: src/development/architecture.md:405
 msgid "Performance Characteristics"
-msgstr ""
+msgstr "성능 특성"
 
-#: src/development/architecture.md:403
+#: src/development/architecture.md:407
 msgid "Operation"
-msgstr ""
+msgstr "작업"
 
-#: src/development/architecture.md:403
+#: src/development/architecture.md:407
 msgid "Time Complexity"
-msgstr ""
+msgstr "시간 복잡도"
 
-#: src/development/architecture.md:405
+#: src/development/architecture.md:409
 msgid "List envs"
-msgstr ""
+msgstr "환경 목록 조회"
 
-#: src/development/architecture.md:405 src/development/architecture.md:409
+#: src/development/architecture.md:409 src/development/architecture.md:413
 msgid "O(n)"
-msgstr ""
+msgstr "O(n)"
 
-#: src/development/architecture.md:405
+#: src/development/architecture.md:409
 msgid "n = number of virtualenvs"
-msgstr ""
+msgstr "n = virtualenv 수"
 
-#: src/development/architecture.md:406
+#: src/development/architecture.md:410
 msgid "Create env"
-msgstr ""
+msgstr "환경 생성"
 
-#: src/development/architecture.md:406
+#: src/development/architecture.md:410
 msgid "O(1)\\*"
-msgstr ""
+msgstr "O(1)\\*"
 
-#: src/development/architecture.md:406
+#: src/development/architecture.md:410
 msgid "\\*Depends on uv performance"
-msgstr ""
-
-#: src/development/architecture.md:407
-msgid "Delete env"
-msgstr ""
-
-#: src/development/architecture.md:407
-msgid "O(1)"
-msgstr ""
-
-#: src/development/architecture.md:407
-msgid "Simple directory removal"
-msgstr ""
-
-#: src/development/architecture.md:408
-msgid "Version resolution"
-msgstr ""
-
-#: src/development/architecture.md:408
-msgid "O(d)"
-msgstr ""
-
-#: src/development/architecture.md:408
-msgid "d = directory depth (walks parents)"
-msgstr ""
-
-#: src/development/architecture.md:409
-msgid "Doctor checks"
-msgstr ""
-
-#: src/development/architecture.md:409
-msgid "n = number of checks (fixed)"
-msgstr ""
+msgstr "\\*uv 성능에 따라 다름"
 
 #: src/development/architecture.md:411
-msgid "Thread Safety"
-msgstr ""
+msgid "Delete env"
+msgstr "환경 삭제"
+
+#: src/development/architecture.md:411
+msgid "O(1)"
+msgstr "O(1)"
+
+#: src/development/architecture.md:411
+msgid "Simple directory removal"
+msgstr "단순 디렉토리 제거"
+
+#: src/development/architecture.md:412
+msgid "Version resolution"
+msgstr "버전 결정"
+
+#: src/development/architecture.md:412
+msgid "O(d)"
+msgstr "O(d)"
+
+#: src/development/architecture.md:412
+msgid "d = directory depth (walks parents)"
+msgstr "d = 디렉토리 깊이 (상위 디렉토리 탐색)"
 
 #: src/development/architecture.md:413
+msgid "Doctor checks"
+msgstr "Doctor 점검"
+
+#: src/development/architecture.md:413
+msgid "n = number of checks (fixed)"
+msgstr "n = 점검 항목 수 (고정)"
+
+#: src/development/architecture.md:415
+msgid "Thread Safety"
+msgstr "스레드 안전성"
+
+#: src/development/architecture.md:417
 msgid ""
 "scoop is a single-threaded CLI application. No concurrent operations are "
 "performed."
-msgstr ""
-
-#: src/development/architecture.md:415
-msgid ""
-"**File locking:** Not implemented. Assumes single user on single machine. "
-"Concurrent operations (e.g., two terminals creating the same env) may result "
-"in race conditions."
-msgstr ""
-
-#: src/development/architecture.md:417 src/development/code-quality.md:342
-msgid "Security Considerations"
-msgstr ""
+msgstr "scoop은 단일 스레드 CLI 애플리케이션입니다. 동시 작업은 수행되지 않습니다."
 
 #: src/development/architecture.md:419
 msgid ""
+"**File locking:** Not implemented. Assumes single user on single machine. "
+"Concurrent operations (e.g., two terminals creating the same env) may result"
+" in race conditions."
+msgstr ""
+"**파일 잠금:** 구현되어 있지 않습니다. 단일 머신에서 단일 사용자가 사용한다고 가정합니다. 동시 작업(예: 두 터미널에서 동일한 "
+"환경 생성)은 레이스 컨디션을 유발할 수 있습니다."
+
+#: src/development/architecture.md:421 src/development/code-quality.md:342
+msgid "Security Considerations"
+msgstr "보안 고려 사항"
+
+#: src/development/architecture.md:423
+msgid ""
 "**Path Traversal:** All user-provided names are validated via regex before "
 "use in filesystem operations."
-msgstr ""
+msgstr "**경로 순회 공격:** 사용자가 제공한 모든 이름은 파일시스템 작업에 사용되기 전에 regex로 검증됩니다."
 
-#: src/development/architecture.md:420
+#: src/development/architecture.md:424
 msgid ""
 "**Command Injection:** uv commands are constructed using typed arguments, "
 "not string concatenation."
-msgstr ""
+msgstr "**커맨드 인젝션:** uv 커맨드는 문자열 연결이 아닌 타입 안전한 인수를 사용하여 구성됩니다."
 
-#: src/development/architecture.md:421
+#: src/development/architecture.md:425
 msgid ""
 "**Symlink Safety:** Doctor checks detect and warn about broken symlinks."
-msgstr ""
+msgstr "**심볼릭 링크 안전성:** Doctor 점검이 끊어진 심볼릭 링크를 감지하고 경고합니다."
 
-#: src/development/architecture.md:422
+#: src/development/architecture.md:426
 msgid ""
 "**Metadata Integrity:** JSON parsing errors are gracefully handled without "
 "panics."
-msgstr ""
+msgstr "**메타데이터 무결성:** JSON 파싱 오류는 패닉 없이 정상적으로 처리됩니다."
 
-#: src/development/architecture.md:424 src/api.md:663
+#: src/development/architecture.md:428 src/api.md:663
 msgid "Related Documentation"
-msgstr ""
+msgstr "관련 문서"
 
-#: src/development/architecture.md:426
+#: src/development/architecture.md:430
 msgid "[API Reference](../api.md) - Detailed API documentation"
-msgstr ""
+msgstr "[API 레퍼런스](../api.md) - 상세 API 문서"
 
-#: src/development/architecture.md:427
+#: src/development/architecture.md:431
 msgid "[Testing](testing.md) - Testing strategies"
-msgstr ""
+msgstr "[테스팅](testing.md) - 테스팅 전략"
 
-#: src/development/architecture.md:428
+#: src/development/architecture.md:432
 msgid "[Contributing](contributing.md) - Development guide"
-msgstr ""
+msgstr "[기여하기](contributing.md) - 개발 가이드"
 
 #: src/api.md:3
 msgid ""
 "This document provides a reference for scoop's public API, primarily "
 "intended for:"
-msgstr ""
+msgstr "이 문서는 scoop의 공개 API 레퍼런스로, 주로 다음을 위한 것입니다:"
 
 #: src/api.md:4
 msgid "**AI/LLM tools** analyzing or modifying the codebase"
-msgstr ""
+msgstr "코드베이스를 분석하거나 수정하는 **AI/LLM 도구**"
 
 #: src/api.md:5
 msgid "**Contributors** extending scoop's functionality"
-msgstr ""
+msgstr "scoop의 기능을 확장하는 **기여자**"
 
 #: src/api.md:6
 msgid "**Advanced users** integrating scoop into custom tooling"
-msgstr ""
+msgstr "scoop을 커스텀 도구에 통합하는 **고급 사용자**"
 
 #: src/api.md:8
 msgid ""
-"**Note**: This is an internal API reference. For CLI usage, see [Commands]"
-"(commands/README.md)."
+"**Note**: This is an internal API reference. For CLI usage, see "
+"[Commands](commands/README.md)."
 msgstr ""
+"**참고**: 이것은 내부 API 레퍼런스입니다. CLI 사용법은 [커맨드](commands/README.md)를 참고하세요."
 
 #: src/api.md:12
 msgid "Core Types"
-msgstr ""
+msgstr "핵심 타입"
 
 #: src/api.md:14
 msgid "VirtualEnv Module (`core/virtualenv/`)"
-msgstr ""
+msgstr "VirtualEnv 모듈 (`core/virtualenv/`)"
 
 #: src/api.md:16
 msgid "`VirtualenvInfo`"
-msgstr ""
+msgstr "`VirtualenvInfo`"
 
 #: src/api.md:18
 msgid ""
 "Represents basic information about a virtual environment. **Marked "
-"`#[non_exhaustive]` since Unreleased** — external Rust consumers can no "
-"longer construct it with struct-literal syntax. Obtain instances from "
+"`#[non_exhaustive]` since 0.14.0** — external Rust consumers can no longer "
+"construct it with struct-literal syntax. Obtain instances from "
 "`VirtualenvService::list()` (or any future read API) instead."
 msgstr ""
+"가상 환경에 대한 기본 정보를 나타냅니다. **0.14.0부터 `#[non_exhaustive]`로 표시됨** — 외부 Rust 사용자는"
+" 더 이상 구조체 리터럴 구문으로 생성할 수 없습니다. 대신 `VirtualenvService::list()`(또는 향후 추가될 읽기 "
+"API)를 통해 인스턴스를 얻으세요."
 
 #: src/api.md:34
 msgid "**Fields:**"
-msgstr ""
+msgstr "**필드:**"
 
 #: src/api.md:35
 msgid "`name` - Environment name (e.g., `\"myproject\"`)"
-msgstr ""
+msgstr "`name` - 환경 이름 (예: `\"myproject\"`)"
 
 #: src/api.md:36
 msgid "`path` - Absolute path to virtualenv directory"
-msgstr ""
+msgstr "`path` - virtualenv 디렉토리의 절대 경로"
 
 #: src/api.md:37
 msgid ""
 "`python_version` - Python version string if metadata exists (e.g., "
 "`Some(\"3.12.1\")`)"
-msgstr ""
+msgstr "`python_version` - 메타데이터가 존재하는 경우 Python 버전 문자열 (예: `Some(\"3.12.1\")`)"
 
 #: src/api.md:38
 msgid ""
-"`created_at` - Creation timestamp from metadata, if present (Unreleased)"
-msgstr ""
+"`created_at` - Creation timestamp from metadata, if present (since 0.13.0)"
+msgstr "`created_at` - 메타데이터에 있을 경우 생성 타임스탬프 (0.13.0부터)"
 
 #: src/api.md:39
 msgid ""
-"`last_used` - Most recent `scoop activate`/`run`/`shell` touch timestamp, if "
-"present (Unreleased). `None` for legacy envs that pre-date the field _and_ "
-"fresh envs that have never been activated."
+"`last_used` - Most recent `scoop activate`/`run`/`shell` touch timestamp, if"
+" present (since 0.13.0). `None` for legacy envs that pre-date the field "
+"_and_ fresh envs that have never been activated."
 msgstr ""
+"`last_used` - 가장 최근의 `scoop activate`/`run`/`shell` 터치 타임스탬프 (있는 경우, "
+"0.13.0부터). 해당 필드 도입 이전에 생성된 레거시 환경과 한 번도 활성화된 적 없는 새 환경의 경우 `None`입니다."
 
 #: src/api.md:43
 msgid ""
 "**Example (consume-only, struct-literal construction is no longer "
 "permitted):**"
-msgstr ""
+msgstr "**예시 (읽기 전용; 구조체 리터럴 생성은 더 이상 허용되지 않습니다):**"
 
 #: src/api.md:47
 msgid "\"{} (last used: {:?})\""
-msgstr ""
+msgstr "\"{} (last used: {:?})\""
 
 #: src/api.md:53 src/development/code-quality.md:261
 msgid "`VirtualenvService`"
-msgstr ""
+msgstr "`VirtualenvService`"
 
 #: src/api.md:55
 msgid "Primary service for virtualenv operations."
-msgstr ""
+msgstr "virtualenv 작업을 위한 기본 서비스입니다."
 
 #: src/api.md:63
 msgid "/// Creates a new service with custom uv wrapper\n"
-msgstr ""
+msgstr "/// 사용자 정의 uv 래퍼로 새 서비스를 생성합니다\n"
 
 #: src/api.md:66
 msgid "/// Creates a service using system's uv installation\n"
-msgstr ""
+msgstr "/// 시스템에 설치된 uv를 사용하는 서비스를 생성합니다\n"
 
 #: src/api.md:69
 msgid "/// Lists all virtualenvs\n"
-msgstr ""
+msgstr "/// 모든 virtualenv를 나열합니다\n"
 
 #: src/api.md:72
 msgid "/// Creates a new virtualenv\n"
-msgstr ""
+msgstr "/// 새로운 virtualenv를 생성합니다\n"
 
 #: src/api.md:75
 msgid "/// Creates a new virtualenv with a specific Python executable\n"
-msgstr ""
+msgstr "/// 특정 Python 실행 파일로 새 virtualenv를 생성합니다\n"
 
 #: src/api.md:78
 msgid "/// Deletes a virtualenv\n"
-msgstr ""
+msgstr "/// virtualenv를 삭제합니다\n"
 
 #: src/api.md:81
 msgid "/// Checks if a virtualenv exists\n"
-msgstr ""
+msgstr "/// virtualenv가 존재하는지 확인합니다\n"
 
 #: src/api.md:84
 msgid "/// Gets the path to a virtualenv\n"
-msgstr ""
+msgstr "/// virtualenv 경로를 가져옵니다\n"
 
 #: src/api.md:87
 msgid ""
 "/// Reads metadata for a virtualenv (best-effort; collapses\n"
 "    /// missing and corrupt into `None`).\n"
 msgstr ""
+"/// virtualenv의 메타데이터를 읽습니다 (최선 시도; 없거나\n"
+"    /// 손상된 경우 `None`으로 처리합니다).\n"
 
 #: src/api.md:91
 msgid ""
 "/// Reads metadata distinguishing missing (`Ok(None)`) from\n"
 "    /// corrupt (`Err(_)`). Touch / gc use this so they can refuse\n"
-"    /// to overwrite garbage. (Unreleased)\n"
+"    /// to overwrite garbage. (since 0.14.0)\n"
 msgstr ""
+"/// 누락된 경우(`Ok(None)`)와 손상된 경우(`Err(_)`)를\n"
+"    /// 구분하여 메타데이터를 읽습니다. touch / gc에서 사용하여\n"
+"    /// 잘못된 데이터 덮어쓰기를 방지합니다. (0.14.0부터)\n"
 
 #: src/api.md:96
-msgid "/// Writes metadata atomically via tempfile + rename. (Unreleased)\n"
-msgstr ""
+msgid "/// Writes metadata atomically via tempfile + rename. (since 0.14.0)\n"
+msgstr "/// 임시 파일 + 이름 변경 방식으로 메타데이터를 원자적으로 씁니다. (0.14.0부터)\n"
 
 #: src/api.md:99
 msgid ""
 "/// Best-effort update to `last_used`. Never returns an error;\n"
-"    /// logs `warn!` on failure. (Unreleased)\n"
+"    /// logs `warn!` on failure. (since 0.14.0)\n"
 msgstr ""
+"/// `last_used`를 최선 시도로 업데이트합니다. 오류를 반환하지 않으며\n"
+"    /// 실패 시 `warn!`을 로그에 남깁니다. (0.14.0부터)\n"
 
 #: src/api.md:105
 msgid "**Common Usage Pattern:**"
-msgstr ""
+msgstr "**일반적인 사용 패턴:**"
 
 #: src/api.md:107
 msgid "// Initialize service\n"
-msgstr ""
+msgstr "// 서비스 초기화\n"
 
 #: src/api.md:109
 msgid "// Check if environment exists\n"
-msgstr ""
+msgstr "// 환경 존재 여부 확인\n"
 
 #: src/api.md:112
 msgid "// Create with Python 3.12\n"
-msgstr ""
+msgstr "// Python 3.12로 생성\n"
 
 #: src/api.md:115
 msgid "// Get environment path\n"
-msgstr ""
+msgstr "// 환경 경로 가져오기\n"
 
 #: src/api.md:118
 msgid "\"Environment at: {}\""
-msgstr ""
+msgstr "\"Environment at: {}\""
 
 #: src/api.md:123
 msgid "Metadata Module (`core/metadata.rs`)"
-msgstr ""
+msgstr "메타데이터 모듈 (`core/metadata.rs`)"
 
 #: src/api.md:125
 msgid "`Metadata`"
-msgstr ""
+msgstr "`Metadata`"
 
 #: src/api.md:127
 msgid "Stores JSON metadata for each virtualenv."
-msgstr ""
+msgstr "각 virtualenv의 JSON 메타데이터를 저장합니다."
 
 #: src/api.md:137
 msgid "// Timestamp (ISO 8601 when serialized)\n"
-msgstr ""
+msgstr "// 타임스탬프 (직렬화 시 ISO 8601 형식)\n"
 
 #: src/api.md:138
 msgid "// \"scoop X.Y.Z\" format\n"
-msgstr ""
+msgstr "// \"scoop X.Y.Z\" 형식\n"
 
 #: src/api.md:139
 msgid "// uv version used\n"
-msgstr ""
+msgstr "// 사용된 uv 버전\n"
 
 #: src/api.md:140
 msgid "// Custom Python executable path (if --python-path was used)\n"
-msgstr ""
+msgstr "// 커스텀 Python 실행 파일 경로 (--python-path를 사용한 경우)\n"
 
 #: src/api.md:141
-msgid "// Last activation timestamp (Unreleased)\n"
-msgstr ""
+msgid "// Last activation timestamp (since 0.13.0)\n"
+msgstr "// 마지막 활성화 타임스탬프 (0.13.0부터)\n"
 
 #: src/api.md:145
 msgid "/// Creates new metadata\n"
-msgstr ""
+msgstr "/// 새 메타데이터를 생성합니다\n"
 
 #: src/api.md:150
 msgid ""
 "**Storage Location:** `~/.scoop/virtualenvs/<name>/.scoop-metadata.json`"
-msgstr ""
+msgstr "**저장 위치:** `~/.scoop/virtualenvs/<name>/.scoop-metadata.json`"
 
 #: src/api.md:152
 msgid "**Example JSON:**"
-msgstr ""
+msgstr "**JSON 예시:**"
 
 #: src/api.md:157
 msgid "\"2024-01-15T10:30:00Z\""
-msgstr ""
+msgstr "\"2024-01-15T10:30:00Z\""
 
 #: src/api.md:158
 msgid "\"created_by\""
-msgstr ""
+msgstr "\"created_by\""
 
 #: src/api.md:158
 msgid "\"scoop <version>\""
-msgstr ""
+msgstr "\"scoop <version>\""
 
 #: src/api.md:159
 msgid "\"0.1.0\""
-msgstr ""
+msgstr "\"0.1.0\""
 
 #: src/api.md:163
 msgid ""
-"**Note**: `created_at` is `DateTime<Utc>` in Rust but serializes to ISO 8601 "
-"string in JSON."
+"**Note**: `created_at` is `DateTime<Utc>` in Rust but serializes to ISO 8601"
+" string in JSON."
 msgstr ""
+"**참고**: `created_at`은 Rust에서 `DateTime<Utc>` 타입이지만 JSON에서는 ISO 8601 문자열로 "
+"직렬화됩니다."
 
 #: src/api.md:167
 msgid "Doctor Module (`core/doctor.rs`)"
-msgstr ""
+msgstr "Doctor 모듈 (`core/doctor.rs`)"
 
 #: src/api.md:169
 msgid "`Check` Trait"
-msgstr ""
+msgstr "`Check` 트레이트"
 
 #: src/api.md:171
 msgid "Interface for health checks."
-msgstr ""
+msgstr "상태 점검을 위한 인터페이스입니다."
 
 #: src/api.md:177
 msgid "// Returns Vec - a check can produce multiple results\n"
-msgstr ""
+msgstr "// Vec를 반환 - 하나의 점검이 여러 결과를 생성할 수 있음\n"
 
 #: src/api.md:181
 msgid "**Implementations:**"
-msgstr ""
+msgstr "**구현체:**"
 
 #: src/api.md:182
 msgid "`UvCheck` - Verifies uv is installed"
-msgstr ""
+msgstr "`UvCheck` - uv 설치 여부를 확인합니다"
 
 #: src/api.md:183
 msgid "`HomeCheck` - Checks `SCOOP_HOME` directory"
-msgstr ""
+msgstr "`HomeCheck` - `SCOOP_HOME` 디렉토리를 점검합니다"
 
 #: src/api.md:184
 msgid "`VirtualenvCheck` - Validates virtualenvs directory"
-msgstr ""
+msgstr "`VirtualenvCheck` - virtualenvs 디렉토리를 검증합니다"
 
 #: src/api.md:185
 msgid ""
-"`SymlinkCheck` - Checks for broken virtualenv Python symlinks (e.g., `<env>/"
-"bin/python`)"
+"`SymlinkCheck` - Checks for broken virtualenv Python symlinks (e.g., "
+"`<env>/bin/python`)"
 msgstr ""
+"`SymlinkCheck` - 끊어진 virtualenv Python 심볼릭 링크를 점검합니다 (예: `<env>/bin/python`)"
 
 #: src/api.md:186
 msgid "`ShellCheck` - Verifies shell integration"
-msgstr ""
+msgstr "`ShellCheck` - shell 통합을 확인합니다"
 
 #: src/api.md:187
 msgid "`VersionCheck` - Validates version files"
-msgstr ""
+msgstr "`VersionCheck` - 버전 파일을 검증합니다"
 
 #: src/api.md:191
 msgid "`CheckStatus`"
-msgstr ""
+msgstr "`CheckStatus`"
 
 #: src/api.md:193
 msgid "Result status for health checks."
-msgstr ""
+msgstr "상태 점검의 결과 상태입니다."
 
 #: src/api.md:197
 msgid "// ✅ Check passed\n"
-msgstr ""
+msgstr "// ✅ 점검 통과\n"
 
 #: src/api.md:198
 msgid "// ⚠️  Issue found, but not critical\n"
-msgstr ""
+msgstr "// ⚠️  문제가 발견되었으나 심각하지 않음\n"
 
 #: src/api.md:199
 msgid "// ❌ Critical issue\n"
-msgstr ""
+msgstr "// ❌ 심각한 문제\n"
 
 #: src/api.md:205
 msgid "`CheckResult`"
-msgstr ""
+msgstr "`CheckResult`"
 
 #: src/api.md:207
 msgid "Detailed result from a health check."
-msgstr ""
+msgstr "상태 점검의 상세 결과입니다."
 
 #: src/api.md:219
 msgid "/// Creates an OK result\n"
-msgstr ""
+msgstr "/// OK 결과를 생성합니다\n"
 
 #: src/api.md:222
 msgid "/// Creates a warning result\n"
-msgstr ""
+msgstr "/// 경고 결과를 생성합니다\n"
 
 #: src/api.md:225
 msgid "/// Creates an error result\n"
-msgstr ""
+msgstr "/// 오류 결과를 생성합니다\n"
 
 #: src/api.md:228
 msgid "/// Adds a suggestion for fixing the issue\n"
-msgstr ""
+msgstr "/// 문제 해결을 위한 제안을 추가합니다\n"
 
 #: src/api.md:231
 msgid "/// Adds detailed information\n"
-msgstr ""
+msgstr "/// 상세 정보를 추가합니다\n"
 
 #: src/api.md:234
 msgid "// Status checks\n"
-msgstr ""
+msgstr "// 상태 확인\n"
 
 #: src/api.md:241
 msgid "**Example - Implementing a Custom Check:**"
-msgstr ""
+msgstr "**예시 - 커스텀 점검 구현:**"
 
 #: src/api.md:247 src/api.md:635
 msgid "\"my_check\""
-msgstr ""
+msgstr "\"my_check\""
 
 #: src/api.md:251 src/api.md:639
 msgid "\"My Custom Check\""
-msgstr ""
+msgstr "\"My Custom Check\""
 
 #: src/api.md:258
 msgid "\"Error message here\""
-msgstr ""
+msgstr "\"Error message here\""
 
 #: src/api.md:259
 msgid "\"Run: scoop fix-it\""
-msgstr ""
+msgstr "\"Run: scoop fix-it\""
 
 #: src/api.md:260
 msgid "\"Expected X, found Y\""
-msgstr ""
+msgstr "\"Expected X, found Y\""
 
 #: src/api.md:268
 msgid "`Doctor`"
-msgstr ""
+msgstr "`Doctor`"
 
 #: src/api.md:270
 msgid "Orchestrates all health checks."
-msgstr ""
+msgstr "모든 상태 점검을 조율합니다."
 
 #: src/api.md:278
 msgid "/// Creates a doctor with default checks\n"
-msgstr ""
+msgstr "/// 기본 점검 항목으로 doctor를 생성합니다\n"
 
 #: src/api.md:281
 msgid "/// Runs all checks without fixing\n"
-msgstr ""
+msgstr "/// 수정 없이 모든 점검을 실행합니다\n"
 
 #: src/api.md:284
 msgid "/// Runs checks and attempts to fix issues\n"
-msgstr ""
+msgstr "/// 점검을 실행하고 문제 수정을 시도합니다\n"
 
 #: src/api.md:295
 msgid "**Usage:**"
-msgstr ""
+msgstr "**사용법:**"
 
 #: src/api.md:298
 msgid "// Run diagnostics\n"
-msgstr ""
+msgstr "// 진단 실행\n"
 
 #: src/api.md:303
 msgid "\"❌ {}: {}\""
-msgstr ""
+msgstr "\"❌ {}: {}\""
 
 #: src/api.md:304
 msgid "\"⚠️  {}: {}\""
-msgstr ""
+msgstr "\"⚠️  {}: {}\""
 
 #: src/api.md:305
 msgid "\"✅ {}\""
-msgstr ""
+msgstr "\"✅ {}\""
 
 #: src/api.md:308
 msgid "// Auto-fix issues (requires Output for progress display)\n"
-msgstr ""
+msgstr "// 문제 자동 수정 (진행 상황 표시를 위해 Output 필요)\n"
 
 #: src/api.md:319
-msgid "`ScoopError` (`error.rs`)"
-msgstr ""
+msgid "`ScoopError` (`error/` module)"
+msgstr "`ScoopError` (`error/` 모듈)"
 
 #: src/api.md:321
 msgid "Primary error type for all scoop operations."
-msgstr ""
+msgstr "모든 scoop 작업에 대한 기본 에러 타입입니다."
 
 #: src/api.md:326
 msgid "// Virtualenv errors\n"
-msgstr ""
+msgstr "// Virtualenv 에러\n"
 
 #: src/api.md:331
 msgid "// Python errors\n"
-msgstr ""
+msgstr "// Python 에러\n"
 
 #: src/api.md:338
 msgid "// uv errors\n"
-msgstr ""
+msgstr "// uv 에러\n"
 
 #: src/api.md:342
 msgid "// Path/IO errors\n"
-msgstr ""
+msgstr "// 경로/IO 에러\n"
 
 #: src/api.md:343
 msgid "// Tuple variant\n"
-msgstr ""
+msgstr "// 튜플 변형\n"
 
 #: src/api.md:345 src/api.md:346
 msgid "// Tuple variant with From\n"
-msgstr ""
+msgstr "// From이 있는 튜플 변형\n"
 
 #: src/api.md:348
 msgid "// Config errors\n"
-msgstr ""
+msgstr "// 설정 에러\n"
 
 #: src/api.md:352
 msgid "// CLI errors\n"
-msgstr ""
+msgstr "// CLI 에러\n"
 
 #: src/api.md:355
 msgid "// Migration errors\n"
-msgstr ""
+msgstr "// 마이그레이션 에러\n"
 
 #: src/api.md:365
 msgid "// Python path errors\n"
-msgstr ""
+msgstr "// Python 경로 에러\n"
 
 #: src/api.md:368
 msgid "// Cascade errors\n"
-msgstr ""
+msgstr "// 연쇄 에러\n"
 
 #: src/api.md:373
-msgid ""
-"/// Returns error code string (e.g., \"ENV_NOT_FOUND\", "
-"\"UV_COMMAND_FAILED\")\n"
-msgstr ""
+msgid "/// Returns error code string (e.g., \"ENV_NOT_FOUND\", \"UV_COMMAND_FAILED\")\n"
+msgstr "/// 에러 코드 문자열을 반환합니다 (예: \"ENV_NOT_FOUND\", \"UV_COMMAND_FAILED\")\n"
 
 #: src/api.md:376
 msgid ""
 "/// Localized message in an explicit locale (bypasses the process-global\n"
-"    /// current locale). `Display` delegates to this with the current "
-"locale.\n"
+"    /// current locale). `Display` delegates to this with the current locale.\n"
 msgstr ""
+"/// 명시적 로케일의 현지화된 메시지를 반환합니다 (프로세스 전역\n"
+"    /// 현재 로케일을 우회합니다). `Display`는 현재 로케일로 이를 위임합니다.\n"
 
 #: src/api.md:380
 msgid ""
 "/// Returns user-friendly suggestion in the current locale (if available)\n"
-msgstr ""
+msgstr "/// 현재 로케일에서 사용자 친화적인 제안을 반환합니다 (가능한 경우)\n"
 
 #: src/api.md:383
 msgid ""
 "/// Locale-explicit sibling of `suggestion()` — useful for deterministic,\n"
 "    /// parallel tests that must not depend on the global locale.\n"
 msgstr ""
+"/// `suggestion()`의 로케일 명시 버전 — 전역 로케일에 의존하지 않아야 하는\n"
+"    /// 결정적 병렬 테스트에 유용합니다.\n"
 
 #: src/api.md:387
 msgid "/// Returns migration-specific exit code\n"
-msgstr ""
+msgstr "/// 마이그레이션 전용 종료 코드를 반환합니다\n"
 
 #: src/api.md:392
 msgid ""
 "The `*_in(locale)` accessors pass `locale =` to rust-i18n's `t!`, which "
-"bypasses the process-global current locale — this lets tests assert messages "
-"deterministically without `#[serial]`."
+"bypasses the process-global current locale — this lets tests assert messages"
+" deterministically without `#[serial]`."
 msgstr ""
+"`*_in(locale)` 접근자는 `locale =`을 rust-i18n의 `t!`에 전달하며, 이를 통해 프로세스 전역 현재 로케일을"
+" 우회합니다. 덕분에 테스트에서 `#[serial]` 없이도 메시지를 결정적으로 검증할 수 있습니다."
 
 #: src/api.md:396
 msgid "**Error Code String Prefixes:**"
-msgstr ""
+msgstr "**에러 코드 문자열 접두사:**"
 
 #: src/api.md:397
 msgid ""
 "`ENV_*` - Environment errors (e.g., `ENV_NOT_FOUND`, `ENV_ALREADY_EXISTS`)"
-msgstr ""
+msgstr "`ENV_*` - 환경 에러 (예: `ENV_NOT_FOUND`, `ENV_ALREADY_EXISTS`)"
 
 #: src/api.md:398
 msgid "`PYTHON_*` - Python version errors (e.g., `PYTHON_NOT_INSTALLED`)"
-msgstr ""
+msgstr "`PYTHON_*` - Python 버전 에러 (예: `PYTHON_NOT_INSTALLED`)"
 
 #: src/api.md:399
 msgid "`UV_*` - uv errors (e.g., `UV_NOT_INSTALLED`, `UV_COMMAND_FAILED`)"
-msgstr ""
+msgstr "`UV_*` - uv 에러 (예: `UV_NOT_INSTALLED`, `UV_COMMAND_FAILED`)"
 
 #: src/api.md:400
 msgid "`IO_*` - Path/IO errors (e.g., `IO_ERROR`, `PATH_ERROR`)"
-msgstr ""
+msgstr "`IO_*` - 경로/IO 에러 (예: `IO_ERROR`, `PATH_ERROR`)"
 
 #: src/api.md:401
 msgid "`CONFIG_*` - Config errors (e.g., `CONFIG_VERSION_FILE_NOT_FOUND`)"
-msgstr ""
+msgstr "`CONFIG_*` - 설정 에러 (예: `CONFIG_VERSION_FILE_NOT_FOUND`)"
 
 #: src/api.md:402
 msgid "`SHELL_*` - Shell errors (e.g., `SHELL_NOT_SUPPORTED`)"
-msgstr ""
+msgstr "`SHELL_*` - Shell 에러 (예: `SHELL_NOT_SUPPORTED`)"
 
 #: src/api.md:403
 msgid "`ARG_*` - CLI argument errors (e.g., `ARG_INVALID`)"
-msgstr ""
+msgstr "`ARG_*` - CLI 인수 에러 (예: `ARG_INVALID`)"
 
 #: src/api.md:404
 msgid "`SOURCE_*` - Migration source errors (e.g., `SOURCE_PYENV_NOT_FOUND`)"
-msgstr ""
+msgstr "`SOURCE_*` - 마이그레이션 소스 에러 (예: `SOURCE_PYENV_NOT_FOUND`)"
 
 #: src/api.md:405
 msgid "`MIGRATE_*` - Migration process errors (e.g., `MIGRATE_FAILED`)"
-msgstr ""
+msgstr "`MIGRATE_*` - 마이그레이션 프로세스 에러 (예: `MIGRATE_FAILED`)"
 
 #: src/api.md:406
 msgid "`UNINSTALL_*` - Uninstall errors (e.g., `UNINSTALL_CASCADE_ABORTED`)"
-msgstr ""
+msgstr "`UNINSTALL_*` - 제거 에러 (예: `UNINSTALL_CASCADE_ABORTED`)"
 
 #: src/api.md:408
 msgid "**Example Error Handling:**"
-msgstr ""
+msgstr "**에러 처리 예시:**"
 
 #: src/api.md:416
 msgid "\"Must start with a letter\""
-msgstr ""
+msgstr "\"Must start with a letter\""
 
 #: src/api.md:420
 msgid "// ... operation\n"
-msgstr ""
+msgstr "// ... 작업\n"
 
 #: src/api.md:424
 msgid "// Usage\n"
-msgstr ""
+msgstr "// 사용 예시\n"
 
 #: src/api.md:426
 msgid "\"123invalid\""
-msgstr ""
+msgstr "\"123invalid\""
 
 #: src/api.md:427
 msgid "\"Success\""
-msgstr ""
+msgstr "\"Success\""
 
 #: src/api.md:429
 msgid "\"Error: {}\""
-msgstr ""
+msgstr "\"Error: {}\""
 
 #: src/api.md:431
 msgid "\"Suggestion: {}\""
-msgstr ""
+msgstr "\"Suggestion: {}\""
 
 #: src/api.md:433
 msgid "\"Error code: {}\""
-msgstr ""
+msgstr "\"Error code: {}\""
 
 #: src/api.md:434
 msgid "// Non-zero exit for error\n"
-msgstr ""
+msgstr "// 에러 시 0이 아닌 종료 코드\n"
 
 #: src/api.md:443
 msgid "Shell Types (`cli/mod.rs`)"
-msgstr ""
+msgstr "Shell 타입 (`cli/mod.rs`)"
 
 #: src/api.md:452
 msgid ""
@@ -9702,296 +10284,310 @@ msgid ""
 "// - shell::fish::init_script() -> &'static str\n"
 "// - shell::powershell::init_script() -> &'static str\n"
 msgstr ""
+"// 참고: ShellType은 메서드가 없는 일반 열거형입니다\n"
+"// Shell 작업은 모듈 수준 함수로 처리됩니다:\n"
+"// - shell::detect_shell() -> ShellType  (shell/mod.rs에 있음)\n"
+"// - shell::bash::init_script() -> &'static str\n"
+"// - shell::zsh::init_script() -> &'static str\n"
+"// - shell::fish::init_script() -> &'static str\n"
+"// - shell::powershell::init_script() -> &'static str\n"
 
 #: src/api.md:462
 msgid "**Auto-detection Priority:**"
-msgstr ""
+msgstr "**자동 감지 우선순위:**"
 
 #: src/api.md:463
 msgid "`FISH_VERSION` → Fish"
-msgstr ""
+msgstr "`FISH_VERSION` → Fish"
 
 #: src/api.md:464
 msgid "`PSModulePath` → PowerShell"
-msgstr ""
+msgstr "`PSModulePath` → PowerShell"
 
 #: src/api.md:465
 msgid "`ZSH_VERSION` → Zsh"
-msgstr ""
+msgstr "`ZSH_VERSION` → Zsh"
 
 #: src/api.md:466
 msgid "Default → Bash"
-msgstr ""
+msgstr "기본값 → Bash"
 
 #: src/api.md:470
 msgid "Path Utilities (`paths.rs`)"
-msgstr ""
+msgstr "경로 유틸리티 (`paths.rs`)"
 
 #: src/api.md:473
 msgid "/// Returns scoop home directory (SCOOP_HOME or ~/.scoop)\n"
-msgstr ""
+msgstr "/// scoop 홈 디렉토리를 반환합니다 (SCOOP_HOME 또는 ~/.scoop)\n"
 
 #: src/api.md:475
 msgid "/// Returns virtualenvs directory\n"
-msgstr ""
+msgstr "/// virtualenvs 디렉토리를 반환합니다\n"
 
 #: src/api.md:478
 msgid "/// Returns global version file path (~/.scoop/version)\n"
-msgstr ""
+msgstr "/// 전역 버전 파일 경로를 반환합니다 (~/.scoop/version)\n"
 
 #: src/api.md:481
 msgid "/// Returns local version file path in the given directory\n"
-msgstr ""
+msgstr "/// 지정된 디렉토리의 로컬 버전 파일 경로를 반환합니다\n"
 
 #: src/api.md:488
 msgid "Version Resolution (`core/version.rs`)"
-msgstr ""
+msgstr "버전 결정 (`core/version.rs`)"
 
 #: src/api.md:490
 msgid "`VersionService`"
-msgstr ""
+msgstr "`VersionService`"
 
 #: src/api.md:492
 msgid "Service for managing version files."
-msgstr ""
+msgstr "버전 파일을 관리하는 서비스입니다."
 
 #: src/api.md:498
 msgid "/// Set the local version for a directory\n"
-msgstr ""
+msgstr "/// 디렉토리의 로컬 버전을 설정합니다\n"
 
 #: src/api.md:501
 msgid "/// Set the global version\n"
-msgstr ""
+msgstr "/// 전역 버전을 설정합니다\n"
 
 #: src/api.md:504
 msgid "/// Get the local version for a directory\n"
-msgstr ""
+msgstr "/// 디렉토리의 로컬 버전을 가져옵니다\n"
 
 #: src/api.md:507
 msgid "/// Get the global version\n"
-msgstr ""
+msgstr "/// 전역 버전을 가져옵니다\n"
 
 #: src/api.md:510
 msgid ""
 "/// Resolve the version for a directory (local -> parent walk -> global)\n"
-msgstr ""
+msgstr "/// 디렉토리의 버전을 결정합니다 (로컬 → 상위 디렉토리 탐색 → 전역)\n"
 
 #: src/api.md:513
 msgid "/// Resolve from current directory\n"
-msgstr ""
+msgstr "/// 현재 디렉토리에서 결정합니다\n"
 
 #: src/api.md:516
 msgid "/// Unset local version (removes .scoop-version)\n"
-msgstr ""
+msgstr "/// 로컬 버전을 해제합니다 (.scoop-version 제거)\n"
 
 #: src/api.md:519
 msgid "/// Unset global version (removes ~/.scoop/version)\n"
-msgstr ""
+msgstr "/// 전역 버전을 해제합니다 (~/.scoop/version 제거)\n"
 
 #: src/api.md:524
 msgid "**CLI Equivalent (User Workflow):**"
-msgstr ""
+msgstr "**동등한 CLI 명령어 (사용자 워크플로우):**"
 
 #: src/api.md:526
 msgid ""
-"`VersionService::set_global()` is exposed by the `scoop use <name> --global` "
-"command. To set Python 3.11.0 as the global default in practice:"
+"`VersionService::set_global()` is exposed by the `scoop use <name> --global`"
+" command. To set Python 3.11.0 as the global default in practice:"
 msgstr ""
+"`VersionService::set_global()`은 `scoop use <name> --global` 명령어로 노출됩니다. 실제로 "
+"Python 3.11.0을 전역 기본값으로 설정하려면:"
 
 #: src/api.md:535
 msgid ""
 "This writes `py311` to `~/.scoop/version`. The global value is used when no "
 "local `.scoop-version` or `SCOOP_VERSION` override is present."
 msgstr ""
+"이 명령어는 `py311`을 `~/.scoop/version`에 기록합니다. 로컬 `.scoop-version`이나 "
+"`SCOOP_VERSION` 재정의가 없을 때 전역 값이 사용됩니다."
 
 #: src/api.md:538
 msgid "**Resolution Priority Order:**"
-msgstr ""
+msgstr "**결정 우선순위 순서:**"
 
 #: src/api.md:539
 msgid ""
 "`SCOOP_VERSION` environment variable (checked at shell hook level, not in "
 "VersionService)"
 msgstr ""
+"`SCOOP_VERSION` 환경 변수 (shell hook 수준에서 확인, VersionService 내부에서는 확인하지 않음)"
 
 #: src/api.md:540
 msgid "`.scoop-version` in current directory"
-msgstr ""
+msgstr "현재 디렉토리의 `.scoop-version`"
 
 #: src/api.md:541
 msgid "`.scoop-version` in parent directories (walks up)"
-msgstr ""
+msgstr "상위 디렉토리의 `.scoop-version` (상위로 탐색)"
 
-#: src/api.md:542 src/llms.md:165
+#: src/api.md:542 src/llms.md:167
 msgid "`~/.scoop/version` (global default)"
-msgstr ""
+msgstr "`~/.scoop/version` (전역 기본값)"
 
 #: src/api.md:544
 msgid "**Note**: `.python-version` is not supported."
-msgstr ""
+msgstr "**참고**: `.python-version`은 지원되지 않습니다."
 
 #: src/api.md:548
 msgid "Testing Patterns"
-msgstr ""
+msgstr "테스트 패턴"
 
 #: src/api.md:550
 msgid "Property-Based Testing"
-msgstr ""
+msgstr "속성 기반 테스트"
 
 #: src/api.md:552
 msgid "scoop uses `proptest` for property-based testing of critical logic:"
-msgstr ""
+msgstr "scoop는 중요 로직의 속성 기반 테스트를 위해 `proptest`를 사용합니다:"
 
 #: src/api.md:568
 msgid "Integration Testing"
-msgstr ""
+msgstr "통합 테스트"
 
 #: src/api.md:570
 msgid "Test files follow the pattern:"
-msgstr ""
+msgstr "테스트 파일은 다음 패턴을 따릅니다:"
 
 #: src/api.md:578
 msgid "// Test setup\n"
-msgstr ""
+msgstr "// 테스트 설정\n"
 
 #: src/api.md:584
 msgid "// Test logic\n"
-msgstr ""
+msgstr "// 테스트 로직\n"
 
 #: src/api.md:591
 msgid "Extending scoop"
-msgstr ""
+msgstr "scoop 확장"
 
 #: src/api.md:595
 msgid "**Define command in `cli/mod.rs`:**"
-msgstr ""
+msgstr "**`cli/mod.rs`에서 명령어 정의:**"
 
 #: src/api.md:599
 msgid "// ... existing commands\n"
-msgstr ""
+msgstr "// ... 기존 명령어\n"
 
 #: src/api.md:601
 msgid "\"Argument description\""
-msgstr ""
+msgstr "\"Argument description\""
 
 #: src/api.md:607
 msgid "**Create handler in `cli/commands/`:**"
-msgstr ""
+msgstr "**`cli/commands/`에 핸들러 생성:**"
 
 #: src/api.md:609
 msgid "// cli/commands/my_command.rs\n"
-msgstr ""
+msgstr "// cli/commands/my_command.rs\n"
 
 #: src/api.md:618
 msgid "**Wire up in `main.rs`:**"
-msgstr ""
+msgstr "**`main.rs`에서 연결:**"
 
 #: src/api.md:627
 msgid "Adding a New Health Check"
-msgstr ""
+msgstr "새 상태 점검 추가"
 
 #: src/api.md:630
 msgid "// In core/doctor.rs\n"
-msgstr ""
+msgstr "// core/doctor.rs에서\n"
 
 #: src/api.md:643
 msgid "// Check logic\n"
-msgstr ""
+msgstr "// 점검 로직\n"
 
 #: src/api.md:647
 msgid "// Register in Doctor::new()\n"
-msgstr ""
+msgstr "// Doctor::new()에 등록\n"
 
 #: src/api.md:665
 msgid ""
 "[Architecture](development/architecture.md) - System design and patterns"
-msgstr ""
+msgstr "[아키텍처](development/architecture.md) - 시스템 설계와 패턴"
 
 #: src/api.md:666
 msgid "[Commands](commands/README.md) - CLI reference"
-msgstr ""
+msgstr "[명령어](commands/README.md) - CLI 참조"
 
 #: src/api.md:667
 msgid "[Contributing](development/contributing.md) - Development guide"
-msgstr ""
+msgstr "[기여하기](development/contributing.md) - 개발 가이드"
 
 #: src/api.md:668
 msgid "[Testing](development/testing.md) - Testing strategies"
-msgstr ""
+msgstr "[테스트](development/testing.md) - 테스트 전략"
 
 #: src/api.md:672
 msgid "For AI/LLM Tools"
-msgstr ""
+msgstr "AI/LLM 도구를 위한 안내"
 
 #: src/api.md:674
 msgid "When analyzing or modifying this codebase:"
-msgstr ""
+msgstr "이 코드베이스를 분석하거나 수정할 때:"
 
 #: src/api.md:676
 msgid "**Use symbolic tools** for precise navigation:"
-msgstr ""
+msgstr "**심볼 도구를 활용하세요** — 정확한 탐색을 위해:"
 
 #: src/api.md:677
 msgid "`find_symbol` to locate specific functions/types"
-msgstr ""
+msgstr "`find_symbol` — 특정 함수/타입 위치 파악"
 
 #: src/api.md:678
 msgid "`find_referencing_symbols` to understand usage"
-msgstr ""
+msgstr "`find_referencing_symbols` — 사용처 파악"
 
 #: src/api.md:679
 msgid "`get_symbols_overview` for module structure"
-msgstr ""
+msgstr "`get_symbols_overview` — 모듈 구조 파악"
 
 #: src/api.md:681
 msgid "**Follow existing patterns**:"
-msgstr ""
+msgstr "**기존 패턴을 따르세요**:"
 
 #: src/api.md:682
 msgid "Error handling: Always return `Result<T>` with `ScoopError`"
-msgstr ""
+msgstr "에러 처리: 항상 `ScoopError`와 함께 `Result<T>`를 반환합니다"
 
 #: src/api.md:683
 msgid "Shell output: CLI outputs shell code, wrapper evals it"
-msgstr ""
+msgstr "Shell 출력: CLI가 shell 코드를 출력하면 래퍼가 eval로 실행합니다"
 
 #: src/api.md:684
 msgid "Testing: Unit tests + integration tests + property tests"
-msgstr ""
+msgstr "테스트: 단위 테스트 + 통합 테스트 + 속성 테스트"
 
 #: src/api.md:685
 msgid "i18n: Use `t!()` macro for all user-facing strings"
-msgstr ""
+msgstr "i18n: 사용자 대상 문자열에는 모두 `t!()` 매크로를 사용합니다"
 
 #: src/api.md:687
 msgid "**Preserve conventions**:"
-msgstr ""
+msgstr "**관례를 유지하세요**:"
 
 #: src/api.md:688
 msgid ""
 "Error codes are string constants (e.g., \"ENV_NOT_FOUND\", "
 "\"UV_COMMAND_FAILED\")"
-msgstr ""
+msgstr "에러 코드는 문자열 상수입니다 (예: \"ENV_NOT_FOUND\", \"UV_COMMAND_FAILED\")"
 
 #: src/api.md:689
 msgid ""
 "Process exit codes follow a layered contract (see **Process exit codes** "
 "below)"
-msgstr ""
+msgstr "프로세스 종료 코드는 계층적 계약을 따릅니다 (아래 **프로세스 종료 코드** 참조)"
 
 #: src/api.md:690
 msgid ""
 "Path handling via `paths.rs` utilities (cross-platform — Unix `bin/` vs "
 "Windows `Scripts/`)"
 msgstr ""
+"경로 처리는 `paths.rs` 유틸리티를 통해 수행합니다 (크로스 플랫폼 — Unix `bin/` vs Windows "
+"`Scripts/`)"
 
 #: src/api.md:691
 msgid "Shell detection via `shell::detect_shell()` function"
-msgstr ""
+msgstr "Shell 감지는 `shell::detect_shell()` 함수를 통해 수행합니다"
 
 #: src/api.md:693
 msgid "Process exit codes"
-msgstr ""
+msgstr "프로세스 종료 코드"
 
 #: src/api.md:695
 msgid ""
@@ -10000,365 +10596,368 @@ msgid ""
 "(e.g. `verify`) opt into `ErrorRenderPolicy::Quiet` so `main.rs` does not "
 "append a duplicate `error:` line."
 msgstr ""
+"scoop는 `ScoopError::exit_code()`를 통해 `src/error/exit.rs`에 종료 코드 정책을 집중 "
+"관리합니다. 자체적으로 보고서를 출력하는 명령어(예: `verify`)는 `ErrorRenderPolicy::Quiet`를 선택하여 "
+"`main.rs`가 중복 `error:` 줄을 추가하지 않도록 합니다."
 
 #: src/api.md:703
 msgid ""
 "Generic failure or semantic finding (verify failed, generic operational "
 "error)"
-msgstr ""
+msgstr "일반적인 실패 또는 의미론적 결과 (verify 실패, 일반 작업 오류)"
 
 #: src/api.md:704
 msgid ""
-"Migration failure / `MigrationNameConflict` (and reserved for future probe/"
-"tool failures)"
-msgstr ""
+"Migration failure / `MigrationNameConflict` (and reserved for future "
+"probe/tool failures)"
+msgstr "마이그레이션 실패 / `MigrationNameConflict` (및 향후 프로브/도구 실패를 위한 예약)"
 
 #: src/api.md:705
 msgid ""
 "Migration source-discovery error (pyenv/conda/venvwrapper missing or "
 "corrupted)"
-msgstr ""
+msgstr "마이그레이션 소스 검색 오류 (pyenv/conda/venvwrapper 없음 또는 손상됨)"
 
 #: src/api.md:707
 msgid "Per-command exit code table:"
-msgstr ""
+msgstr "명령어별 종료 코드 표:"
 
 #: src/api.md:711
 msgid "always (informational)"
-msgstr ""
+msgstr "항상 (정보성)"
 
 #: src/api.md:712
 msgid "`verify --strict`"
-msgstr ""
+msgstr "`verify --strict`"
 
 #: src/api.md:712 src/api.md:714
 msgid "clean"
-msgstr ""
+msgstr "정상"
 
 #: src/api.md:712
 msgid "any Fail check"
-msgstr ""
+msgstr "Fail 점검 발생 시"
 
 #: src/api.md:713
 msgid "`migrate @env` / `migrate all`"
-msgstr ""
+msgstr "`migrate @env` / `migrate all`"
 
 #: src/api.md:713
 msgid "failure / conflict"
-msgstr ""
+msgstr "실패 / 충돌"
 
 #: src/api.md:713
 msgid "source tool not found"
-msgstr ""
+msgstr "소스 도구 없음"
 
 #: src/api.md:714
 msgid "warning"
-msgstr ""
+msgstr "경고"
 
 #: src/api.md:715
 msgid "Other commands"
-msgstr ""
+msgstr "기타 명령어"
 
 #: src/api.md:715
 msgid "failure"
-msgstr ""
+msgstr "실패"
 
 #: src/api.md:717
 msgid "**Documentation requirements**:"
-msgstr ""
+msgstr "**문서화 요구사항**:"
 
 #: src/api.md:718
 msgid "All `pub fn` must have doc comments"
-msgstr ""
+msgstr "모든 `pub fn`에는 doc 주석이 있어야 합니다"
 
 #: src/api.md:719
 msgid "Examples in doctests where applicable"
-msgstr ""
+msgstr "해당하는 경우 doctest에 예시 포함"
 
 #: src/api.md:720
 msgid "Error conditions documented"
-msgstr ""
+msgstr "에러 조건 문서화"
 
 #: src/api.md:721
 msgid "Shell integration changes require cross-shell testing"
-msgstr ""
+msgstr "Shell 통합 변경 사항은 크로스-shell 테스트가 필요합니다"
 
 #: src/api.md:725
-msgid ""
-"**Last Updated:** 2026-06-02 **scoop Version:** Unreleased (post-0.12.0)"
-msgstr ""
+msgid "**Last Updated:** 2026-06-16 **scoop Version:** 0.14.1"
+msgstr "**최종 업데이트:** 2026-06-16 **scoop 버전:** 0.14.1"
 
 #: src/development/testing.md:3
 msgid "Comprehensive guide for testing scoop."
-msgstr ""
+msgstr "scoop 테스트를 위한 종합 가이드입니다."
 
 #: src/development/testing.md:5 src/development/code-quality.md:5
 msgid "Quick Reference"
-msgstr ""
+msgstr "빠른 참조"
 
 #: src/development/testing.md:8 src/development/testing.md:43
 msgid "# Run all tests\n"
-msgstr ""
+msgstr "# 모든 테스트 실행\n"
 
 #: src/development/testing.md:9
 msgid "# Run tests containing \"json\"\n"
-msgstr ""
+msgstr "# \"json\"이 포함된 테스트 실행\n"
 
 #: src/development/testing.md:10
 msgid "# Show println! output\n"
-msgstr ""
+msgstr "# println! 출력 표시\n"
 
 #: src/development/testing.md:11 src/development/code-quality.md:10
 msgid "# Lint check\n"
-msgstr ""
+msgstr "# 린트 검사\n"
 
 #: src/development/testing.md:14
 msgid "Test Structure"
-msgstr ""
+msgstr "테스트 구조"
 
 #: src/development/testing.md:38
 msgid "Running Tests"
-msgstr ""
+msgstr "테스트 실행"
 
 #: src/development/testing.md:40
 msgid "All Tests"
-msgstr ""
+msgstr "전체 테스트"
 
 #: src/development/testing.md:45
 msgid "# Run with all features enabled\n"
-msgstr ""
+msgstr "# 모든 기능을 활성화하여 실행\n"
 
 #: src/development/testing.md:48
 msgid "# Run in release mode (faster execution)\n"
-msgstr ""
+msgstr "# 릴리스 모드로 실행 (더 빠른 실행)\n"
 
 #: src/development/testing.md:53
 msgid "Filtered Tests"
-msgstr ""
+msgstr "필터링된 테스트"
 
 #: src/development/testing.md:56
 msgid "# By name pattern\n"
-msgstr ""
+msgstr "# 이름 패턴으로\n"
 
 #: src/development/testing.md:57
 msgid "# Tests containing \"json\"\n"
-msgstr ""
+msgstr "# \"json\"이 포함된 테스트\n"
 
 #: src/development/testing.md:58
 msgid "# Tests containing \"error\"\n"
-msgstr ""
+msgstr "# \"error\"가 포함된 테스트\n"
 
 #: src/development/testing.md:59
 msgid "# Tests containing \"virtualenv\"\n"
-msgstr ""
+msgstr "# \"virtualenv\"가 포함된 테스트\n"
 
 #: src/development/testing.md:60
 msgid "# By module path\n"
-msgstr ""
+msgstr "# 모듈 경로로\n"
 
 #: src/development/testing.md:62
 msgid "# Tests in output/json.rs\n"
-msgstr ""
+msgstr "# output/json.rs의 테스트\n"
 
 #: src/development/testing.md:63
 msgid "# Tests in error.rs\n"
-msgstr ""
+msgstr "# error.rs의 테스트\n"
 
 #: src/development/testing.md:64
 msgid "# Tests in core/version.rs\n"
-msgstr ""
+msgstr "# core/version.rs의 테스트\n"
 
 #: src/development/testing.md:65
 msgid "# Tests in cli/commands/\n"
-msgstr ""
+msgstr "# cli/commands/의 테스트\n"
 
 #: src/development/testing.md:66
 msgid "# Single test\n"
-msgstr ""
+msgstr "# 단일 테스트\n"
 
 #: src/development/testing.md:71
 msgid "Test Output"
-msgstr ""
+msgstr "테스트 출력"
 
 #: src/development/testing.md:74
 msgid "# Show stdout/stderr (println!, dbg!, etc.)\n"
-msgstr ""
+msgstr "# stdout/stderr 표시 (println!, dbg!, 등)\n"
 
 #: src/development/testing.md:76
 msgid "# Show test names as they run\n"
-msgstr ""
+msgstr "# 실행 중 테스트 이름 표시\n"
 
 #: src/development/testing.md:79
 msgid "# Only show failed tests\n"
-msgstr ""
+msgstr "# 실패한 테스트만 표시\n"
 
 #: src/development/testing.md:84
 msgid "Debugging"
-msgstr ""
+msgstr "디버깅"
 
 #: src/development/testing.md:87
 msgid "# Run single-threaded (easier to debug)\n"
-msgstr ""
+msgstr "# 단일 스레드로 실행 (디버깅이 쉬움)\n"
 
 #: src/development/testing.md:89
 msgid "# Run ignored tests\n"
-msgstr ""
+msgstr "# 무시된 테스트 실행\n"
 
 #: src/development/testing.md:92
 msgid "# Run specific test with output\n"
-msgstr ""
+msgstr "# 출력과 함께 특정 테스트 실행\n"
 
 #: src/development/testing.md:97
 msgid "Test Categories"
-msgstr ""
+msgstr "테스트 카테고리"
 
 #: src/development/testing.md:101
 msgid ""
-"The bulk of the suite (703 tests, ~92% of the total 769) lives within source "
-"files using `#[cfg(test)]`:"
+"The bulk of the suite (844 tests, ~92% of the total 913) lives within source"
+" files using `#[cfg(test)]`:"
 msgstr ""
+"테스트 스위트의 대부분(844개 테스트, 전체 913개의 약 92%)은 `#[cfg(test)]`를 사용하여 소스 파일 내에 위치합니다:"
 
 #: src/development/testing.md:115
 msgid "Key test modules:"
-msgstr ""
+msgstr "주요 테스트 모듈:"
 
 #: src/development/testing.md:117
 msgid "Tests"
-msgstr ""
+msgstr "테스트"
 
 #: src/development/testing.md:117 src/development/testing.md:336
 msgid "Coverage"
-msgstr ""
+msgstr "커버리지"
 
 #: src/development/testing.md:119
 msgid "`error::tests`"
-msgstr ""
+msgstr "`error::tests`"
 
 #: src/development/testing.md:119
 msgid "54"
-msgstr ""
+msgstr "54"
 
 #: src/development/testing.md:119
 msgid "Error types, codes, suggestions"
-msgstr ""
+msgstr "에러 타입, 코드, 제안"
 
 #: src/development/testing.md:120
 msgid "`output::json::tests`"
-msgstr ""
+msgstr "`output::json::tests`"
 
 #: src/development/testing.md:120
 msgid "35"
-msgstr ""
+msgstr "35"
 
 #: src/development/testing.md:120
 msgid "JSON serialization, edge cases"
-msgstr ""
+msgstr "JSON 직렬화, 엣지 케이스"
 
 #: src/development/testing.md:121
 msgid "`validate::tests`"
-msgstr ""
+msgstr "`validate::tests`"
 
 #: src/development/testing.md:121
 msgid "30"
-msgstr ""
+msgstr "30"
 
 #: src/development/testing.md:121
 msgid "Name/version validation"
-msgstr ""
+msgstr "이름/버전 유효성 검사"
 
 #: src/development/testing.md:122
 msgid "`core::version::tests`"
-msgstr ""
+msgstr "`core::version::tests`"
 
 #: src/development/testing.md:122
 msgid "18"
-msgstr ""
+msgstr "18"
 
 #: src/development/testing.md:122
 msgid "Version file resolution"
-msgstr ""
+msgstr "버전 파일 해석"
 
 #: src/development/testing.md:123
 msgid "`core::virtualenv::tests`"
-msgstr ""
+msgstr "`core::virtualenv::tests`"
 
 #: src/development/testing.md:123
 msgid "12"
-msgstr ""
+msgstr "12"
 
 #: src/development/testing.md:123
 msgid "Virtualenv service"
-msgstr ""
+msgstr "Virtualenv 서비스"
 
 #: src/development/testing.md:124
 msgid "`paths::tests`"
-msgstr ""
+msgstr "`paths::tests`"
 
 #: src/development/testing.md:124
 msgid "16"
-msgstr ""
+msgstr "16"
 
 #: src/development/testing.md:124
 msgid "Path utilities"
-msgstr ""
+msgstr "경로 유틸리티"
 
 #: src/development/testing.md:125
 msgid "`shell::*::tests`"
-msgstr ""
+msgstr "`shell::*::tests`"
 
 #: src/development/testing.md:125
 msgid "14"
-msgstr ""
+msgstr "14"
 
 #: src/development/testing.md:125
 msgid "Shell scripts (shellcheck)"
-msgstr ""
+msgstr "Shell 스크립트 (shellcheck)"
 
 #: src/development/testing.md:127
 msgid ""
-"Integration Tests (43 tests in `tests/cli.rs` + 2 in `tests/"
-"i18n_completeness.rs`)"
-msgstr ""
+"Integration Tests (43 tests in `tests/cli.rs` + 2 in "
+"`tests/i18n_completeness.rs`)"
+msgstr "통합 테스트 (43개: `tests/cli.rs` + 2개: `tests/i18n_completeness.rs`)"
 
 #: src/development/testing.md:129
 msgid "Located in `tests/cli.rs`:"
-msgstr ""
+msgstr "`tests/cli.rs`에 위치합니다:"
 
 #: src/development/testing.md:132
 msgid "# Run only integration tests\n"
-msgstr ""
+msgstr "# Run only integration tests\n"
 
 #: src/development/testing.md:136
 msgid "Categories:"
-msgstr ""
+msgstr "카테고리:"
 
 #: src/development/testing.md:138
 msgid "**Error cases** - Invalid inputs, missing arguments"
-msgstr ""
+msgstr "**에러 케이스** - 유효하지 않은 입력, 누락된 인수"
 
 #: src/development/testing.md:139
 msgid "**Output format** - Help, version, JSON output"
-msgstr ""
+msgstr "**출력 형식** - 도움말, 버전, JSON 출력"
 
 #: src/development/testing.md:140
 msgid "**Command behavior** - list, create, use, remove"
-msgstr ""
+msgstr "**커맨드 동작** - list, create, use, remove"
 
 #: src/development/testing.md:142
 msgid "Some tests are marked `#[ignore]` because they require `uv` installed:"
-msgstr ""
+msgstr "일부 테스트는 `uv`가 설치되어 있어야 하므로 `#[ignore]`로 표시됩니다:"
 
 #: src/development/testing.md:145
 msgid "# Run ignored tests (requires uv)\n"
-msgstr ""
+msgstr "# Run ignored tests (requires uv)\n"
 
 #: src/development/testing.md:149
-msgid "Doc Tests (21 tests)"
-msgstr ""
+msgid "Doc Tests (24 tests)"
+msgstr "Doc 테스트 (24개)"
 
 #: src/development/testing.md:151
 msgid "Examples in documentation comments:"
-msgstr ""
+msgstr "문서 주석에 포함된 예시:"
 
 #: src/development/testing.md:154
 msgid ""
@@ -10372,63 +10971,76 @@ msgid ""
 "/// assert!(!is_valid_env_name(\"123bad\"));\n"
 "/// ```\n"
 msgstr ""
+"/// Validates environment name.\n"
+"///\n"
+"/// # Examples\n"
+"///\n"
+"/// ```\n"
+"/// use scoop_uv::validate::is_valid_env_name;\n"
+"/// assert!(is_valid_env_name(\"myenv\"));\n"
+"/// assert!(!is_valid_env_name(\"123bad\"));\n"
+"/// ```\n"
 
 #: src/development/testing.md:167
 msgid "# Run only doc tests\n"
-msgstr ""
+msgstr "# Run only doc tests\n"
 
 #: src/development/testing.md:171
 msgid "Property Tests"
-msgstr ""
+msgstr "프로퍼티 테스트"
 
 #: src/development/testing.md:173
 msgid "Using `proptest` for randomized testing:"
-msgstr ""
+msgstr "`proptest`를 사용한 무작위 테스트:"
 
 #: src/development/testing.md:186
 msgid "Located in `src/validate.rs`."
-msgstr ""
+msgstr "`src/validate.rs`에 위치합니다."
 
 #: src/development/testing.md:188
 msgid "Parameterized Tests"
-msgstr ""
+msgstr "파라미터화 테스트"
 
 #: src/development/testing.md:190
 msgid ""
 "Using `rstest` `#[case]` tables for input/output matrices (e.g. version "
 "parsing, env-name validation) so each case reports independently:"
 msgstr ""
+"`rstest`의 `#[case]` 테이블로 입력/출력 매트릭스(예: 버전 파싱, 환경 이름 유효성 검사)를 정의하여 각 케이스가 "
+"독립적으로 보고됩니다:"
 
 #: src/development/testing.md:198
 msgid "\"123\""
-msgstr ""
+msgstr "\"123\""
 
 #: src/development/testing.md:199
 msgid "\"activate\""
-msgstr ""
+msgstr "\"activate\""
 
 #: src/development/testing.md:205
 msgid "Mutation Testing"
-msgstr ""
+msgstr "변이 테스트"
 
 #: src/development/testing.md:207
 msgid ""
 "`cargo-mutants` verifies the suite actually _catches_ bugs (not just that "
-"lines run). Config in `.cargo/mutants.toml`; CI runs it on changed lines per "
-"PR (`--in-diff`) and a full pass weekly."
+"lines run). Config in `.cargo/mutants.toml`; CI runs it on changed lines per"
+" PR (`--in-diff`) and a full pass weekly."
 msgstr ""
+"`cargo-mutants`는 테스트 스위트가 실제로 버그를 _잡아내는지_ 검증합니다(단순히 라인 실행 여부가 아닌). 설정은 "
+"`.cargo/mutants.toml`에 있으며, CI에서는 PR당 변경된 라인(`--in-diff`)과 매주 전체 검사를 실행합니다."
 
 #: src/development/testing.md:213
 msgid "# full (scoped via mutants.toml)\n"
-msgstr ""
+msgstr "# full (scoped via mutants.toml)\n"
 
 #: src/development/testing.md:214
 msgid "# changed lines\n"
-msgstr ""
+msgstr "# changed lines\n"
 
 #: src/development/testing.md:217
 msgid "Fuzz Testing"
-msgstr ""
+msgstr "퍼즈 테스트"
 
 #: src/development/testing.md:219
 msgid ""
@@ -10436,14 +11048,16 @@ msgid ""
 "isolated `fuzz/` workspace pinned to nightly, so it never affects the "
 "MSRV-1.85 build; CI runs the targets on a weekly schedule."
 msgstr ""
+"`cargo-fuzz` (libFuzzer)는 신뢰할 수 없는 입력 파서를 퍼징합니다. nightly에 고정된 격리된 `fuzz/` "
+"워크스페이스에 위치하여 MSRV-1.85 빌드에 영향을 주지 않으며, CI에서 매주 스케줄에 따라 실행됩니다."
 
 #: src/development/testing.md:228
 msgid "Writing Tests"
-msgstr ""
+msgstr "테스트 작성하기"
 
 #: src/development/testing.md:230
 msgid "Unit Test Template"
-msgstr ""
+msgstr "단위 테스트 템플릿"
 
 #: src/development/testing.md:237
 msgid ""
@@ -10451,132 +11065,137 @@ msgid ""
 "    // Test Group Name\n"
 "    // ========================================\n"
 msgstr ""
+"// ========================================\n"
+"    // Test Group Name\n"
+"    // ========================================\n"
 
 #: src/development/testing.md:243
 msgid "// Arrange\n"
-msgstr ""
+msgstr "// Arrange\n"
 
 #: src/development/testing.md:244
 msgid "\"test input\""
-msgstr ""
+msgstr "\"test input\""
 
 #: src/development/testing.md:246
 msgid "// Act\n"
-msgstr ""
+msgstr "// Act\n"
 
 #: src/development/testing.md:249
 msgid "// Assert\n"
-msgstr ""
+msgstr "// Assert\n"
 
 #: src/development/testing.md:261
 msgid "Integration Test Template"
-msgstr ""
+msgstr "통합 테스트 템플릿"
 
 #: src/development/testing.md:264
 msgid "// tests/cli.rs\n"
-msgstr ""
+msgstr "// tests/cli.rs\n"
 
 #: src/development/testing.md:275
 msgid "\"expected output\""
-msgstr ""
+msgstr "\"expected output\""
 
 #: src/development/testing.md:282
 msgid "\"use\""
-msgstr ""
+msgstr "\"use\""
 
 #: src/development/testing.md:282
 msgid "\"nonexistent\""
-msgstr ""
+msgstr "\"nonexistent\""
 
 #: src/development/testing.md:285
 msgid "\"not found\""
-msgstr ""
+msgstr "\"not found\""
 
 #: src/development/testing.md:289
 msgid "JSON Output Testing"
-msgstr ""
+msgstr "JSON 출력 테스트"
 
 #: src/development/testing.md:294 src/development/testing.md:299
 msgid "\"value\""
-msgstr ""
+msgstr "\"value\""
 
 #: src/development/testing.md:297
 msgid "// Check JSON structure\n"
-msgstr ""
+msgstr "// Check JSON structure\n"
 
 #: src/development/testing.md:299
 msgid "\"field\""
-msgstr ""
+msgstr "\"field\""
 
 #: src/development/testing.md:307
 msgid "// skip_serializing_if = \"Option::is_none\"\n"
-msgstr ""
+msgstr "// skip_serializing_if = \"Option::is_none\"\n"
 
 #: src/development/testing.md:308
 msgid "\"optional\""
-msgstr ""
+msgstr "\"optional\""
 
 #: src/development/testing.md:312
 msgid "Test Utilities"
-msgstr ""
+msgstr "테스트 유틸리티"
 
 #: src/development/testing.md:314
 msgid "Located in `src/test_utils.rs`:"
-msgstr ""
+msgstr "`src/test_utils.rs`에 위치합니다:"
 
 #: src/development/testing.md:322
 msgid ""
 "// SCOOP_HOME is set to temp_dir\n"
 "        // Cleanup happens automatically\n"
 msgstr ""
+"// SCOOP_HOME is set to temp_dir\n"
+"        // Cleanup happens automatically\n"
 
 #: src/development/testing.md:331
 msgid "// Virtual environment created at temp_dir/virtualenvs/myenv\n"
-msgstr ""
+msgstr "// Virtual environment created at temp_dir/virtualenvs/myenv\n"
 
 #: src/development/testing.md:338
 msgid "Using cargo-tarpaulin"
-msgstr ""
+msgstr "cargo-tarpaulin 사용"
 
 #: src/development/testing.md:341 src/development/testing.md:357
 msgid "# Install\n"
-msgstr ""
+msgstr "# Install\n"
 
 #: src/development/testing.md:343 src/development/testing.md:359
 msgid "# Run with HTML report\n"
-msgstr ""
+msgstr "# Run with HTML report\n"
 
 #: src/development/testing.md:346
 msgid "# Run with specific target\n"
-msgstr ""
+msgstr "# Run with specific target\n"
 
 #: src/development/testing.md:349 src/development/testing.md:362
 msgid "# View report\n"
-msgstr ""
+msgstr "# View report\n"
 
 #: src/development/testing.md:354
 msgid "Using cargo-llvm-cov"
-msgstr ""
+msgstr "cargo-llvm-cov 사용"
 
 #: src/development/testing.md:367
 msgid "CI/CD Testing"
-msgstr ""
+msgstr "CI/CD 테스트"
 
 #: src/development/testing.md:369
 msgid "Tests run automatically on:"
-msgstr ""
+msgstr "테스트는 다음 경우에 자동으로 실행됩니다:"
 
 #: src/development/testing.md:371
 msgid "Every push to any branch"
-msgstr ""
+msgstr "모든 브랜치의 모든 푸시"
 
 #: src/development/testing.md:372
 msgid "Every pull request"
-msgstr ""
+msgstr "모든 풀 리퀘스트"
 
 #: src/development/testing.md:374
 msgid "GitHub Actions workflow (`.github/workflows/ci.yml`):"
-msgstr ""
+msgstr "GitHub Actions 워크플로우 (`.github/workflows/ci.yml`):"
 
 #: src/development/testing.md:377 src/development/testing.md:380
 #: src/development/code-quality.md:159 src/development/code-quality.md:166
@@ -10584,91 +11203,91 @@ msgstr ""
 #: src/development/code-quality.md:229 src/development/code-quality.md:234
 #: src/development/code-quality.md:237 src/development/code-quality.md:240
 msgid "name"
-msgstr ""
+msgstr "name"
 
 #: src/development/testing.md:377
 msgid "Run tests"
-msgstr ""
+msgstr "Run tests"
 
 #: src/development/testing.md:378 src/development/code-quality.md:241
 msgid "cargo test --all-features"
-msgstr ""
+msgstr "cargo test --all-features"
 
 #: src/development/testing.md:380
 msgid "Run clippy"
-msgstr ""
+msgstr "Run clippy"
 
 #: src/development/testing.md:381
 msgid "cargo clippy --all-targets -- -D warnings"
-msgstr ""
+msgstr "cargo clippy --all-targets -- -D warnings"
 
 #: src/development/testing.md:386
 msgid "Test Hangs"
-msgstr ""
+msgstr "테스트 멈춤 문제"
 
 #: src/development/testing.md:389
 msgid "# Run single-threaded to identify hanging test\n"
-msgstr ""
+msgstr "# Run single-threaded to identify hanging test\n"
 
 #: src/development/testing.md:393
 msgid "Flaky Tests"
-msgstr ""
+msgstr "플래키 테스트"
 
 #: src/development/testing.md:396
 msgid "# Run specific test multiple times\n"
-msgstr ""
+msgstr "# Run specific test multiple times\n"
 
 #: src/development/testing.md:400
 msgid "Environment Issues"
-msgstr ""
+msgstr "환경 문제"
 
 #: src/development/testing.md:403
 msgid "# Clear test artifacts\n"
-msgstr ""
+msgstr "# Clear test artifacts\n"
 
 #: src/development/testing.md:405
 msgid "# Rebuild and test\n"
-msgstr ""
+msgstr "# Rebuild and test\n"
 
 #: src/development/testing.md:410
 msgid "Shell Tests Fail"
-msgstr ""
+msgstr "Shell 테스트 실패 시"
 
 #: src/development/testing.md:412
 msgid "ShellCheck must be installed for shell script tests:"
-msgstr ""
+msgstr "shell 스크립트 테스트를 위해 ShellCheck이 설치되어 있어야 합니다:"
 
 #: src/development/testing.md:422
 msgid "Best Practices"
-msgstr ""
+msgstr "모범 사례"
 
 #: src/development/testing.md:424
 msgid "**Test naming**: `test_<function>_<scenario>_<expected>`"
-msgstr ""
+msgstr "**테스트 이름 규칙**: `test_<function>_<scenario>_<expected>`"
 
 #: src/development/testing.md:425
 msgid "**Arrange-Act-Assert**: Clear test structure"
-msgstr ""
+msgstr "**Arrange-Act-Assert**: 명확한 테스트 구조"
 
 #: src/development/testing.md:426
 msgid "**One assertion per test**: When practical"
-msgstr ""
+msgstr "**테스트당 하나의 단언**: 실용적인 범위 내에서"
 
 #: src/development/testing.md:427
 msgid "**Test edge cases**: Empty, unicode, special chars, boundaries"
-msgstr ""
+msgstr "**엣지 케이스 테스트**: 빈 값, 유니코드, 특수 문자, 경계값"
 
 #: src/development/testing.md:428
 msgid "**No test interdependencies**: Each test should be isolated"
-msgstr ""
+msgstr "**테스트 간 독립성 유지**: 각 테스트는 독립적으로 실행되어야 합니다"
 
 #: src/development/testing.md:429
 msgid "**Fast tests**: Mock external dependencies"
-msgstr ""
+msgstr "**빠른 테스트**: 외부 의존성은 Mock으로 대체"
 
 #: src/development/testing.md:431
 msgid "Codespaces / Devcontainer"
-msgstr ""
+msgstr "Codespaces / Devcontainer"
 
 #: src/development/testing.md:433
 msgid ""
@@ -10678,54 +11297,58 @@ msgid ""
 "(\"Reopen in Container\") or create a Codespace — both follow the same "
 "lifecycle:"
 msgstr ""
+"`.devcontainer/devcontainer.json`은 `rust-toolchain.toml`에 고정된 로컬 툴체인과 일치하는 "
+"`mcr.microsoft.com/devcontainers/rust:1-bookworm` 기반 Rust 1.85 개발 환경을 시작합니다."
+" VS Code에서 리포지토리를 열면(\"Reopen in Container\") 또는 Codespace를 생성하면 동일한 라이프사이클을"
+" 따릅니다:"
 
 #: src/development/testing.md:439 src/development/code-quality.md:202
 msgid "Hook"
-msgstr ""
+msgstr "Hook"
 
 #: src/development/testing.md:439
 msgid "Runs"
-msgstr ""
+msgstr "실행 시점"
 
 #: src/development/testing.md:439
 msgid "Used for"
-msgstr ""
+msgstr "사용 목적"
 
 #: src/development/testing.md:441
 msgid "`onCreateCommand`"
-msgstr ""
+msgstr "`onCreateCommand`"
 
 #: src/development/testing.md:441
 msgid "once (in Codespace prebuild)"
-msgstr ""
+msgstr "한 번 (Codespace 프리빌드 시)"
 
 #: src/development/testing.md:441
 msgid "install nextest / llvm-cov / mutants / uv, warm `cargo build`"
-msgstr ""
+msgstr "nextest / llvm-cov / mutants / uv 설치, `cargo build` 워밍업"
 
 #: src/development/testing.md:442
 msgid "`updateContentCommand`"
-msgstr ""
+msgstr "`updateContentCommand`"
 
 #: src/development/testing.md:442
 msgid "on every prebuild refresh"
-msgstr ""
+msgstr "프리빌드 갱신 시마다"
 
 #: src/development/testing.md:442
 msgid "`cargo fetch` to keep registry warm"
-msgstr ""
+msgstr "레지스트리 캐시 유지를 위한 `cargo fetch`"
 
 #: src/development/testing.md:443
 msgid "`postCreateCommand`"
-msgstr ""
+msgstr "`postCreateCommand`"
 
 #: src/development/testing.md:443
 msgid "when user creates the Codespace"
-msgstr ""
+msgstr "사용자가 Codespace를 생성할 때"
 
 #: src/development/testing.md:443
 msgid "`prek install`"
-msgstr ""
+msgstr "`prek install`"
 
 #: src/development/testing.md:445
 msgid ""
@@ -10733,10 +11356,12 @@ msgid ""
 "project so two scoop-uv worktrees don't share caches. `target/` is NOT "
 "volumed — it's architecture-specific and warmed in the prebuild layer."
 msgstr ""
+"Cargo 레지스트리와 git 캐시는 프로젝트별 범위의 명명된 Docker 볼륨으로 유지되므로, 두 개의 scoop-uv 워크트리가 "
+"캐시를 공유하지 않습니다. `target/`은 볼륨화되지 않습니다 — 아키텍처에 따라 달라지며 프리빌드 레이어에서 워밍업됩니다."
 
 #: src/development/testing.md:449
 msgid "Enabling Codespace prebuilds"
-msgstr ""
+msgstr "Codespace 프리빌드 활성화"
 
 #: src/development/testing.md:451
 msgid ""
@@ -10745,10 +11370,14 @@ msgid ""
 "minutes low (only rebuilds when `.devcontainer/**` or `Dockerfile` changes) "
 "while still keeping the cargo registry warm via volume persistence."
 msgstr ""
+"리포지토리의 Settings → Codespaces → \"Set up prebuild\"에서 \"configuration "
+"change\" 트리거를 기준으로 `main` 브랜치에 대해 설정합니다. 이렇게 하면 Actions 사용 시간을 "
+"절약하고(`.devcontainer/**` 또는 `Dockerfile` 변경 시에만 재빌드), 볼륨 영속성을 통해 cargo 레지스트리를"
+" 항상 워밍업 상태로 유지합니다."
 
 #: src/development/testing.md:457
 msgid "Multi-source Integration (Docker matrix)"
-msgstr ""
+msgstr "멀티 소스 통합 (Docker 매트릭스)"
 
 #: src/development/testing.md:459
 msgid ""
@@ -10757,159 +11386,168 @@ msgid ""
 "carries only the source-tool it migrates from, so CI can matrix-build just "
 "one variant."
 msgstr ""
+"Dockerfile은 공유 `scoop-test-base` 위에 `pyenv-test`, `conda-test`, "
+"`venvwrapper-test` 세 가지 소스별 리프 스테이지를 빌드합니다. 각 스테이지는 마이그레이션하는 소스 도구만 포함하므로, "
+"CI에서 하나의 변형만 선택적으로 매트릭스 빌드할 수 있습니다."
 
 #: src/development/testing.md:465
 msgid "# Local (sequential)\n"
-msgstr ""
+msgstr "# Local (sequential)\n"
 
 #: src/development/testing.md:469
 msgid "# Local (all three sequentially)\n"
-msgstr ""
+msgstr "# Local (all three sequentially)\n"
 
 #: src/development/testing.md:472
 msgid "# Drop into a single variant for ad-hoc debugging\n"
-msgstr ""
+msgstr "# Drop into a single variant for ad-hoc debugging\n"
 
 #: src/development/testing.md:477
 msgid ""
-"CI runs all three in parallel via `.github/workflows/integration-test.yml`'s "
-"strategy.matrix with per-source BuildKit cache scoping (`cache-from/"
-"to=type=gha,scope=<src>`)."
+"CI runs all three in parallel via `.github/workflows/integration-test.yml`'s"
+" strategy.matrix with per-source BuildKit cache scoping (`cache-"
+"from/to=type=gha,scope=<src>`)."
 msgstr ""
+"CI는 `.github/workflows/integration-test.yml`의 strategy.matrix를 통해 세 가지를 모두 "
+"병렬로 실행하며, 소스별 BuildKit 캐시 범위(`cache-from/to=type=gha,scope=<src>`)를 사용합니다."
 
 #: src/development/testing.md:481
 msgid "Benchmarks (Criterion)"
-msgstr ""
+msgstr "벤치마크 (Criterion)"
 
 #: src/development/testing.md:483
 msgid "Three bench binaries live in `benches/`:"
-msgstr ""
+msgstr "`benches/`에 세 개의 벤치 바이너리가 있습니다:"
 
 #: src/development/testing.md:485
 msgid "Binary"
-msgstr ""
+msgstr "바이너리"
 
 #: src/development/testing.md:485
 msgid "Targets"
-msgstr ""
+msgstr "대상"
 
 #: src/development/testing.md:487
 msgid "`parsing`"
-msgstr ""
+msgstr "`parsing`"
 
 #: src/development/testing.md:487
 msgid "clap parse, TOML manifest, JSON `uv python list`"
-msgstr ""
+msgstr "clap 파싱, TOML 매니페스트, JSON `uv python list`"
 
 #: src/development/testing.md:488
 msgid "`validation`"
-msgstr ""
+msgstr "`validation`"
 
 #: src/development/testing.md:488
 msgid "`is_valid_env_name` across 6 representative inputs"
-msgstr ""
+msgstr "6가지 대표 입력에 대한 `is_valid_env_name`"
 
 #: src/development/testing.md:489
 msgid "`path_lookup`"
-msgstr ""
+msgstr "`path_lookup`"
 
 #: src/development/testing.md:489
 msgid "`find_executable_in` hit + miss"
-msgstr ""
+msgstr "`find_executable_in` 히트 + 미스"
 
 #: src/development/testing.md:491
 msgid "Local workflow"
-msgstr ""
+msgstr "로컬 워크플로우"
 
 #: src/development/testing.md:494
 msgid "# Run all benches once (no baseline diffing)\n"
-msgstr ""
+msgstr "# Run all benches once (no baseline diffing)\n"
 
 #: src/development/testing.md:496
 msgid "# Save current results as a named baseline (default: \"main\")\n"
-msgstr ""
+msgstr "# Save current results as a named baseline (default: \"main\")\n"
 
 #: src/development/testing.md:498
 msgid "# saves as \"main\"\n"
-msgstr ""
+msgstr "# saves as \"main\"\n"
 
 #: src/development/testing.md:499
 msgid "# saves as \"before-X\"\n"
-msgstr ""
+msgstr "# saves as \"before-X\"\n"
 
 #: src/development/testing.md:500
 msgid "# Compare current results against a saved baseline\n"
-msgstr ""
+msgstr "# Compare current results against a saved baseline\n"
 
 #: src/development/testing.md:502
 msgid "# vs \"main\"\n"
-msgstr ""
+msgstr "# vs \"main\"\n"
 
 #: src/development/testing.md:504
 msgid "# Run all benches inside Docker (reproducible)\n"
-msgstr ""
+msgstr "# Run all benches inside Docker (reproducible)\n"
 
 #: src/development/testing.md:509
 msgid ""
 "Criterion writes HTML reports to `target/criterion/report/index.html` for "
 "visual diffing."
 msgstr ""
+"Criterion은 HTML 보고서를 `target/criterion/report/index.html`에 작성하여 시각적 비교를 "
+"지원합니다."
 
 #: src/development/testing.md:512
 msgid "CI regression gate"
-msgstr ""
+msgstr "CI 회귀 게이트"
 
 #: src/development/testing.md:514
 msgid "`.github/workflows/bench.yml` runs every PR and push:"
-msgstr ""
+msgstr "`.github/workflows/bench.yml`은 모든 PR과 푸시에서 실행됩니다:"
 
 #: src/development/testing.md:516
 msgid ""
 "On `main`: results are pushed to the `gh-pages` branch as the new baseline."
-msgstr ""
+msgstr "`main`에서: 결과가 새 기준선으로 `gh-pages` 브랜치에 푸시됩니다."
 
 #: src/development/testing.md:518
 msgid "On PRs: results are compared against that baseline."
-msgstr ""
+msgstr "PR에서: 결과가 해당 기준선과 비교됩니다."
 
 #: src/development/testing.md:519
 msgid "**alert at 130%** — leaves a PR comment, doesn't block merge"
-msgstr ""
+msgstr "**130%에서 경고** — PR 코멘트를 남기며, 머지를 차단하지 않습니다"
 
 #: src/development/testing.md:520
 msgid "**fail at 150%** — fails the workflow, blocks merge"
-msgstr ""
+msgstr "**150%에서 실패** — 워크플로우를 실패시키며, 머지를 차단합니다"
 
 #: src/development/testing.md:522
 msgid ""
-"Thresholds account for GitHub-hosted runner variance (10-30% per-bench noise "
-"is normal on shared CPU). Tighten by running on a self-hosted runner with "
+"Thresholds account for GitHub-hosted runner variance (10-30% per-bench noise"
+" is normal on shared CPU). Tighten by running on a self-hosted runner with "
 "pinned hardware if needed."
 msgstr ""
+"임계값은 GitHub 호스팅 러너의 분산(공유 CPU에서 벤치당 10~30% 노이즈는 정상)을 고려한 것입니다. 더 엄격한 기준이 "
+"필요하다면 고정 하드웨어의 자체 호스팅 러너에서 실행하여 조정할 수 있습니다."
 
 #: src/development/code-quality.md:3
 msgid "Comprehensive guide for maintaining code quality in scoop."
-msgstr ""
+msgstr "scoop의 코드 품질 유지를 위한 종합 가이드입니다."
 
 #: src/development/code-quality.md:8
 msgid "# Format code\n"
-msgstr ""
+msgstr "# Format code\n"
 
 #: src/development/code-quality.md:13
 msgid "# All checks (pre-commit style)\n"
-msgstr ""
+msgstr "# All checks (pre-commit style)\n"
 
 #: src/development/code-quality.md:16
 msgid "# Pre-commit hooks\n"
-msgstr ""
+msgstr "# Pre-commit hooks\n"
 
 #: src/development/code-quality.md:21
 msgid "Formatting (rustfmt)"
-msgstr ""
+msgstr "포맷팅 (rustfmt)"
 
 #: src/development/code-quality.md:25
 msgid "Located in `rustfmt.toml`:"
-msgstr ""
+msgstr "`rustfmt.toml`에 위치합니다:"
 
 #: src/development/code-quality.md:27
 msgid ""
@@ -10921,540 +11559,547 @@ msgid ""
 "use_try_shorthand = true\n"
 "```"
 msgstr ""
+"```toml\n"
+"edition = \"2024\"\n"
+"max_width = 100\n"
+"tab_spaces = 4\n"
+"use_field_init_shorthand = true\n"
+"use_try_shorthand = true\n"
+"```"
 
 #: src/development/code-quality.md:38
 msgid "# Auto-format all files\n"
-msgstr ""
+msgstr "# Auto-format all files\n"
 
 #: src/development/code-quality.md:40
 msgid "# Check formatting (CI mode, no changes)\n"
-msgstr ""
+msgstr "# Check formatting (CI mode, no changes)\n"
 
 #: src/development/code-quality.md:43
 msgid "# Format specific file\n"
-msgstr ""
+msgstr "# Format specific file\n"
 
 #: src/development/code-quality.md:46
 msgid "# Show diff instead of applying\n"
-msgstr ""
+msgstr "# Show diff instead of applying\n"
 
 #: src/development/code-quality.md:53
 msgid "**VS Code** (rust-analyzer):"
-msgstr ""
+msgstr "**VS Code** (rust-analyzer):"
 
 #: src/development/code-quality.md:57
 msgid "\"[rust]\""
-msgstr ""
+msgstr "\"[rust]\""
 
 #: src/development/code-quality.md:58
 msgid "\"editor.formatOnSave\""
-msgstr ""
+msgstr "\"editor.formatOnSave\""
 
 #: src/development/code-quality.md:63
 msgid "**JetBrains (RustRover/CLion)**:"
-msgstr ""
+msgstr "**JetBrains (RustRover/CLion)**:"
 
 #: src/development/code-quality.md:65
 msgid "Settings → Languages → Rust → Rustfmt → Run on save"
-msgstr ""
+msgstr "Settings → Languages → Rust → Rustfmt → Run on save"
 
 #: src/development/code-quality.md:67
 msgid "Linting (Clippy)"
-msgstr ""
+msgstr "린팅 (Clippy)"
 
 #: src/development/code-quality.md:69
 msgid "Basic Usage"
-msgstr ""
+msgstr "기본 사용법"
 
 #: src/development/code-quality.md:72
 msgid "# Standard lint check\n"
-msgstr ""
+msgstr "# Standard lint check\n"
 
 #: src/development/code-quality.md:74
 msgid "# Treat warnings as errors (CI mode)\n"
-msgstr ""
+msgstr "# Treat warnings as errors (CI mode)\n"
 
 #: src/development/code-quality.md:77
 msgid "# All targets (including tests, examples)\n"
-msgstr ""
+msgstr "# All targets (including tests, examples)\n"
 
 #: src/development/code-quality.md:80
 msgid "# All features enabled\n"
-msgstr ""
+msgstr "# All features enabled\n"
 
 #: src/development/code-quality.md:83
 msgid "# Full CI check\n"
-msgstr ""
+msgstr "# Full CI check\n"
 
 #: src/development/code-quality.md:88
 msgid "Lint Categories"
-msgstr ""
+msgstr "Lint 카테고리"
 
 #: src/development/code-quality.md:91
 msgid "# Enable specific lint category\n"
-msgstr ""
+msgstr "# Enable specific lint category\n"
 
 #: src/development/code-quality.md:93
 msgid "# Deny specific lint\n"
-msgstr ""
+msgstr "# Deny specific lint\n"
 
 #: src/development/code-quality.md:96
 msgid "# Allow specific lint\n"
-msgstr ""
+msgstr "# Allow specific lint\n"
 
 #: src/development/code-quality.md:101
 msgid "Common Lints"
-msgstr ""
+msgstr "주요 Lint 목록"
 
 #: src/development/code-quality.md:103
 msgid "Lint"
-msgstr ""
+msgstr "Lint"
 
 #: src/development/code-quality.md:103
 msgid "Severity"
-msgstr ""
+msgstr "심각도"
 
 #: src/development/code-quality.md:105
 msgid "`clippy::unwrap_used`"
-msgstr ""
+msgstr "`clippy::unwrap_used`"
 
 #: src/development/code-quality.md:105
 msgid "Use `?` or `expect()` instead"
-msgstr ""
+msgstr "`?` 또는 `expect()`를 대신 사용"
 
 #: src/development/code-quality.md:106
 msgid "`clippy::panic`"
-msgstr ""
+msgstr "`clippy::panic`"
 
 #: src/development/code-quality.md:106
 msgid "Avoid panic in library code"
-msgstr ""
+msgstr "라이브러리 코드에서 panic 사용 금지"
 
 #: src/development/code-quality.md:107
 msgid "`clippy::todo`"
-msgstr ""
+msgstr "`clippy::todo`"
 
 #: src/development/code-quality.md:107
 msgid "Remove before release"
-msgstr ""
+msgstr "릴리스 전에 제거"
 
 #: src/development/code-quality.md:108
 msgid "`clippy::dbg_macro`"
-msgstr ""
+msgstr "`clippy::dbg_macro`"
 
 #: src/development/code-quality.md:108
 msgid "Remove debug macros"
-msgstr ""
+msgstr "디버그 매크로 제거"
 
 #: src/development/code-quality.md:109
 msgid "`clippy::print_stdout`"
-msgstr ""
+msgstr "`clippy::print_stdout`"
 
 #: src/development/code-quality.md:109
 msgid "Use logging instead"
-msgstr ""
+msgstr "로깅으로 대체"
 
 #: src/development/code-quality.md:111
 msgid "Fixing Lints"
-msgstr ""
+msgstr "Lint 수정"
 
 #: src/development/code-quality.md:114
 msgid "# Auto-fix where possible\n"
-msgstr ""
+msgstr "# Auto-fix where possible\n"
 
 #: src/development/code-quality.md:116
 msgid "# Allow fixes that change behavior\n"
-msgstr ""
+msgstr "# Allow fixes that change behavior\n"
 
 #: src/development/code-quality.md:121
 msgid "Suppressing Lints"
-msgstr ""
+msgstr "Lint 억제"
 
 #: src/development/code-quality.md:124
 msgid "// Single line\n"
-msgstr ""
+msgstr "// Single line\n"
 
 #: src/development/code-quality.md:127
 msgid "// Entire module\n"
-msgstr ""
+msgstr "// Entire module\n"
 
 #: src/development/code-quality.md:130
 msgid "// With explanation\n"
-msgstr ""
+msgstr "// With explanation\n"
 
 #: src/development/code-quality.md:132
 msgid "// Safe: validated in parse()\n"
-msgstr ""
+msgstr "// Safe: validated in parse()\n"
 
 #: src/development/code-quality.md:136
 msgid "Pre-commit Hooks (prek)"
-msgstr ""
+msgstr "Pre-commit Hook (prek)"
 
 #: src/development/code-quality.md:141
 msgid "# Install prek\n"
-msgstr ""
+msgstr "# Install prek\n"
 
 #: src/development/code-quality.md:142
 msgid "# or\n"
-msgstr ""
+msgstr "# or\n"
 
 #: src/development/code-quality.md:145
 msgid "# Install hooks in repository\n"
-msgstr ""
+msgstr "# Install hooks in repository\n"
 
 #: src/development/code-quality.md:152
 msgid "Located in `.pre-commit-config.yaml`:"
-msgstr ""
+msgstr "`.pre-commit-config.yaml`에 위치합니다:"
 
 #: src/development/code-quality.md:155
 msgid "repos"
-msgstr ""
+msgstr "repos"
 
 #: src/development/code-quality.md:156
 msgid "repo"
-msgstr ""
+msgstr "repo"
 
 #: src/development/code-quality.md:156
 msgid "local"
-msgstr ""
+msgstr "local"
 
 #: src/development/code-quality.md:157
 msgid "hooks"
-msgstr ""
+msgstr "hooks"
 
 #: src/development/code-quality.md:158 src/development/code-quality.md:165
 #: src/development/code-quality.md:172
 msgid "id"
-msgstr ""
+msgstr "id"
 
 #: src/development/code-quality.md:158
 msgid "cargo-fmt"
-msgstr ""
+msgstr "cargo-fmt"
 
 #: src/development/code-quality.md:159
 msgid "cargo fmt"
-msgstr ""
+msgstr "cargo fmt"
 
 #: src/development/code-quality.md:160 src/development/code-quality.md:167
 #: src/development/code-quality.md:174
 msgid "entry"
-msgstr ""
+msgstr "entry"
 
 #: src/development/code-quality.md:160
 msgid "cargo fmt --all --"
-msgstr ""
+msgstr "cargo fmt --all --"
 
 #: src/development/code-quality.md:161 src/development/code-quality.md:168
 #: src/development/code-quality.md:175
 msgid "language"
-msgstr ""
+msgstr "language"
 
 #: src/development/code-quality.md:161 src/development/code-quality.md:168
 #: src/development/code-quality.md:175
 msgid "system"
-msgstr ""
+msgstr "system"
 
 #: src/development/code-quality.md:162 src/development/code-quality.md:169
 #: src/development/code-quality.md:176
 msgid "types"
-msgstr ""
+msgstr "types"
 
 #: src/development/code-quality.md:162 src/development/code-quality.md:169
 #: src/development/code-quality.md:176
 msgid "rust"
-msgstr ""
+msgstr "rust"
 
 #: src/development/code-quality.md:163 src/development/code-quality.md:170
 #: src/development/code-quality.md:177
 msgid "pass_filenames"
-msgstr ""
+msgstr "pass_filenames"
 
 #: src/development/code-quality.md:165
 msgid "cargo-clippy"
-msgstr ""
+msgstr "cargo-clippy"
 
 #: src/development/code-quality.md:166
 msgid "cargo clippy"
-msgstr ""
+msgstr "cargo clippy"
 
 #: src/development/code-quality.md:167 src/development/code-quality.md:238
 msgid "cargo clippy --all-targets --all-features -- -D warnings"
-msgstr ""
+msgstr "cargo clippy --all-targets --all-features -- -D warnings"
 
 #: src/development/code-quality.md:172
 msgid "cargo-check"
-msgstr ""
+msgstr "cargo-check"
 
 #: src/development/code-quality.md:173
 msgid "cargo check"
-msgstr ""
+msgstr "cargo check"
 
 #: src/development/code-quality.md:174
 msgid "cargo check --all-targets"
-msgstr ""
+msgstr "cargo check --all-targets"
 
 #: src/development/code-quality.md:183
 msgid "# Run all hooks on staged files\n"
-msgstr ""
+msgstr "# Run all hooks on staged files\n"
 
 #: src/development/code-quality.md:185
 msgid "# Run all hooks on all files\n"
-msgstr ""
+msgstr "# Run all hooks on all files\n"
 
 #: src/development/code-quality.md:188
 msgid "# Run specific hook\n"
-msgstr ""
+msgstr "# Run specific hook\n"
 
 #: src/development/code-quality.md:192
 msgid "# Run multiple specific hooks\n"
-msgstr ""
+msgstr "# Run multiple specific hooks\n"
 
 #: src/development/code-quality.md:195
 msgid "# Skip hooks (emergency only!)\n"
-msgstr ""
+msgstr "# Skip hooks (emergency only!)\n"
 
 #: src/development/code-quality.md:200
 msgid "Available Hooks"
-msgstr ""
+msgstr "사용 가능한 Hook 목록"
 
 #: src/development/code-quality.md:202
 msgid "When"
-msgstr ""
+msgstr "시점"
 
 #: src/development/code-quality.md:204
 msgid "`cargo-fmt`"
-msgstr ""
+msgstr "`cargo-fmt`"
 
 #: src/development/code-quality.md:204
 msgid "Code formatting"
-msgstr ""
+msgstr "코드 포맷팅"
 
 #: src/development/code-quality.md:204 src/development/code-quality.md:205
 #: src/development/code-quality.md:206 src/development/code-quality.md:207
 #: src/development/code-quality.md:208 src/development/code-quality.md:209
 #: src/development/code-quality.md:210
 msgid "Pre-commit"
-msgstr ""
+msgstr "Pre-commit"
 
 #: src/development/code-quality.md:205
 msgid "`cargo-clippy`"
-msgstr ""
+msgstr "`cargo-clippy`"
 
 #: src/development/code-quality.md:205
 msgid "Linting"
-msgstr ""
+msgstr "린팅"
 
 #: src/development/code-quality.md:206
 msgid "`cargo-check`"
-msgstr ""
+msgstr "`cargo-check`"
 
 #: src/development/code-quality.md:206
 msgid "Type checking"
-msgstr ""
+msgstr "타입 검사"
 
 #: src/development/code-quality.md:207
 msgid "`trailing-whitespace`"
-msgstr ""
+msgstr "`trailing-whitespace`"
 
 #: src/development/code-quality.md:207
 msgid "Remove trailing spaces"
-msgstr ""
+msgstr "후행 공백 제거"
 
 #: src/development/code-quality.md:208
 msgid "`end-of-file-fixer`"
-msgstr ""
+msgstr "`end-of-file-fixer`"
 
 #: src/development/code-quality.md:208
 msgid "Ensure newline at EOF"
-msgstr ""
+msgstr "파일 끝에 줄바꿈 보장"
 
 #: src/development/code-quality.md:209
 msgid "`check-toml`"
-msgstr ""
+msgstr "`check-toml`"
 
 #: src/development/code-quality.md:209
 msgid "Validate TOML files"
-msgstr ""
+msgstr "TOML 파일 유효성 검사"
 
 #: src/development/code-quality.md:210
 msgid "`check-yaml`"
-msgstr ""
+msgstr "`check-yaml`"
 
 #: src/development/code-quality.md:210
 msgid "Validate YAML files"
-msgstr ""
+msgstr "YAML 파일 유효성 검사"
 
 #: src/development/code-quality.md:212
 msgid "CI Pipeline"
-msgstr ""
+msgstr "CI 파이프라인"
 
 #: src/development/code-quality.md:214
 msgid "GitHub Actions"
-msgstr ""
+msgstr "GitHub Actions"
 
 #: src/development/code-quality.md:216
 msgid "Located in `.github/workflows/ci.yml`:"
-msgstr ""
+msgstr "`.github/workflows/ci.yml`에 위치합니다:"
 
 #: src/development/code-quality.md:219
 msgid "CI"
-msgstr ""
+msgstr "CI"
 
 #: src/development/code-quality.md:221
 msgid "push"
-msgstr ""
+msgstr "push"
 
 #: src/development/code-quality.md:221
 msgid "pull_request"
-msgstr ""
+msgstr "pull_request"
 
 #: src/development/code-quality.md:222
 msgid "jobs"
-msgstr ""
+msgstr "jobs"
 
 #: src/development/code-quality.md:224
 msgid "check"
-msgstr ""
+msgstr "check"
 
 #: src/development/code-quality.md:225
 msgid "runs-on"
-msgstr ""
+msgstr "runs-on"
 
 #: src/development/code-quality.md:225
 msgid "ubuntu-latest"
-msgstr ""
+msgstr "ubuntu-latest"
 
 #: src/development/code-quality.md:226
 msgid "steps"
-msgstr ""
+msgstr "steps"
 
 #: src/development/code-quality.md:227 src/development/code-quality.md:230
 msgid "uses"
-msgstr ""
+msgstr "uses"
 
 #: src/development/code-quality.md:227
 msgid "actions/checkout@v4"
-msgstr ""
+msgstr "actions/checkout@v4"
 
 #: src/development/code-quality.md:229
 msgid "Install Rust"
-msgstr ""
+msgstr "Install Rust"
 
 #: src/development/code-quality.md:230
 msgid "dtolnay/rust-action@stable"
-msgstr ""
+msgstr "dtolnay/rust-action@stable"
 
 #: src/development/code-quality.md:231
 msgid "with"
-msgstr ""
+msgstr "with"
 
 #: src/development/code-quality.md:232
 msgid "components"
-msgstr ""
+msgstr "components"
 
 #: src/development/code-quality.md:232
 msgid "rustfmt, clippy"
-msgstr ""
+msgstr "rustfmt, clippy"
 
 #: src/development/code-quality.md:234
 msgid "Format check"
-msgstr ""
+msgstr "Format check"
 
 #: src/development/code-quality.md:235
 msgid "cargo fmt --all -- --check"
-msgstr ""
+msgstr "cargo fmt --all -- --check"
 
 #: src/development/code-quality.md:237
 msgid "Clippy"
-msgstr ""
+msgstr "Clippy"
 
 #: src/development/code-quality.md:240
 msgid "Test"
-msgstr ""
+msgstr "Test"
 
 #: src/development/code-quality.md:244
 msgid "Local CI Simulation"
-msgstr ""
+msgstr "로컬 CI 시뮬레이션"
 
 #: src/development/code-quality.md:247
 msgid "# Run exactly what CI runs\n"
-msgstr ""
+msgstr "# Run exactly what CI runs\n"
 
 #: src/development/code-quality.md:253
 msgid "Code Style Guidelines"
-msgstr ""
+msgstr "코드 스타일 가이드라인"
 
 #: src/development/code-quality.md:255
 msgid "Naming Conventions"
-msgstr ""
+msgstr "네이밍 컨벤션"
 
 #: src/development/code-quality.md:257
 msgid "Item"
-msgstr ""
+msgstr "항목"
 
 #: src/development/code-quality.md:257
 msgid "Convention"
-msgstr ""
+msgstr "컨벤션"
 
 #: src/development/code-quality.md:257 src/examples.md:5
 msgid "Example"
-msgstr ""
+msgstr "예시"
 
 #: src/development/code-quality.md:259
 msgid "Modules"
-msgstr ""
+msgstr "모듈"
 
 #: src/development/code-quality.md:259 src/development/code-quality.md:260
 msgid "`snake_case`"
-msgstr ""
+msgstr "`snake_case`"
 
 #: src/development/code-quality.md:259
 msgid "`version_file`"
-msgstr ""
+msgstr "`version_file`"
 
 #: src/development/code-quality.md:260
 msgid "Functions"
-msgstr ""
+msgstr "함수"
 
 #: src/development/code-quality.md:260
 msgid "`get_version()`"
-msgstr ""
+msgstr "`get_version()`"
 
 #: src/development/code-quality.md:261
 msgid "Types"
-msgstr ""
+msgstr "타입"
 
 #: src/development/code-quality.md:261
 msgid "`PascalCase`"
-msgstr ""
+msgstr "`PascalCase`"
 
 #: src/development/code-quality.md:262
 msgid "Constants"
-msgstr ""
+msgstr "상수"
 
 #: src/development/code-quality.md:262
 msgid "`SCREAMING_SNAKE`"
-msgstr ""
+msgstr "`SCREAMING_SNAKE`"
 
 #: src/development/code-quality.md:262
 msgid "`MAX_NAME_LENGTH`"
-msgstr ""
+msgstr "`MAX_NAME_LENGTH`"
 
 #: src/development/code-quality.md:263
 msgid "Lifetimes"
-msgstr ""
+msgstr "라이프타임"
 
 #: src/development/code-quality.md:263
 msgid "short lowercase"
-msgstr ""
+msgstr "짧은 소문자"
 
 #: src/development/code-quality.md:263
 msgid "`'a`, `'src`"
-msgstr ""
+msgstr "`'a`, `'src`"
 
 #: src/development/code-quality.md:265
 msgid "Documentation"
-msgstr ""
+msgstr "문서화"
 
 #: src/development/code-quality.md:268
 msgid ""
@@ -11482,74 +12127,97 @@ msgid ""
 "/// # }\n"
 "/// ```\n"
 msgstr ""
+"/// Creates a new virtual environment.\n"
+"///\n"
+"/// # Arguments\n"
+"///\n"
+"/// * `name` - Environment name (must be valid)\n"
+"/// * `python` - Python version (e.g., \"3.12\")\n"
+"///\n"
+"/// # Returns\n"
+"///\n"
+"/// Path to the created environment.\n"
+"///\n"
+"/// # Errors\n"
+"///\n"
+"/// Returns [`ScoopError::InvalidEnvName`] if name is invalid.\n"
+"///\n"
+"/// # Examples\n"
+"///\n"
+"/// ```\n"
+"/// # fn main() -> Result<(), Box<dyn std::error::Error>> {\n"
+"/// let path = create_env(\"myenv\", \"3.12\")?;\n"
+"/// # Ok(())\n"
+"/// # }\n"
+"/// ```\n"
 
 #: src/development/code-quality.md:299
 msgid "// Good: Use ? operator\n"
-msgstr ""
+msgstr "// Good: Use ? operator\n"
 
 #: src/development/code-quality.md:305
 msgid "// Good: Contextual errors\n"
-msgstr ""
+msgstr "// Good: Contextual errors\n"
 
 #: src/development/code-quality.md:312
 msgid "// Avoid: unwrap() in library code\n"
-msgstr ""
+msgstr "// Avoid: unwrap() in library code\n"
 
 #: src/development/code-quality.md:315
 msgid "// Bad\n"
-msgstr ""
+msgstr "// Bad\n"
 
 #: src/development/code-quality.md:317
 msgid "// OK: expect() with explanation\n"
-msgstr ""
+msgstr "// OK: expect() with explanation\n"
 
 #: src/development/code-quality.md:321
 msgid "\"home directory must exist\""
-msgstr ""
+msgstr "\"home directory must exist\""
 
 #: src/development/code-quality.md:325
 msgid "Import Organization"
-msgstr ""
+msgstr "import 정리"
 
 #: src/development/code-quality.md:328
 msgid "// 1. Standard library\n"
-msgstr ""
+msgstr "// 1. Standard library\n"
 
 #: src/development/code-quality.md:331
 msgid "// 2. External crates\n"
-msgstr ""
+msgstr "// 2. External crates\n"
 
 #: src/development/code-quality.md:336
 msgid "// 3. Local modules\n"
-msgstr ""
+msgstr "// 3. Local modules\n"
 
 #: src/development/code-quality.md:344
 msgid "Dependency Auditing"
-msgstr ""
+msgstr "의존성 감사"
 
 #: src/development/code-quality.md:347
 msgid "# Install cargo-audit\n"
-msgstr ""
+msgstr "# Install cargo-audit\n"
 
 #: src/development/code-quality.md:349
 msgid "# Run audit\n"
-msgstr ""
+msgstr "# Run audit\n"
 
 #: src/development/code-quality.md:352
 msgid "# Fix vulnerabilities\n"
-msgstr ""
+msgstr "# Fix vulnerabilities\n"
 
 #: src/development/code-quality.md:357
 msgid "MSRV (Minimum Supported Rust Version)"
-msgstr ""
+msgstr "MSRV (최소 지원 Rust 버전)"
 
 #: src/development/code-quality.md:359
 msgid "Current MSRV: **1.85**"
-msgstr ""
+msgstr "현재 MSRV: **1.85**"
 
 #: src/development/code-quality.md:360
 msgid "Defined in `Cargo.toml`:"
-msgstr ""
+msgstr "`Cargo.toml`에 정의합니다:"
 
 #: src/development/code-quality.md:361
 msgid ""
@@ -11558,682 +12226,747 @@ msgid ""
 "rust-version = \"1.85\"\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"rust-version = \"1.85\"\n"
+"```"
 
 #: src/development/code-quality.md:366
 msgid "Unsafe Code"
-msgstr ""
+msgstr "Unsafe 코드"
 
 #: src/development/code-quality.md:368
 msgid "Avoid `unsafe` unless absolutely necessary"
-msgstr ""
+msgstr "꼭 필요한 경우가 아니면 `unsafe` 사용 금지"
 
 #: src/development/code-quality.md:369
 msgid "Document safety invariants"
-msgstr ""
+msgstr "안전성 불변식을 문서화"
 
 #: src/development/code-quality.md:370
 msgid "Use `#![forbid(unsafe_code)]` in library crates"
-msgstr ""
+msgstr "라이브러리 크레이트에서 `#![forbid(unsafe_code)]` 사용"
 
 #: src/development/code-quality.md:374
 msgid "Profiling"
-msgstr ""
+msgstr "프로파일링"
 
 #: src/development/code-quality.md:377
 msgid "# Build with debug info for release\n"
-msgstr ""
+msgstr "# Build with debug info for release\n"
 
 #: src/development/code-quality.md:379
 msgid "# Use flamegraph\n"
-msgstr ""
+msgstr "# Use flamegraph\n"
 
 #: src/development/code-quality.md:385
 msgid "Benchmarks"
-msgstr ""
+msgstr "벤치마크"
 
 #: src/development/code-quality.md:388
 msgid "# Run benchmarks (if defined)\n"
-msgstr ""
+msgstr "# Run benchmarks (if defined)\n"
 
 #: src/development/code-quality.md:390
 msgid "# Using criterion\n"
-msgstr ""
+msgstr "# Using criterion\n"
 
 #: src/development/code-quality.md:395
 msgid "Continuous Improvement"
-msgstr ""
+msgstr "지속적 개선"
 
 #: src/development/code-quality.md:397
 msgid "Regular Checks"
-msgstr ""
+msgstr "정기 점검"
 
 #: src/development/code-quality.md:400
 msgid "# Weekly dependency update check\n"
-msgstr ""
+msgstr "# Weekly dependency update check\n"
 
 #: src/development/code-quality.md:402
 msgid "# Security audit\n"
-msgstr ""
+msgstr "# Security audit\n"
 
 #: src/development/code-quality.md:405
 msgid "# MSRV check\n"
-msgstr ""
+msgstr "# MSRV check\n"
 
 #: src/development/code-quality.md:410
 msgid "Upgrade Dependencies"
-msgstr ""
+msgstr "의존성 업그레이드"
 
 #: src/development/code-quality.md:413
 msgid "# Update Cargo.lock\n"
-msgstr ""
+msgstr "# Update Cargo.lock\n"
 
 #: src/development/code-quality.md:415
 msgid "# Upgrade to latest compatible versions\n"
-msgstr ""
+msgstr "# Upgrade to latest compatible versions\n"
 
 #: src/development/code-quality.md:417
 msgid "# requires cargo-edit\n"
-msgstr ""
+msgstr "# requires cargo-edit\n"
 
 #: src/development/code-quality.md:422
 msgid "Clippy False Positives"
-msgstr ""
+msgstr "Clippy 거짓 양성"
 
 #: src/development/code-quality.md:425
 msgid "// Silence with explanation\n"
-msgstr ""
+msgstr "// Silence with explanation\n"
 
 #: src/development/code-quality.md:428
 msgid "// Intentional for readability\n"
-msgstr ""
+msgstr "// Intentional for readability\n"
 
 #: src/development/code-quality.md:432
 msgid "Format Conflicts"
-msgstr ""
+msgstr "포맷 충돌"
 
 #: src/development/code-quality.md:435
 msgid "// Skip formatting for specific block\n"
-msgstr ""
+msgstr "// Skip formatting for specific block\n"
 
 #: src/development/code-quality.md:444
 msgid "CI vs Local Differences"
-msgstr ""
+msgstr "CI와 로컬 환경의 차이"
 
 #: src/development/code-quality.md:447
 msgid "# Ensure same toolchain as CI\n"
-msgstr ""
+msgstr "# Ensure same toolchain as CI\n"
 
 #: src/development/code-quality.md:450
 msgid "# Check Rust version\n"
-msgstr ""
+msgstr "# Check Rust version\n"
 
 #: src/development/code-quality.md:455
 msgid "Summary Checklist"
-msgstr ""
+msgstr "요약 체크리스트"
 
 #: src/development/code-quality.md:457
 msgid "Before committing:"
-msgstr ""
+msgstr "커밋하기 전:"
 
 #: src/development/code-quality.md:459
 msgid "`cargo fmt` - Code formatted"
-msgstr ""
+msgstr "`cargo fmt` - 코드 포맷팅 완료"
 
 #: src/development/code-quality.md:460
 msgid "`cargo clippy -- -D warnings` - No lint warnings"
-msgstr ""
+msgstr "`cargo clippy -- -D warnings` - 린트 경고 없음"
 
 #: src/development/code-quality.md:461
 msgid "`cargo test` - All tests pass"
-msgstr ""
+msgstr "`cargo test` - 모든 테스트 통과"
 
 #: src/development/code-quality.md:462
 msgid "`cargo doc` - Documentation builds"
-msgstr ""
+msgstr "`cargo doc` - 문서 빌드 성공"
 
 #: src/development/code-quality.md:463
 msgid "No `todo!()` or `dbg!()` left in code"
-msgstr ""
+msgstr "코드에 `todo!()`나 `dbg!()`가 남아 있지 않음"
 
 #: src/development/code-quality.md:464
 msgid "Public APIs documented"
-msgstr ""
+msgstr "공개 API 문서화 완료"
 
 #: src/development/code-quality.md:465
 msgid "Error messages are helpful"
-msgstr ""
+msgstr "오류 메시지가 유용함"
 
 #: src/llms.md:3
 msgid ""
 "This page provides a concise reference for AI/LLM tools working with scoop."
-msgstr ""
+msgstr "이 페이지는 scoop을 사용하는 AI/LLM 도구를 위한 간결한 참조 자료를 제공합니다."
 
 #: src/llms.md:5
 msgid ""
-"**Tip**: The raw text versions are available at [`llms.txt`](https://"
-"github.com/ai-screams/scoop-uv/blob/main/llms.txt) (concise) and [`llms-"
-"full.txt`](https://github.com/ai-screams/scoop-uv/blob/main/llms-full.txt) "
-"(full API reference)."
+"**Tip**: The raw text versions are available at "
+"[`llms.txt`](https://github.com/ai-screams/scoop-uv/blob/main/llms.txt) "
+"(concise) and [`llms-full.txt`](https://github.com/ai-screams/scoop-"
+"uv/blob/main/llms-full.txt) (full API reference)."
 msgstr ""
+"**팁**: 원시 텍스트 버전은 [`llms.txt`](https://github.com/ai-screams/scoop-"
+"uv/blob/main/llms.txt) (간결 버전)와 [`llms-full.txt`](https://github.com/ai-"
+"screams/scoop-uv/blob/main/llms-full.txt) (전체 API 레퍼런스)에서 확인할 수 있습니다."
 
 #: src/llms.md:13
 msgid ""
 "**scoop** is a centralized Python virtual environment manager — pyenv-style "
 "workflow powered by uv. Written in Rust."
 msgstr ""
+"**scoop**은 중앙 집중식 Python 가상 환경 관리자로, uv를 기반으로 pyenv 스타일의 워크플로우를 제공합니다. Rust로"
+" 작성되었습니다."
 
 #: src/llms.md:15
 msgid ""
 "All virtualenvs are stored in `~/.scoop/virtualenvs/`. Override with "
 "`SCOOP_HOME` env var."
 msgstr ""
+"모든 virtualenv는 `~/.scoop/virtualenvs/`에 저장됩니다. `SCOOP_HOME` 환경 변수로 경로를 재정의할 "
+"수 있습니다."
 
 #: src/llms.md:21
 msgid "List virtualenvs (aliases: `ls`)"
-msgstr ""
+msgstr "virtualenv 목록 표시 (별칭: `ls`)"
 
 #: src/llms.md:22
 msgid "List installed Python versions"
-msgstr ""
+msgstr "설치된 Python 버전 목록 표시"
 
 #: src/llms.md:23
 msgid "`scoop list --sort <name\\|created\\|last-used>`"
-msgstr ""
+msgstr "`scoop list --sort <name\\|created\\|last-used>`"
 
 #: src/llms.md:23
 msgid ""
 "Sort order; envs missing the timestamp sort last with name tie-break "
-"(Unreleased)"
-msgstr ""
+"(0.13.0)"
+msgstr "정렬 순서; 타임스탬프가 없는 환경은 마지막에 표시되며 이름 기준으로 순서가 결정됩니다 (0.13.0)"
 
 #: src/llms.md:24
 msgid "`scoop create <name> [version]`"
-msgstr ""
+msgstr "`scoop create <name> [version]`"
 
 #: src/llms.md:24
 msgid "Create virtualenv (default: latest Python)"
-msgstr ""
+msgstr "virtualenv 생성 (기본값: 최신 Python)"
 
 #: src/llms.md:25
 msgid "`scoop create <name> <ver> --install-python`"
-msgstr ""
+msgstr "`scoop create <name> <ver> --install-python`"
 
 #: src/llms.md:25
 msgid "Create env; install Python on demand if missing (v0.11.0)"
-msgstr ""
+msgstr "환경 생성; Python이 없으면 필요 시 자동 설치 (v0.11.0)"
 
 #: src/llms.md:26
 msgid "`scoop use <name>`"
-msgstr ""
+msgstr "`scoop use <name>`"
 
 #: src/llms.md:27
 msgid "`scoop use <name> --global`"
-msgstr ""
+msgstr "`scoop use <name> --global`"
 
 #: src/llms.md:28
 msgid "`scoop use <name> --link`"
-msgstr ""
+msgstr "`scoop use <name> --link`"
 
 #: src/llms.md:28
 msgid "Also create `.venv` symlink for IDE"
-msgstr ""
+msgstr "IDE를 위한 `.venv` 심볼릭 링크도 함께 생성"
 
 #: src/llms.md:29
 msgid "`scoop use system`"
-msgstr ""
+msgstr "`scoop use system`"
 
 #: src/llms.md:29
 msgid "Deactivate, use system Python"
-msgstr ""
+msgstr "비활성화 후 시스템 Python 사용"
 
 #: src/llms.md:30
 msgid "`scoop use --unset`"
-msgstr ""
+msgstr "`scoop use --unset`"
 
 #: src/llms.md:30
 msgid "Remove version file"
-msgstr ""
+msgstr "버전 파일 제거"
 
 #: src/llms.md:31
 msgid "`scoop remove <name>`"
-msgstr ""
+msgstr "`scoop remove <name>`"
 
 #: src/llms.md:31
 msgid "Delete virtualenv (aliases: `rm`, `delete`)"
-msgstr ""
+msgstr "virtualenv 삭제 (별칭: `rm`, `delete`)"
 
 #: src/llms.md:32
 msgid "`scoop clone <src> <dst>`"
-msgstr ""
+msgstr "`scoop clone <src> <dst>`"
 
 #: src/llms.md:32
 msgid "Duplicate an env in-place (`--no-packages` for skeleton) (v0.11.0)"
-msgstr ""
+msgstr "환경을 그대로 복제 (`--no-packages`로 패키지 없이 스켈레톤만 복제 가능) (v0.11.0)"
 
 #: src/llms.md:33
 msgid "`scoop install [version]`"
-msgstr ""
+msgstr "`scoop install [version]`"
 
 #: src/llms.md:34
 msgid "`scoop uninstall <version>`"
-msgstr ""
+msgstr "`scoop uninstall <version>`"
 
 #: src/llms.md:34
 msgid "Remove Python version"
-msgstr ""
+msgstr "Python 버전 제거"
 
 #: src/llms.md:35
 msgid "`scoop info <name>`"
-msgstr ""
+msgstr "`scoop info <name>`"
 
 #: src/llms.md:35
-msgid "Show virtualenv details (includes `Last used:` row since Unreleased)"
-msgstr ""
+msgid "Show virtualenv details (includes `Last used:` row since 0.13.0)"
+msgstr "virtualenv 상세 정보 표시 (0.13.0부터 `Last used:` 항목 포함)"
 
 #: src/llms.md:36
 msgid "`scoop status`"
-msgstr ""
+msgstr "`scoop status`"
 
 #: src/llms.md:36
 msgid ""
 "Summarise current state (Active/Configured/System/None) (v0.11.0); includes "
-"`Last used:` since Unreleased"
+"`Last used:` since 0.13.0"
 msgstr ""
+"현재 상태 요약 (Active/Configured/System/None) (v0.11.0); 0.13.0부터 `Last used:` 포함"
 
 #: src/llms.md:37
 msgid "`scoop which <exe>`"
-msgstr ""
+msgstr "`scoop which <exe>`"
 
 #: src/llms.md:37
 msgid "Resolve an executable inside the active env (v0.11.0)"
-msgstr ""
+msgstr "활성 환경 내 실행 파일 경로 확인 (v0.11.0)"
 
 #: src/llms.md:38
 msgid "`scoop run <env> -- <cmd>`"
-msgstr ""
+msgstr "`scoop run <env> -- <cmd>`"
 
 #: src/llms.md:38
 msgid "Run a command inside an env without activating (v0.11.0)"
-msgstr ""
+msgstr "환경을 활성화하지 않고 내부에서 명령 실행 (v0.11.0)"
 
 #: src/llms.md:39
 msgid "`scoop sync`"
-msgstr ""
+msgstr "`scoop sync`"
 
 #: src/llms.md:39
 msgid "Reconcile the active env with `.scoop.toml` manifest (v0.11.0)"
-msgstr ""
+msgstr "활성 환경을 `.scoop.toml` 매니페스트와 동기화 (v0.11.0)"
 
 #: src/llms.md:40
 msgid "`scoop export <name>`"
-msgstr ""
+msgstr "`scoop export <name>`"
 
 #: src/llms.md:40
 msgid "Snapshot an env as JSON (schema v1) (v0.11.0)"
-msgstr ""
+msgstr "환경을 JSON 스냅샷으로 내보내기 (스키마 v1) (v0.11.0)"
 
 #: src/llms.md:41
 msgid "`scoop import <file>`"
-msgstr ""
+msgstr "`scoop import <file>`"
 
 #: src/llms.md:41
 msgid "Restore an env from a JSON snapshot (v0.11.0)"
-msgstr ""
+msgstr "JSON 스냅샷으로부터 환경 복원 (v0.11.0)"
 
 #: src/llms.md:42
 msgid "Health check"
-msgstr ""
+msgstr "상태 점검"
 
 #: src/llms.md:43
 msgid "`scoop doctor --fix`"
-msgstr ""
+msgstr "`scoop doctor --fix`"
 
 #: src/llms.md:43
 msgid "Auto-fix issues"
-msgstr ""
+msgstr "문제 자동 수정"
 
 #: src/llms.md:44
 msgid "`scoop shell <name>`"
-msgstr ""
+msgstr "`scoop shell <name>`"
 
 #: src/llms.md:45
 msgid "`scoop shell --unset`"
-msgstr ""
+msgstr "`scoop shell --unset`"
 
 #: src/llms.md:45
 msgid "Clear shell-specific setting"
-msgstr ""
+msgstr "shell 전용 설정 초기화"
 
 #: src/llms.md:46
 msgid "`scoop init <shell>`"
-msgstr ""
+msgstr "`scoop init <shell>`"
 
 #: src/llms.md:46
 msgid "Output shell init script"
-msgstr ""
+msgstr "shell 초기화 스크립트 출력"
 
 #: src/llms.md:47
 msgid "`scoop completions <shell>`"
-msgstr ""
+msgstr "`scoop completions <shell>`"
 
 #: src/llms.md:47
 msgid "Generate completion script"
-msgstr ""
+msgstr "자동 완성 스크립트 생성"
 
 #: src/llms.md:48
 msgid "`scoop lang [code]`"
-msgstr ""
+msgstr "`scoop lang [code]`"
 
 #: src/llms.md:48
 msgid "Get/set language (en, ko, ja, pt-BR)"
-msgstr ""
+msgstr "언어 조회/설정 (en, ko, ja, pt-BR)"
 
 #: src/llms.md:49
 msgid "`scoop migrate list`"
-msgstr ""
+msgstr "`scoop migrate list`"
 
 #: src/llms.md:49
 msgid "List migratable envs (pyenv, conda, virtualenvwrapper)"
-msgstr ""
+msgstr "마이그레이션 가능한 환경 목록 표시 (pyenv, conda, virtualenvwrapper)"
 
 #: src/llms.md:50
 msgid "`scoop migrate @env <name>`"
-msgstr ""
+msgstr "`scoop migrate @env <name>`"
 
 #: src/llms.md:50
 msgid "Migrate single environment"
-msgstr ""
+msgstr "단일 환경 마이그레이션"
 
 #: src/llms.md:51
 msgid "Migrate all environments (parallel via rayon since v0.11.0)"
-msgstr ""
+msgstr "모든 환경 마이그레이션 (v0.11.0부터 rayon을 통한 병렬 처리)"
 
 #: src/llms.md:52
 msgid "`scoop gc`"
-msgstr ""
+msgstr "`scoop gc`"
 
 #: src/llms.md:52
 msgid ""
-"Garbage-collect orphan virtualenvs (`--yes` to actually remove, `--"
-"aggressive` also for unused Pythons, `--older-than <n>d/w/y` flags stale "
+"Garbage-collect orphan virtualenvs (`--yes` to actually remove, "
+"`--aggressive` also for unused Pythons, `--older-than <n>d/w/y` flags stale "
 "envs by `last_used`; envs with no `last_used` are never matched)"
 msgstr ""
+"고아 virtualenv 가비지 컬렉션 (`--yes`로 실제 삭제, `--aggressive`는 미사용 Python도 대상 포함, "
+"`--older-than <n>d/w/y`는 `last_used` 기준으로 오래된 환경 표시; `last_used`가 없는 환경은 절대 "
+"대상에 포함되지 않음)"
 
 #: src/llms.md:53
 msgid "`scoop prune`"
-msgstr ""
+msgstr "`scoop prune`"
 
 #: src/llms.md:53
 msgid "Prune the uv cache (`uv cache prune` wrapper)"
-msgstr ""
+msgstr "uv 캐시 정리 (`uv cache prune` 래퍼)"
 
 #: src/llms.md:54
 msgid "`scoop verify [NAME]`"
-msgstr ""
+msgstr "`scoop verify [NAME]`"
 
 #: src/llms.md:54
 msgid ""
 "Per-env health diagnosis — 6 checks (metadata, python binary, pyvenv.cfg, "
 "activate, exec, manifest drift); `--strict` exits 1 on issues"
 msgstr ""
+"환경별 상태 진단 — 6가지 검사 (metadata, python binary, pyvenv.cfg, activate, exec, "
+"manifest drift); `--strict` 옵션은 문제 발생 시 종료 코드 1 반환"
 
 #: src/llms.md:55
 msgid "`scoop man [DIR]`"
-msgstr ""
+msgstr "`scoop man [DIR]`"
 
 #: src/llms.md:55
 msgid "Generate man pages (stdout or one file per subcommand in DIR)"
-msgstr ""
+msgstr "man 페이지 생성 (stdout 출력 또는 DIR에 서브커맨드별 파일 생성)"
+
+#: src/llms.md:56
+msgid "`scoop diff <a> <b>`"
+msgstr "`scoop diff <a> <b>`"
+
+#: src/llms.md:56
+msgid "Compare two environments: Python, packages, metadata"
+msgstr "두 환경 비교: Python, 패키지, 메타데이터"
 
 #: src/llms.md:57
-msgid "Most commands support `--json` for machine-readable output."
-msgstr ""
+msgid "`scoop self update`"
+msgstr "`scoop self update`"
+
+#: src/llms.md:57
+msgid "Update scoop itself from crates.io"
+msgstr "crates.io에서 scoop 자체를 업데이트"
 
 #: src/llms.md:59
-msgid "Global options: `--quiet`, `--no-color`"
-msgstr ""
+msgid "Most commands support `--json` for machine-readable output."
+msgstr "대부분의 명령은 기계가 읽기 쉬운 출력을 위해 `--json`을 지원합니다."
 
 #: src/llms.md:61
-msgid "Key Concepts"
-msgstr ""
+msgid "Global options: `--quiet`, `--no-color`"
+msgstr "전역 옵션: `--quiet`, `--no-color`"
 
 #: src/llms.md:63
-msgid "Set a Specific Python Version as Global Default"
-msgstr ""
+msgid "Key Concepts"
+msgstr "주요 개념"
 
 #: src/llms.md:65
+msgid "Set a Specific Python Version as Global Default"
+msgstr "특정 Python 버전을 전역 기본값으로 설정"
+
+#: src/llms.md:67
 msgid "To set Python `3.11.0` as the global default for new shells:"
-msgstr ""
+msgstr "새 shell의 전역 기본값으로 Python `3.11.0`을 설정하려면:"
 
-#: src/llms.md:73
+#: src/llms.md:75
 msgid ""
-"Important: `--global` stores an environment name (`py311`) in `~/.scoop/"
-"version`, not the raw Python version string. Local `.scoop-version` and "
-"`SCOOP_VERSION` override the global default."
+"Important: `--global` stores an environment name (`py311`) in "
+"`~/.scoop/version`, not the raw Python version string. Local `.scoop-"
+"version` and `SCOOP_VERSION` override the global default."
 msgstr ""
+"중요: `--global`은 Python 버전 문자열이 아닌 환경 이름(`py311`)을 `~/.scoop/version`에 저장합니다."
+" 로컬 `.scoop-version`과 `SCOOP_VERSION`은 전역 기본값보다 우선합니다."
 
-#: src/llms.md:85
+#: src/llms.md:87
 msgid ""
 "If `3.9.5` is not found, check discovery with `uv python list` and `scoop "
 "list --pythons`, then install and retry."
 msgstr ""
+"`3.9.5`를 찾을 수 없는 경우 `uv python list`와 `scoop list --pythons`로 탐지 상태를 확인한 후 "
+"설치하고 다시 시도하세요."
 
-#: src/llms.md:88
+#: src/llms.md:90
 msgid "Uninstall Python and Associated Environments"
-msgstr ""
-
-#: src/llms.md:91
-msgid "# Optional preview\n"
-msgstr ""
+msgstr "Python 및 관련 환경 제거"
 
 #: src/llms.md:93
+msgid "# Optional preview\n"
+msgstr "# Optional preview\n"
+
+#: src/llms.md:95
 msgid "# Remove Python 3.12 and all environments that use it\n"
-msgstr ""
+msgstr "# Remove Python 3.12 and all environments that use it\n"
 
-#: src/llms.md:96
+#: src/llms.md:98
 msgid "# Verify cleanup\n"
-msgstr ""
+msgstr "# Verify cleanup\n"
 
-#: src/llms.md:102
+#: src/llms.md:104
 msgid ""
-"For automation, use `scoop uninstall 3.12 --cascade --force`. Without `--"
-"cascade`, dependent environments are not removed and may become broken."
+"For automation, use `scoop uninstall 3.12 --cascade --force`. Without "
+"`--cascade`, dependent environments are not removed and may become broken."
 msgstr ""
+"자동화를 위해 `scoop uninstall 3.12 --cascade --force`를 사용하세요. `--cascade` 없이 사용하면"
+" 의존하는 환경이 제거되지 않아 손상될 수 있습니다."
 
-#: src/llms.md:105
+#: src/llms.md:107
 msgid "Temporarily Disable or Customize Auto-Activation (Project-Scoped)"
-msgstr ""
+msgstr "자동 활성화 일시 비활성화 또는 사용자 정의 (프로젝트 범위)"
 
-#: src/llms.md:108
+#: src/llms.md:110
 msgid "# Current shell only (temporary disable)\n"
-msgstr ""
+msgstr "# Current shell only (temporary disable)\n"
 
-#: src/llms.md:111
+#: src/llms.md:113
 msgid "# Project-local behavior (writes .scoop-version in current dir)\n"
-msgstr ""
+msgstr "# Project-local behavior (writes .scoop-version in current dir)\n"
 
-#: src/llms.md:115
+#: src/llms.md:117
 msgid "# Terminal-only override (no file changes)\n"
-msgstr ""
-
-#: src/llms.md:121
-msgid "Use these without `--global` to avoid changing global settings."
-msgstr ""
+msgstr "# Terminal-only override (no file changes)\n"
 
 #: src/llms.md:123
+msgid "Use these without `--global` to avoid changing global settings."
+msgstr "`--global` 없이 사용하여 전역 설정을 변경하지 않도록 하세요."
+
+#: src/llms.md:125
 msgid "Install Dependencies from requirements.txt in Active Environment"
-msgstr ""
+msgstr "활성 환경에 requirements.txt 의존성 설치"
 
-#: src/llms.md:126
+#: src/llms.md:128
 msgid "# environment already active (prompt shows: (myproject))\n"
-msgstr ""
+msgstr "# environment already active (prompt shows: (myproject))\n"
 
-#: src/llms.md:130
+#: src/llms.md:132
 msgid ""
 "Use `pip install -r path/to/requirements.txt` for non-root files. Verify "
 "with `pip list`."
 msgstr ""
+"루트 경로가 아닌 파일에는 `pip install -r path/to/requirements.txt`를 사용하세요. `pip list`로"
+" 설치 여부를 확인할 수 있습니다."
 
-#: src/llms.md:133
+#: src/llms.md:135
 msgid "List Python Versions and Associated Environments"
-msgstr ""
+msgstr "Python 버전 및 관련 환경 목록"
 
-#: src/llms.md:141
+#: src/llms.md:143
 msgid ""
 "Use `--json` for automation and `--bare` for script-friendly output. For "
-"full mapping in shell scripts, iterate versions from `scoop list --pythons --"
-"bare` and query each with `scoop list --python-version <VERSION> --bare`."
+"full mapping in shell scripts, iterate versions from `scoop list --pythons "
+"--bare` and query each with `scoop list --python-version <VERSION> --bare`."
 msgstr ""
+"자동화에는 `--json`을, 스크립트 친화적 출력에는 `--bare`를 사용하세요. shell 스크립트에서 전체 매핑이 필요한 경우 "
+"`scoop list --pythons --bare`로 버전을 순회하며 `scoop list --python-version "
+"<VERSION> --bare`로 각각 조회하세요."
 
-#: src/llms.md:145
+#: src/llms.md:147
 msgid "Integrate Custom or Pre-Existing Python"
-msgstr ""
-
-#: src/llms.md:148
-msgid "# Preferred: explicit interpreter path\n"
-msgstr ""
+msgstr "커스텀 또는 기존 Python 통합"
 
 #: src/llms.md:150
-msgid "# Alternative: make interpreter discoverable via PATH\n"
-msgstr ""
+msgid "# Preferred: explicit interpreter path\n"
+msgstr "# Preferred: explicit interpreter path\n"
 
-#: src/llms.md:156
+#: src/llms.md:152
+msgid "# Alternative: make interpreter discoverable via PATH\n"
+msgstr "# Alternative: make interpreter discoverable via PATH\n"
+
+#: src/llms.md:158
 msgid ""
 "Verify with `uv python list`, `scoop info myenv`, and `scoop doctor -v`. "
 "Custom interpreter path is stored in `~/.scoop/virtualenvs/<name>/.scoop-"
 "metadata.json` (`python_path` field)."
 msgstr ""
-
-#: src/llms.md:160
-msgid "Version Files"
-msgstr ""
+"`uv python list`, `scoop info myenv`, `scoop doctor -v`로 확인하세요. 커스텀 인터프리터 "
+"경로는 `~/.scoop/virtualenvs/<name>/.scoop-metadata.json`의 `python_path` 필드에 "
+"저장됩니다."
 
 #: src/llms.md:162
-msgid "Priority (first match wins):"
-msgstr ""
-
-#: src/llms.md:163
-msgid "`SCOOP_VERSION` env var (shell session override, set by `scoop shell`)"
-msgstr ""
+msgid "Version Files"
+msgstr "버전 파일"
 
 #: src/llms.md:164
-msgid "`.scoop-version` in current directory (local, walks parent directories)"
-msgstr ""
+msgid "Priority (first match wins):"
+msgstr "우선순위 (처음 일치하는 항목 적용):"
 
-#: src/llms.md:169
+#: src/llms.md:165
+msgid "`SCOOP_VERSION` env var (shell session override, set by `scoop shell`)"
+msgstr "`SCOOP_VERSION` 환경 변수 (shell 세션 재정의, `scoop shell`로 설정)"
+
+#: src/llms.md:166
+msgid ""
+"`.scoop-version` in current directory (local, walks parent directories)"
+msgstr "현재 디렉터리의 `.scoop-version` (로컬, 상위 디렉터리까지 탐색)"
+
+#: src/llms.md:171
 msgid ""
 "scoop outputs shell code to stdout; the shell wrapper `eval`s it (pyenv "
-"pattern). Auto-activation triggers on directory change when `.scoop-version` "
-"is present."
+"pattern). Auto-activation triggers on directory change when `.scoop-version`"
+" is present."
 msgstr ""
+"scoop은 shell 코드를 stdout으로 출력하며, shell 래퍼가 이를 `eval`로 실행합니다 (pyenv 패턴). "
+"`.scoop-version`이 있는 디렉터리로 이동하면 자동 활성화가 실행됩니다."
 
-#: src/llms.md:172
+#: src/llms.md:174
 msgid ""
 "Supported shells: bash, zsh, fish, PowerShell (Core 7.x+ and Windows "
 "PowerShell 5.1+)"
 msgstr ""
-
-#: src/llms.md:174
-msgid "Disable auto-activation: `export SCOOP_NO_AUTO=1`"
-msgstr ""
+"지원 shell: bash, zsh, fish, PowerShell (Core 7.x+ 및 Windows PowerShell 5.1+)"
 
 #: src/llms.md:176
-msgid "Environment Name Rules"
-msgstr ""
+msgid "Disable auto-activation: `export SCOOP_NO_AUTO=1`"
+msgstr "자동 활성화 비활성화: `export SCOOP_NO_AUTO=1`"
 
 #: src/llms.md:178
-msgid "Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` (max 64 chars)"
-msgstr ""
-
-#: src/llms.md:179
-msgid "Must start with a letter"
-msgstr ""
+msgid "Environment Name Rules"
+msgstr "환경 이름 규칙"
 
 #: src/llms.md:180
+msgid "Pattern: `^[a-zA-Z][a-zA-Z0-9_-]*$` (max 64 chars)"
+msgstr "패턴: `^[a-zA-Z][a-zA-Z0-9_-]*$` (최대 64자)"
+
+#: src/llms.md:181
+msgid "Must start with a letter"
+msgstr "영문자로 시작해야 합니다"
+
+#: src/llms.md:182
 msgid ""
 "Reserved words: activate, base, completions, create, deactivate, default, "
 "delete, global, help, init, install, list, local, remove, resolve, root, "
 "system, uninstall, use, version, versions"
 msgstr ""
-
-#: src/llms.md:182
-msgid "Migration Sources"
-msgstr ""
+"예약어: activate, base, completions, create, deactivate, default, delete, "
+"global, help, init, install, list, local, remove, resolve, root, system, "
+"uninstall, use, version, versions"
 
 #: src/llms.md:184
-msgid ""
-"Import environments from pyenv-virtualenv, virtualenvwrapper, and conda."
-msgstr ""
+msgid "Migration Sources"
+msgstr "마이그레이션 소스"
 
 #: src/llms.md:186
-msgid "Internationalization"
-msgstr ""
+msgid ""
+"Import environments from pyenv-virtualenv, virtualenvwrapper, and conda."
+msgstr "pyenv-virtualenv, virtualenvwrapper, conda에서 환경을 가져올 수 있습니다."
 
 #: src/llms.md:188
-msgid ""
-"Supported languages: English (`en`), Korean (`ko`), Japanese (`ja`), "
-"Portuguese-BR (`pt-BR`)"
-msgstr ""
+msgid "Internationalization"
+msgstr "국제화"
 
 #: src/llms.md:190
 msgid ""
+"Supported languages: English (`en`), Korean (`ko`), Japanese (`ja`), "
+"Portuguese-BR (`pt-BR`)"
+msgstr "지원 언어: 영어 (`en`), 한국어 (`ko`), 일본어 (`ja`), 포르투갈어-BR (`pt-BR`)"
+
+#: src/llms.md:192
+msgid ""
 "Priority: `SCOOP_LANG` env > `~/.scoop/config.json` > system locale > `en`"
-msgstr ""
-
-#: src/llms.md:194
-msgid "Config file: `~/.scoop/config.json`"
-msgstr ""
-
-#: src/llms.md:195
-msgid "Home directory: `~/.scoop/` (override: `SCOOP_HOME`)"
-msgstr ""
+msgstr "우선순위: `SCOOP_LANG` 환경 변수 > `~/.scoop/config.json` > 시스템 로케일 > `en`"
 
 #: src/llms.md:196
+msgid "Config file: `~/.scoop/config.json`"
+msgstr "설정 파일: `~/.scoop/config.json`"
+
+#: src/llms.md:197
+msgid "Home directory: `~/.scoop/` (override: `SCOOP_HOME`)"
+msgstr "홈 디렉터리: `~/.scoop/` (재정의: `SCOOP_HOME`)"
+
+#: src/llms.md:198
 msgid "Metadata: `~/.scoop/virtualenvs/<name>/.scoop-metadata.json`"
-msgstr ""
+msgstr "메타데이터: `~/.scoop/virtualenvs/<name>/.scoop-metadata.json`"
 
 #: src/examples.md:3
 msgid ""
-"Explore real-world usage examples in the [examples/ directory on GitHub]"
-"(https://github.com/ai-screams/scoop-uv/blob/main/examples/README.md)."
+"Explore real-world usage examples in the [examples/ directory on "
+"GitHub](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/README.md)."
 msgstr ""
+"GitHub의 [examples/ 디렉터리](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/README.md)에서 실제 사용 예제를 확인해 보세요."
 
 #: src/examples.md:7
 msgid ""
-"[Basic Workflow](https://github.com/ai-screams/scoop-uv/blob/main/examples/"
-"basic_workflow.sh)"
+"[Basic Workflow](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/basic_workflow.sh)"
 msgstr ""
+"[기본 워크플로우](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/basic_workflow.sh)"
 
 #: src/examples.md:7
 msgid "Create, use, and remove environments"
-msgstr ""
+msgstr "환경 생성, 사용 및 제거"
 
 #: src/examples.md:8
 msgid ""
-"[Migration from pyenv](https://github.com/ai-screams/scoop-uv/blob/main/"
-"examples/migration_from_pyenv.sh)"
+"[Migration from pyenv](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/migration_from_pyenv.sh)"
 msgstr ""
+"[pyenv에서 마이그레이션](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/migration_from_pyenv.sh)"
 
 #: src/examples.md:8
 msgid "Import pyenv-virtualenv environments"
-msgstr ""
+msgstr "pyenv-virtualenv 환경 가져오기"
 
 #: src/examples.md:9
 msgid ""
-"[Multi-Project Setup](https://github.com/ai-screams/scoop-uv/blob/main/"
-"examples/multi_project_setup.sh)"
+"[Multi-Project Setup](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/multi_project_setup.sh)"
 msgstr ""
+"[멀티 프로젝트 설정](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/multi_project_setup.sh)"
 
 #: src/examples.md:9
 msgid "Manage multiple project environments"
-msgstr ""
+msgstr "여러 프로젝트 환경 관리"
 
 #: src/examples.md:10
 msgid ""
-"[GitHub Actions CI](https://github.com/ai-screams/scoop-uv/blob/main/"
-"examples/ci_github_actions.yml)"
+"[GitHub Actions CI](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/ci_github_actions.yml)"
 msgstr ""
+"[GitHub Actions CI](https://github.com/ai-screams/scoop-"
+"uv/blob/main/examples/ci_github_actions.yml)"
 
 #: src/examples.md:10
 msgid "Use scoop in CI pipelines"
-msgstr ""
+msgstr "CI 파이프라인에서 scoop 사용"


### PR DESCRIPTION
## Summary

Brings the Korean documentation (`docs/po/ko.po`) to **full coverage**. Previously ~99% untranslated (2738/2770 empty); now **0 untranslated, 0 fuzzy**.

Pipeline:
1. Re-extracted the gettext template from the current English source (`MDBOOK_OUTPUT='{"xgettext": {}}' mdbook build -d po`).
2. `msgmerge` to sync `ko.po` with the template (also resolves the "Verify ko translations are in sync" CI guard against the post-0.14.1 source).
3. Translated all 2767 remaining entries into natural Korean.

## Translation policy
- Natural, fluent Korean (no translationese), consistent 합니다/입니다 doc tone.
- CLI commands/flags, env vars, file paths, code, and proper names (scoop, uv, pyenv, Python, Rust, mdBook) kept in English.
- Pure code/command/path entries left verbatim; prose and link text localized (URLs preserved).

## Verification (against committed file)
- ✅ 0 untranslated, 0 fuzzy (2805 entries)
- ✅ `msgfmt -c` clean
- ✅ Translation↔msgid alignment: 2767/2767, **0 mismatches**
- ✅ Placeholder `{...}` and URL preservation: **0 mismatches** across 1956 translated entries
- ✅ 849 verbatim entries confirmed to be code/identifiers/paths/proper-names (no prose left untranslated)
- ✅ Korean book builds (`MDBOOK_BOOK__LANGUAGE=ko mdbook build -d book/ko`)
- ✅ `msgmerge` against current `.pot` yields no msgid drift (CI sync guard passes)

Only `docs/po/ko.po` changes; `messages.pot` is gitignored.