### PR TITLE
chore: release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55691a65892c33ee2de49c15ea5600c6f4a70e8eeb8e6c3cd96d2a231d230c40"
+checksum = "752c95174ef2555cd95873d6f12d0bee9f0a1dcbf1b631dde847053a29174996"
 dependencies = [
  "globwalk",
  "regex",
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-macro"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30de488acadcf767d97cd48518a8da8ea9777b1c9a5beca4eab78bbf77d07309"
+checksum = "cc99fd028c912b59841bd745ec11c2dda112549ae6de25a850f384bb59d1a8f8"
 dependencies = [
  "glob",
  "proc-macro2",
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-support"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea0fef8a93c06326b66392c95a115120e609674cb2132d37d276a6b05b545b4"
+checksum = "3dfb30689b70c7fd955e8e5c709fa055a778ae024ef6a382c4eb425dd2c2fabb"
 dependencies = [
  "arc-swap",
  "base62",
@@ -2102,6 +2102,6 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"


### PR DESCRIPTION



## 🤖 New release

* `scoop-uv`: 0.14.2 -> 0.15.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0] - 2026-07-13

### Changed

- **BREAKING**: command renamed `scoop` → `scuv` (binary, shell functions, completions, man pages)
  to coexist with the Windows Scoop package manager. Repo/crate stay `scoop-uv`.
- **BREAKING**: `SCOOP_HOME/VERSION/LANG/NO_AUTO/RESOLVE_MAX_DEPTH` → `SCUV_*`; `~/.scoop` → `~/.scuv`;
  `.scoop-version` → `.scuv-version`; `.scoop.toml` → `.scuv.toml`. Legacy values/files are still READ
  with a one-shot deprecation warning; support ends in v0.16.0. Migrate: rename the files and
  `mv ~/.scoop ~/.scuv`. `scuv use --unset` removes both the old and new local version files;
  `scuv shell` transitionally exports both `SCUV_VERSION` and `SCOOP_VERSION`.
- **BREAKING**: session state variables (`SCUV_ACTIVE`, `_SCUV_OLD_PATH`, `_SCUV_OLD_PYTHONHOME`)
  were renamed with **no** fallback. After upgrading, restart your shells and update rc files to
  `eval "$(scuv init <shell>)"` (fish: `scuv init fish | source`).
- bash/zsh/fish `scuv init` emits a deprecated `scoop` forwarding function that warns on use
  (removed in v0.16.0). PowerShell never defines `scoop` (scoop.sh coexistence).
- Upgrading from 0.14.x via `scoop self update` works, but the old binary's post-install
  verification prints a "could not locate the freshly installed `scoop` binary" warning —
  this is expected across the rename (the new binary is `scuv`) and safe to ignore; the
  update itself has already succeeded.
- Docker: uv pinned 0.11.16 → 0.11.28.

### Added

- **doctor:** New `legacy` check lists leftover scoop-era settings and flags rc files still
  invoking `scoop init`.

### Fixed

- **docs:** fish shell docs now use `scuv init fish | source` and `scuv shell <name> | source` —
  the previously documented `eval (...)` idiom never worked in fish (pre-existing bug since at
  least 0.14.1).

### Unchanged

- Serialized-format compatibility, kept as-is on purpose: per-env metadata file
  `.scoop-metadata.json`; export-schema JSON field `scoop_export_version` (renaming either would
  break reading existing envs/export files for zero user value).

[0.15.0]: https://github.com/ai-screams/scoop-uv/compare/0.14.2...0.15.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).