### PR TITLE
docs: upgrading-from-scoop guide + fuzz gnu-target fix

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -53,7 +53,10 @@ jobs:
           restore-keys: fuzz-corpus-${{ matrix.target }}-
 
       - name: Run fuzzer (time-bounded)
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=120
+        # Explicit gnu target: install-action ships a musl-built cargo-fuzz,
+        # whose default target (its own host triple) is musl — and ASan is
+        # incompatible with statically linked libc.
+        run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=120
 
       - name: Upload crash artifacts
         if: failure()

--- a/README.md
+++ b/README.md
@@ -261,6 +261,36 @@ Or restart your terminal after installing Rust.
 
 </details>
 
+### Upgrading from scoop (≤ 0.14.x) 🔁
+
+The CLI command was renamed in v0.15.0 (`scoop` → `scuv`). One-time migration:
+
+```bash
+# 1. Update — installs the new `scuv` binary
+scoop self update        # or: cargo install scoop-uv
+# ("could not locate the freshly installed `scoop` binary" warning is
+#  expected across the rename — the update itself already succeeded)
+
+# 2. Remove the old binary if cargo left one behind
+rm -f ~/.cargo/bin/scoop
+
+# 3. Update your shell rc: scoop init → scuv init
+#    ~/.zshrc / ~/.bashrc:  eval "$(scuv init zsh)"      # or bash
+#    fish:                  scuv init fish | source
+
+# 4. Move your freezer
+mv ~/.scoop ~/.scuv
+
+# 5. Restart your shell, then verify
+scuv doctor              # flags anything left over
+```
+
+Legacy `SCOOP_*` env vars and `.scoop-version` / `.scoop.toml` files keep
+working (with a one-shot deprecation warning) until v0.16.0, and typing
+`scoop` in bash/zsh/fish still works through a deprecated forwarder that
+warns and calls `scuv`. Skipping step 2 is the one dangerous gap: a
+leftover old binary keeps running 0.14.x silently, without any warning.
+
 ### Shell Setup
 
 #### Step 1: Add to your shell config

--- a/docs/po/ko.po
+++ b/docs/po/ko.po
@@ -453,59 +453,105 @@ msgid "Verify the upgrade:"
 msgstr "업그레이드 확인:"
 
 #: src/installation.md:34
+msgid "Upgrading from scoop (≤ 0.14.x)"
+msgstr "scoop(≤ 0.14.x)에서 업그레이드하기"
+
+#: src/installation.md:36
+msgid ""
+"The CLI command was renamed in v0.15.0 (`scoop` → `scuv`). One-time "
+"migration:"
+msgstr "CLI 명령어가 v0.15.0에서 이름이 바뀌었습니다(`scoop` → `scuv`). 일회성 마이그레이션:"
+
+#: src/installation.md:39
+msgid ""
+"# installs the new `scuv` binary\n"
+"                         # (the \"could not locate the freshly installed\n"
+"                         #  `scoop` binary\" warning is expected)\n"
+msgstr ""
+
+#: src/installation.md:42
+msgid "# remove the old binary if cargo left one behind\n"
+msgstr ""
+
+#: src/installation.md:43
+msgid "# move your environments\n"
+msgstr "환경 삭제"
+
+#: src/installation.md:46
+msgid ""
+"Then update your shell rc file — replace `eval \"$(scoop init <shell>)\"` "
+"with `eval \"$(scuv init <shell>)\"` (fish: `scuv init fish | source`), "
+"restart your shell, and run `scuv doctor` to confirm nothing legacy is left "
+"over."
+msgstr ""
+"그다음 셸 rc 파일을 갱신하세요 — `eval \"$(scoop init <shell>)\"`를 `eval \"$(scuv init "
+"<shell>)\"`로 바꾸고(fish는 `scuv init fish | source`), 셸을 재시작한 뒤 `scuv doctor`를 "
+"실행해 남은 레거시가 없는지 확인합니다."
+
+#: src/installation.md:50
+msgid ""
+"Legacy `SCOOP_*` env vars and `.scoop-version` / `.scoop.toml` files keep "
+"working with a one-shot deprecation warning until v0.16.0. Don't skip the "
+"`rm` step: a leftover old binary keeps running 0.14.x silently."
+msgstr ""
+"레거시 `SCOOP_*` 환경 변수와 `.scoop-version` / `.scoop.toml` 파일은 v0.16.0까지 일회성 사용 "
+"중단 경고와 함께 계속 동작합니다. `rm` 단계를 건너뛰지 마세요 — 남은 옛 바이너리는 아무 경고 없이 0.14.x를 계속 "
+"실행합니다."
+
+#: src/installation.md:54
 msgid "Verify Installation"
 msgstr "설치 확인"
 
-#: src/installation.md:37
+#: src/installation.md:57
 msgid "# scuv 0.15.0\n"
 msgstr "# scuv 0.15.0\n"
 
