### PR TITLE
fix: v0.15.1 follow-up — panic fix, double-warning, test hardening

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["command-line-utilities", "development-tools"]
 # 화이트리스트: crates.io 배포에 필요한 파일만 포함
 include = [
     "src/**/*.rs",
+    "build.rs",
     "Cargo.toml",
     "/LICENSE-*",
     "/README.md",

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+//! Build script: track non-Rust inputs that proc-macros read at expansion time.
+
+fn main() {
+    // rust_i18n's `i18n!()` reads locales/app.yml during macro expansion,
+    // but cargo doesn't know about that dependency — without this line a
+    // yml-only edit reuses the stale compiled strings and `cargo test`
+    // reports false-green.
+    println!("cargo:rerun-if-changed=locales/app.yml");
+}

--- a/locales/app.yml
+++ b/locales/app.yml
@@ -1420,24 +1420,24 @@ doctor.legacy_suggestion:
 # ============================================================================
 deprecation.env_var:
   en: "%{old} is deprecated; use %{new} (support ends in v0.16.0)"
-  ko: "%{old}은(는) 곧 사라져요; %{new}을(를) 사용하세요 (v0.16.0에서 지원 종료)"
+  ko: "%{old}은(는) 사용 중단되었습니다 — %{new}을(를) 사용하세요 (v0.16.0에서 지원 종료)"
   pt-BR: "%{old} está obsoleto; use %{new} (suporte encerra na v0.16.0)"
   ja: "%{old} は非推奨です。%{new} を使用してください (v0.16.0でサポート終了)"
 
 deprecation.version_file:
   en: ".scoop-version is deprecated; rename it to .scuv-version (support ends in v0.16.0)"
-  ko: ".scoop-version은 곧 사라져요; .scuv-version으로 이름을 바꿔주세요 (v0.16.0에서 지원 종료)"
+  ko: ".scoop-version은 사용 중단되었습니다 — .scuv-version으로 이름을 바꿔주세요 (v0.16.0에서 지원 종료)"
   pt-BR: ".scoop-version está obsoleto; renomeie para .scuv-version (suporte encerra na v0.16.0)"
   ja: ".scoop-version は非推奨です。.scuv-version にリネームしてください (v0.16.0でサポート終了)"
 
 deprecation.manifest_file:
   en: ".scoop.toml is deprecated; rename it to .scuv.toml (support ends in v0.16.0)"
-  ko: ".scoop.toml은 곧 사라져요; .scuv.toml으로 이름을 바꿔주세요 (v0.16.0에서 지원 종료)"
+  ko: ".scoop.toml은 사용 중단되었습니다 — .scuv.toml로 이름을 바꿔주세요 (v0.16.0에서 지원 종료)"
   pt-BR: ".scoop.toml está obsoleto; renomeie para .scuv.toml (suporte encerra na v0.16.0)"
   ja: ".scoop.toml は非推奨です。.scuv.toml にリネームしてください (v0.16.0でサポート終了)"
 
 deprecation.home_dir:
   en: "~/.scoop is deprecated; run `mv ~/.scoop ~/.scuv` (support ends in v0.16.0)"
-  ko: "~/.scoop은 곧 사라져요; `mv ~/.scoop ~/.scuv` 명령을 실행해 주세요 (v0.16.0에서 지원 종료)"
+  ko: "~/.scoop은 사용 중단되었습니다 — `mv ~/.scoop ~/.scuv` 명령을 실행해 주세요 (v0.16.0에서 지원 종료)"
   pt-BR: "~/.scoop está obsoleto; execute `mv ~/.scoop ~/.scuv` (suporte encerra na v0.16.0)"
   ja: "~/.scoop は非推奨です。`mv ~/.scoop ~/.scuv` を実行してください (v0.16.0でサポート終了)"

--- a/src/core/doctor.rs
+++ b/src/core/doctor.rs
@@ -988,7 +988,15 @@ impl Check for VersionCheck {
 fn check_legacy_remnants() -> CheckResult {
     let mut found: Vec<String> = Vec::new();
 
-    for var in [paths::LEGACY_HOME_ENV, "SCOOP_VERSION", "SCOOP_LANG"] {
+    for var in [
+        paths::LEGACY_HOME_ENV,
+        "SCOOP_VERSION",
+        "SCOOP_LANG",
+        // No runtime warning for this one (it's read per prompt by the shell
+        // hook, warning there would spam) — this doctor hint is the only
+        // place a user learns to rename it.
+        "SCOOP_NO_AUTO",
+    ] {
         if std::env::var_os(var).is_some() {
             found.push(format!("${var}"));
         }
@@ -1526,6 +1534,7 @@ mod tests {
             (paths::LEGACY_HOME_ENV, None),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1551,6 +1560,7 @@ mod tests {
             ),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1582,6 +1592,7 @@ mod tests {
             (paths::LEGACY_HOME_ENV, None),
             ("SCOOP_VERSION", Some("myenv")),
             ("SCOOP_LANG", Some("ko")),
+            ("SCOOP_NO_AUTO", Some("1")),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1597,6 +1608,7 @@ mod tests {
         };
         assert!(msg.contains("SCOOP_VERSION"), "got: {msg}");
         assert!(msg.contains("SCOOP_LANG"), "got: {msg}");
+        assert!(msg.contains("SCOOP_NO_AUTO"), "got: {msg}");
     }
 
     #[test]
@@ -1608,6 +1620,7 @@ mod tests {
             (paths::LEGACY_HOME_ENV, None),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1638,6 +1651,7 @@ mod tests {
             (paths::LEGACY_HOME_ENV, None),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1657,6 +1671,7 @@ mod tests {
             (paths::LEGACY_HOME_ENV, None),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1690,6 +1705,7 @@ mod tests {
             ),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),
@@ -1785,6 +1801,7 @@ mod tests {
             (paths::LEGACY_HOME_ENV, None),
             ("SCOOP_VERSION", None),
             ("SCOOP_LANG", None),
+            ("SCOOP_NO_AUTO", None),
             (paths::SCUV_HOME_ENV, None),
             ("SCUV_VERSION", None),
             ("SCUV_LANG", None),

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -325,6 +325,17 @@ mod tests {
 
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555)).unwrap();
         let _restore = RestorePerms(dir);
+
+        // root (e.g. the Docker integration CI) bypasses the read-only bit, so
+        // the unwritable-dir scenario is unreproducible there. Probe with a
+        // real write and skip rather than false-fail when perms aren't enforced.
+        let probe = dir.join(".perm-probe");
+        let perms_enforced = std::fs::write(&probe, b"x").is_err();
+        let _ = std::fs::remove_file(&probe);
+        if !perms_enforced {
+            return;
+        }
+
         let result = VersionService::unset_local(dir);
 
         assert!(result.is_err(), "read-only dir must surface an error");

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -313,10 +313,19 @@ mod tests {
         std::fs::write(dir.join(".scuv-version"), "newenv\n").unwrap();
         std::fs::write(dir.join(".scoop-version"), "oldenv\n").unwrap();
 
+        // Restore permissions from a Drop guard so a panic between chmod and
+        // the assertions can't strand a read-only dir that TempDir then fails
+        // to clean up.
+        struct RestorePerms<'a>(&'a std::path::Path);
+        impl Drop for RestorePerms<'_> {
+            fn drop(&mut self) {
+                let _ = std::fs::set_permissions(self.0, std::fs::Permissions::from_mode(0o755));
+            }
+        }
+
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let _restore = RestorePerms(dir);
         let result = VersionService::unset_local(dir);
-        // restore before asserting so TempDir cleanup works even on failure
-        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         assert!(result.is_err(), "read-only dir must surface an error");
         assert!(dir.join(".scuv-version").exists());

--- a/src/core/version.rs
+++ b/src/core/version.rs
@@ -300,6 +300,29 @@ mod tests {
         assert!(!dir.join(".scoop-version").exists());
     }
 
+    /// Partial-failure behavior is fail-fast: on an unwritable directory the
+    /// first removal errors and `unset_local` returns Err without silently
+    /// claiming success — both files stay in place.
+    #[cfg(unix)]
+    #[test]
+    fn test_unset_local_fails_fast_on_unwritable_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+        std::fs::write(dir.join(".scuv-version"), "newenv\n").unwrap();
+        std::fs::write(dir.join(".scoop-version"), "oldenv\n").unwrap();
+
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let result = VersionService::unset_local(dir);
+        // restore before asserting so TempDir cleanup works even on failure
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(result.is_err(), "read-only dir must surface an error");
+        assert!(dir.join(".scuv-version").exists());
+        assert!(dir.join(".scoop-version").exists());
+    }
+
     #[test]
     fn test_read_version_file_normalizes_system_case() {
         let temp = TempDir::new().unwrap();

--- a/src/output/deprecation.rs
+++ b/src/output/deprecation.rs
@@ -7,10 +7,19 @@ use once_cell::sync::Lazy;
 
 static SEEN: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
+/// Environment variable that silences deprecation warnings for the process.
+///
+/// Set by the shell wrapper's chained `use` → `activate` call so a single
+/// user action doesn't print the same warning twice (each chained call is a
+/// fresh process, so the in-process dedup can't help there). An empty value
+/// counts as unset. Scripts may also set it to quiet migration noise.
+pub const SUPPRESS_ENV: &str = "SCUV_SUPPRESS_DEPRECATION";
+
 /// Prints `warning: <message>` to stderr once per unique message per process.
 ///
 /// Returns `true` if the warning was emitted, `false` if it was suppressed
-/// as a duplicate. Never touches stdout.
+/// as a duplicate or via [`SUPPRESS_ENV`]. Suppressed messages are not
+/// recorded as seen. Never touches stdout.
 ///
 /// # Examples
 ///
@@ -25,6 +34,9 @@ static SEEN: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new
 /// Panics if the internal seen-message set's mutex is poisoned (i.e. a
 /// previous holder of the lock panicked while holding it).
 pub fn warn_once(message: &str) -> bool {
+    if std::env::var_os(SUPPRESS_ENV).is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
     let mut seen = SEEN.lock().expect("deprecation set poisoned");
     if !seen.insert(message.to_string()) {
         return false;
@@ -36,11 +48,32 @@ pub fn warn_once(message: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn warn_once_emits_then_suppresses() {
         assert!(warn_once("task1-test-msg-a"));
         assert!(!warn_once("task1-test-msg-a"));
         assert!(warn_once("task1-test-msg-b"));
+    }
+
+    #[test]
+    #[serial]
+    fn warn_once_respects_suppress_env() {
+        {
+            let _g = crate::test_utils::env_guard(&[(SUPPRESS_ENV, Some("1"))]);
+            assert!(!warn_once("suppress-env-msg"));
+        }
+        // Suppressed calls are not recorded: without the env var the same
+        // message still warns.
+        let _g = crate::test_utils::env_guard(&[(SUPPRESS_ENV, None)]);
+        assert!(warn_once("suppress-env-msg"));
+    }
+
+    #[test]
+    #[serial]
+    fn warn_once_treats_empty_suppress_env_as_unset() {
+        let _g = crate::test_utils::env_guard(&[(SUPPRESS_ENV, Some(""))]);
+        assert!(warn_once("suppress-env-empty-msg"));
     }
 }

--- a/src/output/deprecation.rs
+++ b/src/output/deprecation.rs
@@ -51,7 +51,12 @@ mod tests {
     use serial_test::serial;
 
     #[test]
+    #[serial]
     fn warn_once_emits_then_suppresses() {
+        // Guard against an inherited SCUV_SUPPRESS_DEPRECATION (would make
+        // every warn_once return false) and serialize against the other
+        // env-mutating tests here.
+        let _g = crate::test_utils::env_guard(&[(SUPPRESS_ENV, None)]);
         assert!(warn_once("task1-test-msg-a"));
         assert!(!warn_once("task1-test-msg-a"));
         assert!(warn_once("task1-test-msg-b"));

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -369,6 +369,18 @@ mod tests {
         );
     }
 
+    /// The auto-activate gate must honor the new variable AND the legacy one
+    /// (deprecated read, removed in 0.16.0) — fish/powershell have the same
+    /// test; this pins bash/zsh symmetrically.
+    #[test]
+    fn init_script_checks_both_no_auto_variables() {
+        let script = init_script();
+        assert!(
+            script.contains(r#"[[ -z "$SCUV_NO_AUTO" && -z "$SCOOP_NO_AUTO" ]]"#),
+            "auto-activate gate must check SCUV_NO_AUTO with legacy SCOOP_NO_AUTO fallback"
+        );
+    }
+
     #[test]
     fn init_script_defines_deprecated_scoop_forwarder() {
         assert!(init_script().contains("scoop() {"));

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -25,7 +25,8 @@ scuv() {
                     esac
                 done
                 if [[ -n "$name" ]]; then
-                    eval "$(command scuv activate "$name")"
+                    # 'use' above already warned about any legacy config; don't warn twice
+                    eval "$(SCUV_SUPPRESS_DEPRECATION=1 command scuv activate "$name")"
                 fi
             fi
             return $ret
@@ -379,6 +380,13 @@ mod tests {
             script.contains(r#"[[ -z "$SCUV_NO_AUTO" && -z "$SCOOP_NO_AUTO" ]]"#),
             "auto-activate gate must check SCUV_NO_AUTO with legacy SCOOP_NO_AUTO fallback"
         );
+    }
+
+    /// The chained use→activate call must suppress duplicate deprecation
+    /// warnings (each chained call is a fresh process).
+    #[test]
+    fn init_script_suppresses_duplicate_deprecation_in_use_chain() {
+        assert!(init_script().contains("SCUV_SUPPRESS_DEPRECATION"));
     }
 
     #[test]

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -49,7 +49,8 @@ function scuv
             if test $ret -eq 0
                 for arg in $argv[2..-1]
                     if not string match -q -- '-*' "$arg"
-                        eval (command scuv activate "$arg")
+                        # 'use' above already warned about any legacy config; don't warn twice
+                        eval (env SCUV_SUPPRESS_DEPRECATION=1 scuv activate "$arg")
                         break
                     end
                 end
@@ -346,6 +347,13 @@ mod tests {
             script.contains("scuv list --pythons --bare"),
             "Script must provide dynamic Python version completions"
         );
+    }
+
+    /// The chained use→activate call must suppress duplicate deprecation
+    /// warnings (each chained call is a fresh process).
+    #[test]
+    fn init_script_suppresses_duplicate_deprecation_in_use_chain() {
+        assert!(init_script().contains("SCUV_SUPPRESS_DEPRECATION"));
     }
 
     #[test]

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -56,7 +56,13 @@ function scuv {
             if ($LASTEXITCODE -eq 0) {
                 $name = $Arguments | Where-Object { $_ -notmatch '^-' } | Select-Object -Skip 1 -First 1
                 if ($name) {
-                    Invoke-Expression (& $script:ScuvBin activate $name)
+                    # 'use' above already warned about any legacy config; don't warn twice
+                    $env:SCUV_SUPPRESS_DEPRECATION = '1'
+                    try {
+                        Invoke-Expression (& $script:ScuvBin activate $name)
+                    } finally {
+                        Remove-Item Env:SCUV_SUPPRESS_DEPRECATION -ErrorAction SilentlyContinue
+                    }
                 }
             }
         }
@@ -314,6 +320,18 @@ mod tests {
     /// Safety-critical: scoop.sh (the Windows package manager) coexistence.
     /// PowerShell must NEVER define a `scoop` function or alias, or it would
     /// shadow the real `scoop` command for scoop.sh users.
+    /// The chained use→activate call must suppress duplicate deprecation
+    /// warnings (each chained call is a fresh process).
+    #[test]
+    fn init_script_suppresses_duplicate_deprecation_in_use_chain() {
+        let s = init_script();
+        assert!(s.contains("SCUV_SUPPRESS_DEPRECATION"));
+        assert!(
+            s.contains("Remove-Item Env:SCUV_SUPPRESS_DEPRECATION"),
+            "suppression must not leak into the user's session"
+        );
+    }
+
     #[test]
     fn init_script_never_defines_scoop() {
         let s = init_script();

--- a/src/shell/powershell.rs
+++ b/src/shell/powershell.rs
@@ -56,12 +56,19 @@ function scuv {
             if ($LASTEXITCODE -eq 0) {
                 $name = $Arguments | Where-Object { $_ -notmatch '^-' } | Select-Object -Skip 1 -First 1
                 if ($name) {
-                    # 'use' above already warned about any legacy config; don't warn twice
+                    # 'use' above already warned about any legacy config; don't warn twice.
+                    # Save/restore so a user-set suppression value survives this call.
+                    $hadSuppress = Test-Path Env:SCUV_SUPPRESS_DEPRECATION
+                    $prevSuppress = if ($hadSuppress) { $env:SCUV_SUPPRESS_DEPRECATION } else { $null }
                     $env:SCUV_SUPPRESS_DEPRECATION = '1'
                     try {
                         Invoke-Expression (& $script:ScuvBin activate $name)
                     } finally {
-                        Remove-Item Env:SCUV_SUPPRESS_DEPRECATION -ErrorAction SilentlyContinue
+                        if ($hadSuppress) {
+                            $env:SCUV_SUPPRESS_DEPRECATION = $prevSuppress
+                        } else {
+                            Remove-Item Env:SCUV_SUPPRESS_DEPRECATION -ErrorAction SilentlyContinue
+                        }
                     }
                 }
             }
@@ -317,21 +324,26 @@ mod tests {
         );
     }
 
-    /// Safety-critical: scoop.sh (the Windows package manager) coexistence.
-    /// PowerShell must NEVER define a `scoop` function or alias, or it would
-    /// shadow the real `scoop` command for scoop.sh users.
     /// The chained use→activate call must suppress duplicate deprecation
-    /// warnings (each chained call is a fresh process).
+    /// warnings (each chained call is a fresh process), and must restore any
+    /// pre-existing user value rather than leak `1` into the session.
     #[test]
     fn init_script_suppresses_duplicate_deprecation_in_use_chain() {
         let s = init_script();
         assert!(s.contains("SCUV_SUPPRESS_DEPRECATION"));
         assert!(
+            s.contains("$env:SCUV_SUPPRESS_DEPRECATION = $prevSuppress"),
+            "must restore a user-set suppression value"
+        );
+        assert!(
             s.contains("Remove-Item Env:SCUV_SUPPRESS_DEPRECATION"),
-            "suppression must not leak into the user's session"
+            "must clear the variable when the user had not set it"
         );
     }
 
+    /// Safety-critical: scoop.sh (the Windows package manager) coexistence.
+    /// PowerShell must NEVER define a `scoop` function or alias, or it would
+    /// shadow the real `scoop` command for scoop.sh users.
     #[test]
     fn init_script_never_defines_scoop() {
         let s = init_script();

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -497,6 +497,18 @@ mod tests {
         );
     }
 
+    /// The auto-activate gate must honor the new variable AND the legacy one
+    /// (deprecated read, removed in 0.16.0) — fish/powershell have the same
+    /// test; this pins bash/zsh symmetrically.
+    #[test]
+    fn init_script_checks_both_no_auto_variables() {
+        let script = init_script();
+        assert!(
+            script.contains(r#"[[ -z "$SCUV_NO_AUTO" && -z "$SCOOP_NO_AUTO" ]]"#),
+            "auto-activate gate must check SCUV_NO_AUTO with legacy SCOOP_NO_AUTO fallback"
+        );
+    }
+
     #[test]
     fn init_script_defines_deprecated_scoop_forwarder() {
         assert!(init_script().contains("scoop() {"));

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -28,7 +28,8 @@ scuv() {
                     esac
                 done
                 if [[ -n "$name" ]]; then
-                    eval "$(command scuv activate "$name")"
+                    # 'use' above already warned about any legacy config; don't warn twice
+                    eval "$(SCUV_SUPPRESS_DEPRECATION=1 command scuv activate "$name")"
                 fi
             fi
             return $ret
@@ -507,6 +508,13 @@ mod tests {
             script.contains(r#"[[ -z "$SCUV_NO_AUTO" && -z "$SCOOP_NO_AUTO" ]]"#),
             "auto-activate gate must check SCUV_NO_AUTO with legacy SCOOP_NO_AUTO fallback"
         );
+    }
+
+    /// The chained use→activate call must suppress duplicate deprecation
+    /// warnings (each chained call is a fresh process).
+    #[test]
+    fn init_script_suppresses_duplicate_deprecation_in_use_chain() {
+        assert!(init_script().contains("SCUV_SUPPRESS_DEPRECATION"));
     }
 
     #[test]

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -279,13 +279,16 @@ impl PythonVersion {
             digits.parse().ok()
         });
 
-        // Extract suffix (e.g., "a1", "b2", "rc1")
-        let suffix = if let Some(minor_str) = trimmed.split('.').nth(1) {
-            let suffix_start = minor_str.chars().position(|c| c.is_ascii_alphabetic());
-            suffix_start.map(|pos| minor_str[pos..].to_string())
-        } else {
-            None
-        };
+        // Extract suffix (e.g., "a1", "b2", "rc1"). char_indices, not
+        // chars().position(): slicing needs a BYTE offset, and a char index
+        // diverges from it (and can panic) once any multi-byte character
+        // precedes the suffix.
+        let suffix = trimmed.split('.').nth(1).and_then(|minor_str| {
+            minor_str
+                .char_indices()
+                .find(|(_, c)| c.is_ascii_alphabetic())
+                .map(|(pos, _)| minor_str[pos..].to_string())
+        });
 
         Some(Self {
             major,
@@ -541,6 +544,26 @@ mod tests {
         assert!(validate_python_version("stable").is_ok());
         assert!(validate_python_version("STABLE").is_ok());
         assert!(validate_python_version("").is_err());
+    }
+
+    /// Fuzz regression (crash-dbaf50a5, found 2026-07-14): suffix extraction
+    /// took a CHAR index from `chars().position()` and sliced the string with
+    /// it as a BYTE index — any multi-byte character before the alphabetic
+    /// suffix panicked on a non-char-boundary slice.
+    #[test]
+    fn test_python_version_parse_multibyte_before_suffix_does_not_panic() {
+        // Exact fuzzer input: "0.\u{0678}la'0+"
+        let input = String::from_utf8(vec![48, 46, 217, 184, 108, 97, 39, 48, 43]).unwrap();
+        let v = PythonVersion::parse(&input).expect("major digit parses");
+        assert_eq!(v.major, 0);
+        assert_eq!(v.minor, None);
+        // suffix starts at the first ASCII-alphabetic char, at a byte boundary
+        assert_eq!(v.suffix.as_deref(), Some("la'0+"));
+
+        // Multi-byte char before a DIGIT then suffix: slicing by char index
+        // would silently return the wrong suffix here instead of panicking.
+        let v = PythonVersion::parse("3.β1a").expect("major digit parses");
+        assert_eq!(v.suffix.as_deref(), Some("a"));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -47,6 +47,9 @@ fn scoop_cmd(scoop_home: &std::path::Path) -> Command {
     // Force English locale for consistent test assertions
     cmd.env("SCUV_LANG", "en");
     cmd.env_remove("SCOOP_LANG");
+    // A developer running the suite with this exported would otherwise
+    // silence the deprecation warnings the legacy-shim tests assert on.
+    cmd.env_remove("SCUV_SUPPRESS_DEPRECATION");
     cmd
 }
 
@@ -81,6 +84,7 @@ fn test_legacy_scoop_env_vars_still_work() {
     let mut cmd = Command::cargo_bin("scuv").unwrap();
     cmd.env_remove("SCUV_HOME");
     cmd.env_remove("SCUV_LANG");
+    cmd.env_remove("SCUV_SUPPRESS_DEPRECATION");
     cmd.env("SCOOP_HOME", &fixture.scoop_home);
     cmd.env("SCOOP_LANG", "en");
     cmd.arg("list")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -257,13 +257,35 @@ fn test_resolve_with_version_file() {
     // Create a legacy-named version file in the temp directory
     std::fs::write(fixture.temp_dir.path().join(".scoop-version"), "testenv").unwrap();
 
-    // resolve should succeed and output the env name
+    // resolve should succeed, output the env name, and warn (once) that the
+    // legacy file name is deprecated
     scoop_cmd(&fixture.scoop_home)
         .arg("resolve")
         .current_dir(fixture.temp_dir.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("testenv"));
+        .stdout(predicate::str::contains("testenv"))
+        .stderr(predicate::str::contains(".scoop-version is deprecated"));
+}
+
+/// DEPRECATION(0.16.0): legacy-shim regression test — a legacy `.scoop.toml`
+/// manifest is still found by `scuv sync`, with a deprecation warning on
+/// stderr. No success assertion: the warning fires during manifest discovery,
+/// before any uv/env work that may fail in minimal environments.
+#[test]
+fn test_sync_warns_on_legacy_manifest() {
+    let fixture = TestFixture::new();
+    std::fs::write(
+        fixture.temp_dir.path().join(".scoop.toml"),
+        "[environment]\nname = \"synctest\"\npython = \"3.12\"\n",
+    )
+    .unwrap();
+
+    scoop_cmd(&fixture.scoop_home)
+        .args(["sync", "--dry-run"])
+        .current_dir(fixture.temp_dir.path())
+        .assert()
+        .stderr(predicate::str::contains(".scoop.toml is deprecated"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Post-0.15.0 follow-up patch (v0.15.1): bug fixes, a fuzzer-found panic fix, test hardening, and i18n polish. All `fix:`/`test:` commits — no `feat`, so release-plz cuts a **patch**, not a minor (0.16.0 is reserved for the legacy-shim removal).

### Fixes

- **`fix(validate)`: UTF-8 boundary panic (fuzzer-found, CLI-reachable DoS).** `PythonVersion` suffix extraction took a char index from `chars().position()` and sliced the string with it as a byte offset — any multi-byte character before the alphabetic suffix panicked. Reachable from an unvalidated `scuv uninstall <VER>` argument and from `.scuv-version` content, so the panic could abort the shell hook running it. Fixed with `char_indices()`; exact fuzzer crash input pinned as a regression test.
- **`fix(shell)`: `scuv use` printed its legacy-deprecation warning twice.** The `use`→`activate` shell chain runs two processes, and `warn_once`'s in-process dedup can't span them. `warn_once` now honors `SCUV_SUPPRESS_DEPRECATION`, and all four shell wrappers set it only on the chained `activate` call (PowerShell save/restores any user value; bash/zsh/fish keep it child-only).
- **`fix(build)`: track `locales/app.yml`.** A `build.rs` `cargo:rerun-if-changed` so a locale-only edit rebuilds the rust_i18n strings instead of reusing a stale binary (which reported false-green `cargo test`).
- **`fix(doctor)`: flag legacy `SCOOP_NO_AUTO`** in the legacy-remnants check — it has no runtime warning by design, so `scuv doctor` is the only migration nudge for it.
- **`fix(i18n)`: ko deprecation strings** — formal register, no semicolons (matching the file convention), correct `.scuv.toml로` particle.

### Tests

- `test:` closes coverage gaps: `unset_local` fail-fast on an unwritable dir (unwind-safe perms restore), bash/zsh `SCUV_NO_AUTO` gate assertions, and e2e stderr assertions for the legacy `.scoop-version` / `.scoop.toml` deprecation warnings. All env-mutating tests are `#[serial]` + env-guarded so an exported `SCUV_SUPPRESS_DEPRECATION` can't false-fail them.

## Review

- Reviewed twice by Codex (model sol): a full task review (5 findings — critical commit-type, PowerShell state clobber, test hermeticity, unwind safety, a stray doc comment — all fixed here) and a dedicated security/DoS audit → **Safe to ship**, no Critical/High/Medium/Low, with fish `env` vs `command` PATH semantics verified empirically.
- Gates green in both a clean env and a hostile `SCUV_SUPPRESS_DEPRECATION=1` env: 898 unit + 45 integration + 2 i18n + 25 doctest, clippy `-D warnings`, fmt.

## Note

The branch history was rewritten once (a single commit's type `feat(doctor)` → `fix(doctor)`) so release-plz produces 0.15.1 rather than 0.16.0. Force-pushed before any PR existed on it.
