### PR TITLE
fix(deps): bump crossbeam-epoch 0.9.20, anyhow 1.0.103 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why

The scheduled **Security** workflow (run #368, `main`) failed after new RustSec advisories were published against the committed lockfile — not a code regression.

| Job | Result | Cause |
|-----|--------|-------|
| Security Audit (`cargo audit`) | ❌ exit 1 | `crossbeam-epoch 0.9.18` |
| Dependency Check (`cargo-deny`) | ❌ `advisories FAILED` | same |

## Changes (lockfile-only, +4/-4)

- **RUSTSEC-2026-0204** (error): `crossbeam-epoch 0.9.18 → 0.9.20` — invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`. Transitive via `rayon` and `rust-i18n`'s `ignore`.
- **RUSTSEC-2026-0190** (warning): `anyhow 1.0.102 → 1.0.103` — `Error::downcast_mut()` unsoundness.

Both are patch-level, MSRV 1.85 compatible; no source changes.

## Verification (local)

- `cargo audit` → exit 0 (0 vulnerabilities, 0 warnings)
- `cargo deny --all-features check` → advisories ok, bans ok, licenses ok, sources ok
- `cargo check --all-targets` → compiles clean