-#: src/installation.md:41 src/python-management.md:175
+#: src/installation.md:61 src/python-management.md:175
 #: src/development/testing.md:384 src/development/code-quality.md:420
 msgid "Troubleshooting"
 msgstr "문제 해결"
 
-#: src/installation.md:43
+#: src/installation.md:63
 msgid "`scuv: command not found`"
 msgstr "`scuv: command not found`"
 
-#: src/installation.md:45
+#: src/installation.md:65
 msgid "Ensure `~/.cargo/bin` is in your PATH:"
 msgstr "`~/.cargo/bin`이 PATH에 포함되어 있는지 확인하세요:"
 
-#: src/installation.md:48
+#: src/installation.md:68
 msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# ~/.zshrc 또는 ~/.bashrc에 추가\n"
 
-#: src/installation.md:49
+#: src/installation.md:69
 msgid "\"$HOME/.cargo/bin:$PATH\""
 msgstr "\"$HOME/.cargo/bin:$PATH\""
 
-#: src/installation.md:52
+#: src/installation.md:72
 msgid "Then restart your terminal or run:"
 msgstr "이후 터미널을 재시작하거나 다음을 실행하세요:"
 
-#: src/installation.md:55
+#: src/installation.md:75
 msgid "# or ~/.bashrc\n"
 msgstr "# 또는 ~/.bashrc\n"
 
-#: src/installation.md:58
+#: src/installation.md:78
 msgid "uv not found"
 msgstr "uv를 찾을 수 없음"
 
-#: src/installation.md:60
+#: src/installation.md:80
 msgid "scuv requires uv to be installed and available in PATH. Verify:"
 msgstr "scuv는 uv가 설치되어 있고 PATH에서 사용 가능해야 합니다. 확인 방법:"
 
-#: src/installation.md:66
+#: src/installation.md:86
 msgid "If not installed, run:"
 msgstr "설치되어 있지 않다면 다음을 실행하세요:"
 
-#: src/installation.md:72 src/quick-start.md:111
+#: src/installation.md:92 src/quick-start.md:111
 msgid "Next Steps"
 msgstr "다음 단계"
 
-#: src/installation.md:74
+#: src/installation.md:94
 msgid ""
 "After installation, set up [Shell Integration](shell-integration.md) to "
 "enable auto-activation and tab completion."

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -31,6 +31,26 @@ Verify the upgrade:
 scuv --version
 ```
 
+### Upgrading from scoop (≤ 0.14.x)
+
+The CLI command was renamed in v0.15.0 (`scoop` → `scuv`). One-time migration:
+
+```bash
+scoop self update        # installs the new `scuv` binary
+                         # (the "could not locate the freshly installed
+                         #  `scoop` binary" warning is expected)
+rm -f ~/.cargo/bin/scoop # remove the old binary if cargo left one behind
+mv ~/.scoop ~/.scuv      # move your environments
+```
+
+Then update your shell rc file — replace `eval "$(scoop init <shell>)"` with
+`eval "$(scuv init <shell>)"` (fish: `scuv init fish | source`), restart your
+shell, and run `scuv doctor` to confirm nothing legacy is left over.
+
+Legacy `SCOOP_*` env vars and `.scoop-version` / `.scoop.toml` files keep
+working with a one-shot deprecation warning until v0.16.0. Don't skip the
+`rm` step: a leftover old binary keeps running 0.14.x silently.
+
 ## Verify Installation
 
 ```bash


### PR DESCRIPTION
## Summary

**Upgrade guide (README + installation manual, en/ko):** step-by-step one-time migration from scoop ≤0.14.x — discovered on a real upgrade that cargo's orphaned-bin cleanup can leave the old `~/.cargo/bin/scoop` binary behind, which then keeps running 0.14.x silently with no deprecation warning. The guide covers: `scoop self update` (expected verify warning), removing the stale binary, rc update (`scuv init`; fish `| source`), `mv ~/.scoop ~/.scuv`, and `scuv doctor` verification. Korean translations included; ko.po msgmerge round-trip verified byte-identical (tag-push gate will pass).

**Fuzz workflow, part 2:** ec4f31e fixed the toolchain (nightly), which unmasked the next failure — install-action ships a musl-built cargo-fuzz whose default target is its own musl host triple, and ASan is incompatible with statically linked libc. Pin `--target x86_64-unknown-linux-gnu`. Verifiable via workflow_dispatch after merge.

**Not in this PR:** the main Security workflow failure resolved itself — cargo-deny-action v2.1.0 (published 09:32 yesterday, between our green PR run and the red main run) broke the action; upstream v2.1.1 fixed it and the rerun is green. No change needed on our side.

## Verification
- mdBook builds clean in en + ko; ko installation page renders the new section.
- ko.po: 0 fuzzy, fresh-msgmerge round-trip byte-identical modulo timestamp headers.
- Docs + workflow-only diff — no Rust code touched.